### PR TITLE
Add label-based auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v4
@@ -60,4 +60,4 @@ jobs:
           git add package.json
           git commit -m "Bump version to ${{ steps.version.outputs.version }}"
           git tag "v${{ steps.version.outputs.version }}"
-          git push origin main --tags
+          git push origin HEAD:main --tags


### PR DESCRIPTION
## Summary

- Adds `auto-release.yml` workflow that triggers when a labeled PR is merged to `main`
- Labels `release:patch`, `release:minor`, `release:major` control the version bump type
- Workflow bumps `package.json` version, commits, tags, and pushes — the existing `release.yml` (daemon binaries + Homebrew) and `publish.yml` (npm) fire from the new tag
- PRs without a release label are unaffected

## How it works

1. Add a `release:patch` / `release:minor` / `release:major` label to a PR
2. Merge the PR
3. Workflow runs `npm version <type>`, commits, creates `v*` tag, pushes
4. Existing tag-triggered workflows handle the rest

## Labels created

| Label | Color | Purpose |
|---|---|---|
| `release:patch` | green | Bug fixes, docs |
| `release:minor` | blue | New features |
| `release:major` | red | Breaking changes |

## Test plan

- [ ] Merge a test PR with `release:patch` label and verify version bump + tag creation
- [ ] Verify `release.yml` and `publish.yml` trigger from the new tag
- [ ] Merge a PR without a release label and verify no workflow runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that runs when a pull request merged into main is closed with a release label (`release:patch`, `release:minor`, `release:major`). It determines the release type from the label, increments the package version, commits the updated version, creates a corresponding version tag (v<version>), and pushes the commit and tags back to main.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->