### PR TITLE
Fix plugin kind: context-engine instead of memory

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "LibraVDB Memory",
   "description": "Persistent vector memory with three-tier hybrid scoring",
   "version": "1.3.3",
-  "kind": "memory",
+  "kind": "context-engine",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export default definePluginEntry({
   id: "libravdb-memory",
   name: "LibraVDB Memory",
   description: "Persistent vector memory with three-tier hybrid scoring",
-  kind: "memory",
+  kind: "context-engine",
 
   register(api: OpenClawPluginApi) {
     const cfg = api.pluginConfig as PluginConfig;


### PR DESCRIPTION
## Summary

Changes `kind` from `"memory"` to `"context-engine"` in `openclaw.plugin.json` and `src/index.ts`.

## Problem

After install, the plugin had 0 turns and 0 memories stored despite the sidecar running correctly. Ingestion was never happening.

## Root Cause

The `kind` field controls which plugin slot gets auto-set during `openclaw plugins install`. The core maps:

- `"memory"` → sets `plugins.slots.memory`
- `"context-engine"` → sets `plugins.slots.contextEngine`

LibraVDB needs the `contextEngine` slot set to its ID — that's how the gateway knows to call its `ingest`/`assemble`/`compact` lifecycle. But it declared `kind: "memory"`, so install only set the `memory` slot. The `contextEngine` slot stayed at the default (`"legacy"`), meaning the built-in legacy engine handled all turns and libravdb's ingest hook was never called.

Changing `kind` to `"context-engine"` means install will auto-set `plugins.slots.contextEngine = "libravdb-memory"`, which is the slot the gateway checks when deciding which engine processes turns.

## Why this is safe

- `registerMemoryPromptSection()` uses direct API registration, independent of the `kind` field — the plugin keeps providing its memory prompt section even with `kind: "context-engine"`
- The plugin registers no hooks gated by the memory slot
- Only the install-time slot assignment changes

## Test plan

- [ ] Fresh `openclaw plugins install` sets `plugins.slots.contextEngine` to `libravdb-memory`
- [ ] Ingestion fires on first conversation turn after install (`openclaw memory status` shows non-zero turns)
- [ ] Memory recall still works via prompt section