### PR TITLE
Fix MemoryPromptSectionBuilder contract for OpenClaw 2026.3.28

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export default definePluginEntry({
     api.registerContextEngine("libravdb-memory", () =>
       buildContextEngineFactory(runtime.getRpc, cfg, recallCache),
     );
-    api.registerMemoryPromptSection(buildMemoryPromptSection(runtime.getRpc, cfg, recallCache));
+    api.registerMemoryPromptSection(buildMemoryPromptSection());
     api.on("gateway_stop", () => runtime.shutdown());
   },
 });

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -1,70 +1,24 @@
-import { buildMemoryHeader } from "./recall-utils.js";
-import { fitPromptBudget } from "./tokens.js";
-import { scoreCandidates } from "./scoring.js";
-import type { RpcGetter } from "./plugin-runtime.js";
-import type { MemoryMessage, PluginConfig, RecallCache, SearchResult } from "./types.js";
-
-export function buildMemoryPromptSection(
-  getRpc: RpcGetter,
-  cfg: PluginConfig,
-  recallCache: RecallCache<SearchResult>,
-) {
-  return async function memoryPromptSection(args: {
-    userId: string;
-    messages: MemoryMessage[];
-  }) {
-    const queryText = args.messages.at(-1)?.content ?? "";
-    if (!queryText) {
-      return {
-        id: "libravdb-memory",
-        content: "",
-        };
-    }
-
-    const rpc = await getRpc();
-    const [userHits, globalHits] = await Promise.all([
-      rpc.call<{ results: SearchResult[] }>("search_text", {
-        collection: `user:${args.userId}`,
-        text: queryText,
-        k: Math.ceil((cfg.topK ?? 8) / 2),
-      }).catch(() => ({ results: [] })),
-      rpc.call<{ results: SearchResult[] }>("search_text", {
-        collection: "global",
-        text: queryText,
-        k: Math.ceil((cfg.topK ?? 8) / 4),
-      }).catch(() => ({ results: [] })),
-    ]);
-
-    recallCache.put({
-      userId: args.userId,
-      queryText,
-      userHits: userHits.results,
-      globalHits: globalHits.results,
-    });
-
-    const ranked = scoreCandidates(
-      [
-        ...userHits.results,
-        ...globalHits.results,
-      ],
-      {
-        alpha: cfg.alpha,
-        beta: cfg.beta,
-        gamma: cfg.gamma,
-        recencyLambdaSession: cfg.recencyLambdaSession,
-        recencyLambdaUser: cfg.recencyLambdaUser,
-        recencyLambdaGlobal: cfg.recencyLambdaGlobal,
-        sessionId: "",
-        userId: args.userId,
-      },
-    );
-
-    const selected = fitPromptBudget(ranked, 800);
-    const body = buildMemoryHeader(selected);
-
-    return {
-      id: "libravdb-memory",
-      content: body,
-    };
+/**
+ * Builds the memory prompt section for the agent system prompt.
+ *
+ * As of OpenClaw 2026.3.28 the MemoryPromptSectionBuilder contract changed:
+ *   - Params: { availableTools: Set<string>, citationsMode?: string }
+ *   - Return: string[]  (lines to splice into the system prompt)
+ *
+ * Heavy recall (per-query vector search, scoring, budget fitting) is handled
+ * by the context engine's `assemble` hook, not here.  This builder only emits
+ * a short static section that tells the model LibraVDB memory is active.
+ */
+export function buildMemoryPromptSection(): (params: {
+  availableTools: Set<string>;
+  citationsMode?: string;
+}) => string[] {
+  return function memoryPromptSection(_params) {
+    return [
+      "## Memory",
+      "LibraVDB persistent memory is active. Recalled memories will appear",
+      "in context via the context-engine assembler when relevant.",
+      "",
+    ];
   };
 }

--- a/test/unit/memory-provider.test.ts
+++ b/test/unit/memory-provider.test.ts
@@ -2,42 +2,27 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildMemoryPromptSection } from "../../src/memory-provider.js";
-import { createRecallCache } from "../../src/recall-cache.js";
-import type { PluginConfig, SearchResult } from "../../src/types.js";
 
-const cfg: PluginConfig = {
-  rpcTimeoutMs: 1000,
-  topK: 8,
-  alpha: 0.7,
-  beta: 0.2,
-  gamma: 0.1,
-};
-
-test("memory prompt returns empty content for empty query", async () => {
-  const rpc = { call: async () => ({ results: [] }) };
-  const section = buildMemoryPromptSection(
-    (async () => rpc) as never,
-    cfg,
-    createRecallCache<SearchResult>(),
-  );
-
-  const result = await section({ userId: "u1", messages: [] });
-  assert.equal(result.content, "");
-});
-
-test("memory prompt handles RPC failure with empty results", async () => {
-  const rpc = { call: async () => { throw new Error("boom"); } };
-  const section = buildMemoryPromptSection(
-    (async () => rpc) as never,
-    cfg,
-    createRecallCache<SearchResult>(),
-  );
-
-  const result = await section({
-    userId: "u1",
-    messages: [{ role: "user", content: "hello" }],
+test("memory prompt section returns string array", () => {
+  const section = buildMemoryPromptSection();
+  const result = section({
+    availableTools: new Set(["read", "exec"]),
   });
 
-  assert.equal(result.id, "libravdb-memory");
-  assert.equal(result.content, "");
+  assert.ok(Array.isArray(result), "result should be an array");
+  assert.ok(result.length > 0, "result should not be empty");
+  for (const line of result) {
+    assert.equal(typeof line, "string", "each element should be a string");
+  }
+});
+
+test("memory prompt section works with citationsMode", () => {
+  const section = buildMemoryPromptSection();
+  const result = section({
+    availableTools: new Set(),
+    citationsMode: "inline",
+  });
+
+  assert.ok(Array.isArray(result));
+  assert.ok(result.some((line) => line.toLowerCase().includes("memory")));
 });


### PR DESCRIPTION
## Summary
- Fixes `TypeError: memorySection is not iterable` crash on OpenClaw 2026.3.28 caused by breaking change in the `MemoryPromptSectionBuilder` contract
- The builder now returns `string[]` (prompt lines) and accepts `{ availableTools, citationsMode }` instead of the previous `{ id, content }` return / `{ userId, messages }` args
- Per-query vector recall continues to work via the context engine's `assemble()` hook — the prompt section is now a lightweight static header

## Context
OpenClaw 2026.3.28 changed how `buildMemorySection` consumes the registered prompt builder. The gateway spreads the return value (`...memorySection`) into the system prompt array, so a non-iterable object crashes the agent before it can reply.

Two errors in the gateway log:
1. `TypeError: memorySection is not iterable` — spread of `{ id, content }` object
2. `TypeError: Cannot read properties of undefined (reading 'at')` — `args.messages` is now undefined since the new params are `{ availableTools, citationsMode }`

## Test plan
- [x] Unit tests updated and passing (`test/unit/memory-provider.test.ts`)
- [ ] Integration test with OpenClaw 2026.3.28 gateway — verify agent boots without error and memory section appears in system prompt