### PR TITLE
fix: keep plugin manifest version in sync with package releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -50,6 +50,7 @@ jobs:
         id: version
         run: |
           npm version "${{ steps.bump.outputs.type }}" --no-git-tag-version
+          node --input-type=module -e 'import fs from "node:fs"; const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); const manifest = JSON.parse(fs.readFileSync("openclaw.plugin.json", "utf8")); manifest.version = pkg.version; fs.writeFileSync("openclaw.plugin.json", `${JSON.stringify(manifest, null, 2)}\n`);'
           version=$(node -p "require('./package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -57,7 +58,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
+          git add package.json openclaw.plugin.json
           git commit -m "Bump version to ${{ steps.version.outputs.version }}"
           git tag "v${{ steps.version.outputs.version }}"
           git push origin HEAD:main --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,10 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
-      - name: Verify release tag matches package version
+      - name: Verify release tag matches package and manifest versions
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          node -e 'const pkg=require("./package.json"); const tag=process.env.RELEASE_TAG.replace(/^refs\/tags\/v/,""); if (pkg.version !== tag) { console.error(`package.json version ${pkg.version} does not match release tag ${tag}`); process.exit(1); }'
+          node -e 'const fs=require("fs"); const pkg=require("./package.json"); const manifest=JSON.parse(fs.readFileSync("./openclaw.plugin.json", "utf8")); const tag=process.env.RELEASE_TAG.replace(/^refs\/tags\/v/,""); if (pkg.version !== tag) { console.error(`package.json version ${pkg.version} does not match release tag ${tag}`); process.exit(1); } if (manifest.version !== tag) { console.error(`openclaw.plugin.json version ${manifest.version} does not match release tag ${tag}`); process.exit(1); } if (manifest.version !== pkg.version) { console.error(`openclaw.plugin.json version ${manifest.version} does not match package.json version ${pkg.version}`); process.exit(1); }'
         env:
           RELEASE_TAG: ${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,12 @@ jobs:
         with:
           node-version: 22
 
+      - name: Verify release tag matches package and manifest versions
+        run: |
+          node -e 'const fs=require("fs"); const pkg=require("./package.json"); const manifest=JSON.parse(fs.readFileSync("./openclaw.plugin.json", "utf8")); const tag=process.env.RELEASE_TAG.replace(/^refs\/tags\/v/,""); if (pkg.version !== tag) { console.error(`package.json version ${pkg.version} does not match release tag ${tag}`); process.exit(1); } if (manifest.version !== tag) { console.error(`openclaw.plugin.json version ${manifest.version} does not match release tag ${tag}`); process.exit(1); } if (manifest.version !== pkg.version) { console.error(`openclaw.plugin.json version ${manifest.version} does not match package.json version ${pkg.version}`); process.exit(1); }'
+        env:
+          RELEASE_TAG: ${{ github.ref }}
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,3 +75,11 @@ Before opening a PR:
 - any new gating signal must come with calibration or invariant coverage
 - any retrieval math change must be reflected in [mathematics-v2.md](./mathematics-v2.md)
 - any gating change must be reflected in [gating.md](./gating.md)
+
+## Release Versioning
+
+`package.json` is the source of truth for the release version.
+
+The release automation syncs `openclaw.plugin.json` from `package.json` during the
+auto-bump/tag flow, and the publish workflow refuses to publish if the Git tag,
+`package.json`, and `openclaw.plugin.json` versions do not all match.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,3 +83,6 @@ Before opening a PR:
 The release automation syncs `openclaw.plugin.json` from `package.json` during the
 auto-bump/tag flow, and the publish workflow refuses to publish if the Git tag,
 `package.json`, and `openclaw.plugin.json` versions do not all match.
+
+The daemon release workflow enforces the same alignment before generating the
+Homebrew formula, so package, manifest, tag, and formula versioning stay in lockstep.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "libravdb-memory",
   "name": "LibraVDB Memory",
   "description": "Persistent vector memory with three-tier hybrid scoring",
-  "version": "1.3.11",
+  "version": "1.4.1",
   "kind": ["memory", "context-engine"],
   "configSchema": {
     "type": "object",

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -15,6 +15,7 @@ test("manifest and package metadata satisfy checklist structure", async () => {
     Object.keys(manifest).sort(),
     ["configSchema", "description", "id", "kind", "name", "version"],
   );
+  assert.equal(manifest.version, pkg.version);
 
   assert.ok(Array.isArray(pkg.openclaw?.extensions));
   assert.ok(pkg.openclaw.extensions.includes("./src/index.ts"));

--- a/test/unit/generate-homebrew-formula.test.ts
+++ b/test/unit/generate-homebrew-formula.test.ts
@@ -29,13 +29,13 @@ test("buildFormula fills version and checksum placeholders", async () => {
   const { buildFormula } = await loadModule();
   assert.equal(
     buildFormula({
-      version: "1.3.11",
+      version: "9.9.9",
       template: "version \"__VERSION__\"\nsha256 \"__SHA256_DARWIN_ARM64__\"\n",
       checksums: {
         "__SHA256_DARWIN_ARM64__": "e".repeat(64),
       },
     }),
-    `version "1.3.11"\nsha256 "${"e".repeat(64)}"\n`,
+    `version "9.9.9"\nsha256 "${"e".repeat(64)}"\n`,
   );
 });
 


### PR DESCRIPTION
## Summary
- update `openclaw.plugin.json` to the current `1.4.1` version
- add a regression assertion that `openclaw.plugin.json` and `package.json` versions match
- make the auto-release workflow sync `openclaw.plugin.json` from `package.json` when bumping versions
- make the publish workflow fail if the git tag, `package.json`, and `openclaw.plugin.json` ever drift
- keep the formula-generation unit test generic so stale real release numbers do not linger in fixtures

## Why
The published npm package was `1.4.1`, but `openclaw.plugin.json` in the package still advertised `1.3.11`.

A one-time bump fixes the current release, but the real problem is release automation: future releases can drift again unless the manifest version is updated automatically and checked before publish.

This PR makes `package.json` the source of truth for release versioning and enforces that the manifest and release tag stay aligned.

## Testing
- `pnpm run test:ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added checks to verify manifest and package version consistency during validation and formula generation.

* **Chores**
  * Bumped plugin version from 1.3.11 to 1.4.1.
  * Release automation now syncs, stages, and commits the manifest version alongside the package version and enforces tag/version alignment.

* **Documentation**
  * Added “Release Versioning” guidance clarifying the package version as source of truth and enforced alignment across tag, package, manifest, and generated formula.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->