### PR TITLE
fix: derive durable memory namespace from session keys

### DIFF
--- a/docs/gating.md
+++ b/docs/gating.md
@@ -79,11 +79,12 @@ with:
 \[ F(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{turns:u}, 0.80, k=10)}{5}, 1\right) \]
 \[ S(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{user:u}, 0.85, k=5)}{3}, 1\right) \]
 
-where $u$ is the resolved durable namespace used by the host boundary. When the
-host supplies an explicit user id, $u$ is that id. On current OpenClaw
-releases, the plugin falls back to a stable session-key-derived namespace so
-the gate continues to measure repetition and saturation against the same
-durable scope.
+where $u$ is the resolved durable namespace used by the host boundary. The
+resolver chooses $u$ in this order: explicit `userId`, then the
+session-key-derived namespace, then `agentId`, and finally the resolver
+fallback/default when no host identity is available. When the host does not
+provide a `userId`, the gate still measures repetition and saturation against a
+stable durable scope.
 
 Why a product? High input frequency should help only if durable memory is not already saturated. High saturation must veto the repetition term regardless of frequency. The veto property is structural: $S(t) = 1 \Rightarrow R(t) = 0$.
 

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -76,8 +76,14 @@ The repetition term is a product, not a sum:
 \[ R(t) = F(t) \cdot (1 - S(t)) \]
 
 with:
-\[ F(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{turns:userId}, 0.80, k=10)}{5}, 1\right) \]
-\[ S(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{user:userId}, 0.85, k=5)}{3}, 1\right) \]
+\[ F(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{turns:u}, 0.80, k=10)}{5}, 1\right) \]
+\[ S(t) = \min\left(\frac{\mathrm{hitsAbove}(\mathrm{user:u}, 0.85, k=5)}{3}, 1\right) \]
+
+where $u$ is the resolved durable namespace used by the host boundary. When the
+host supplies an explicit user id, $u$ is that id. On current OpenClaw
+releases, the plugin falls back to a stable session-key-derived namespace so
+the gate continues to measure repetition and saturation against the same
+durable scope.
 
 Why a product? High input frequency should help only if durable memory is not already saturated. High saturation must veto the repetition term regardless of frequency. The veto property is structural: $S(t) = 1 \Rightarrow R(t) = 0$.
 

--- a/docs/mathematics-v2.md
+++ b/docs/mathematics-v2.md
@@ -203,10 +203,10 @@ config — do not change the decay formula itself.
 This makes session context fade fastest, durable namespace memory fade more slowly, and
 global memory remain the most stable.
 
-When the host supplies an explicit `userId`, the durable namespace is that
-user id. On current OpenClaw releases, the plugin falls back to a stable
-session-key-derived durable namespace so the retrieval math and scope weighting
-stay unchanged even when the host does not expose a separate user principal.
+When the host supplies an explicit `userId`, the durable namespace matches that
+`userId`. When the host does not provide a `userId`, the plugin derives a stable
+durable namespace from the session key so the retrieval math and scope
+weighting stay unchanged even when the host does not expose a separate user principal.
 
 **Note on symbol disambiguation.** The symbol $\lambda_s$ here denotes the
 scope-specific recency decay constant with units $\mathrm{s}^{-1}$. Section 7.3

--- a/docs/mathematics-v2.md
+++ b/docs/mathematics-v2.md
@@ -205,7 +205,8 @@ global memory remain the most stable.
 
 When the host supplies an explicit `userId`, the durable namespace matches that
 `userId`. When the host does not provide a `userId`, the plugin derives a stable
-durable namespace from the session key so the retrieval math and scope
+durable namespace from the session key, or falls back to `session:${sessionId}`
+when both `userId` and `sessionKey` are absent, so the retrieval math and scope
 weighting stay unchanged even when the host does not expose a separate user principal.
 
 **Note on symbol disambiguation.** The symbol $\lambda_s$ here denotes the

--- a/docs/mathematics-v2.md
+++ b/docs/mathematics-v2.md
@@ -61,7 +61,7 @@ $$
 S(d)=
 \begin{cases}
 1.0 & \text{if } d \text{ is from the active session} \\
-0.6 & \text{if } d \text{ is from durable user memory} \\
+0.6 & \text{if } d \text{ is from durable namespace memory} \\
 0.3 & \text{if } d \text{ is from global memory}
 \end{cases}
 $$
@@ -182,7 +182,7 @@ product $\lambda_s \Delta t_d$ is dimensionless, as required by the exponential.
 The current implementation uses different constants by scope:
 
 - active session: $\lambda_s = 0.0001$
-- durable user memory: $\lambda_s = 0.00001$
+- durable namespace memory: $\lambda_s = 0.00001$
 - global memory: $\lambda_s = 0.000002$
 
 The implied half-lives make the decay constants auditable at a glance:
@@ -200,8 +200,13 @@ $$
 If those half-lives feel wrong for a given deployment, adjust $\lambda_s$ via
 config — do not change the decay formula itself.
 
-This makes session context fade fastest, user memory fade more slowly, and
+This makes session context fade fastest, durable namespace memory fade more slowly, and
 global memory remain the most stable.
+
+When the host supplies an explicit `userId`, the durable namespace is that
+user id. On current OpenClaw releases, the plugin falls back to a stable
+session-key-derived durable namespace so the retrieval math and scope weighting
+stay unchanged even when the host does not expose a separate user principal.
 
 **Note on symbol disambiguation.** The symbol $\lambda_s$ here denotes the
 scope-specific recency decay constant with units $\mathrm{s}^{-1}$. Section 7.3

--- a/sidecar/server/rpc.go
+++ b/sidecar/server/rpc.go
@@ -127,9 +127,9 @@ type expandSummaryParams struct {
 }
 
 type queryRawSessionParams struct {
-	SessionID string   `json:"sessionId"`
-	Text     string   `json:"text"`
-	K        int      `json:"k"`
+	SessionID  string   `json:"sessionId"`
+	Text       string   `json:"text"`
+	K          int      `json:"k"`
 	ExcludeIDs []string `json:"excludeIds"`
 }
 
@@ -176,7 +176,8 @@ type gatingScalarParams struct {
 }
 
 type flushNamespaceParams struct {
-	UserID string `json:"userId"`
+	UserID    string `json:"userId"`
+	Namespace string `json:"namespace"`
 }
 
 type memoryStatus struct {
@@ -418,10 +419,7 @@ func (s *Server) handleExportMemory(ctx context.Context, raw any) (any, error) {
 		return nil, err
 	}
 
-	prefix := "user:"
-	if params.UserID != "" {
-		prefix = "user:" + params.UserID
-	}
+	prefix := resolveDurableMemoryCollectionPrefix(params)
 
 	collections := s.Store.CollectionNames()
 	records := make([]exportMemoryRecord, 0)
@@ -454,13 +452,27 @@ func (s *Server) handleFlushNamespace(ctx context.Context, raw any) (any, error)
 	if err := decode(raw, &params); err != nil {
 		return nil, err
 	}
-	if params.UserID == "" {
-		return nil, fmt.Errorf("userId is required")
+	prefix := resolveDurableMemoryCollectionPrefix(params)
+	if prefix == "user:" {
+		return nil, fmt.Errorf("namespace or userId is required")
 	}
-	if err := s.Store.DeleteCollectionsByPrefix(ctx, "user:"+params.UserID); err != nil {
+	if err := s.Store.DeleteCollectionsByPrefix(ctx, prefix); err != nil {
 		return nil, err
 	}
 	return map[string]any{"ok": true}, nil
+}
+
+func resolveDurableMemoryCollectionPrefix(params flushNamespaceParams) string {
+	if namespace := strings.TrimSpace(params.Namespace); namespace != "" {
+		if strings.HasPrefix(namespace, "user:") {
+			return namespace
+		}
+		return "user:" + namespace
+	}
+	if userID := strings.TrimSpace(params.UserID); userID != "" {
+		return "user:" + userID
+	}
+	return "user:"
 }
 
 func (s *Server) handleDelete(ctx context.Context, raw any) (any, error) {

--- a/sidecar/server/rpc_test.go
+++ b/sidecar/server/rpc_test.go
@@ -636,3 +636,52 @@ func TestRPCExportMemoryAndFlushNamespace(t *testing.T) {
 		t.Fatalf("expected user:u2 to remain intact, got %+v", u2)
 	}
 }
+
+func TestRPCExportMemoryAndFlushNamespaceNamespaceParam(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.libravdb"), fakeEmbedder{})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	srv := New(fakeEmbedder{}, nil, nil, st, compact.DefaultGatingConfig(), 500)
+
+	namespace := "session-key:fixed-session"
+	if err := st.InsertText(ctx, "user:"+namespace, "a", "memory-match", map[string]any{"userId": namespace}); err != nil {
+		t.Fatalf("namespace insert error = %v", err)
+	}
+	if err := st.InsertText(ctx, "user:u2", "b", "memory-match", map[string]any{"userId": "u2"}); err != nil {
+		t.Fatalf("u2 insert error = %v", err)
+	}
+
+	exportedRaw, err := srv.Call(ctx, "export_memory", map[string]any{"namespace": namespace})
+	if err != nil {
+		t.Fatalf("export_memory error = %v", err)
+	}
+	exported, ok := exportedRaw.(exportMemoryResult)
+	if !ok {
+		t.Fatalf("expected exportMemoryResult, got %T", exportedRaw)
+	}
+	if len(exported.Records) != 1 || exported.Records[0].Collection != "user:"+namespace || exported.Records[0].ID != "a" {
+		t.Fatalf("unexpected export records: %+v", exported.Records)
+	}
+
+	if _, err := srv.Call(ctx, "flush_namespace", map[string]any{"namespace": namespace}); err != nil {
+		t.Fatalf("flush_namespace error = %v", err)
+	}
+
+	items, err := st.ListCollection(ctx, "user:"+namespace)
+	if err != nil {
+		t.Fatalf("ListCollection(user:%s) error = %v", namespace, err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected user:%s to be empty after flush, got %+v", namespace, items)
+	}
+
+	u2, err := st.ListCollection(ctx, "user:u2")
+	if err != nil {
+		t.Fatalf("ListCollection(user:u2) error = %v", err)
+	}
+	if len(u2) != 1 || u2[0].ID != "b" {
+		t.Fatalf("expected user:u2 to remain intact, got %+v", u2)
+	}
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveDurableNamespace } from "./durable-namespace.js";
 import type { PluginRuntime } from "./plugin-runtime.js";
 import type { LoggerLike, PluginConfig } from "./types.js";
 
@@ -26,6 +27,7 @@ type ExportResult = {
 
 type CliOptionBag = {
   userId?: string;
+  sessionKey?: string;
   sessionId?: string;
   limit?: string | number;
   yes?: boolean;
@@ -70,12 +72,13 @@ export function registerMemoryCli(
         .action(() => void runStatus(runtime, cfg, logger));
 
       const flush = ensureCommand(root, "flush")
-        .description("Wipe a user memory namespace after confirmation");
+        .description("Wipe a durable memory namespace after confirmation");
       if (flush.requiredOption) {
         flush.requiredOption("--user-id <userId>", "User id whose durable memory should be deleted");
       } else {
         flush.option("--user-id <userId>", "User id whose durable memory should be deleted");
       }
+      flush.option("--session-key <sessionKey>", "Session key whose derived durable namespace should be deleted");
       flush
         .option("--yes", "Skip the confirmation prompt")
         .action((opts) => void runFlush(runtime, opts, logger));
@@ -83,6 +86,7 @@ export function registerMemoryCli(
       const exportCmd = ensureCommand(root, "export")
         .description("Stream stored memories as newline-delimited JSON");
       exportCmd.option("--user-id <userId>", "Restrict export to a single user namespace");
+      exportCmd.option("--session-key <sessionKey>", "Restrict export to a derived session-key namespace");
       exportCmd.action((opts) => void runExport(runtime, opts, logger));
 
       const journal = ensureCommand(root, "journal")
@@ -147,15 +151,15 @@ async function runStatus(runtime: PluginRuntime, cfg: PluginConfig, logger: Logg
 }
 
 async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
-  const userId = opts?.userId?.trim();
-  if (!userId) {
-    logger.error("LibraVDB flush requires --user-id <userId>.");
+  const namespace = resolveCliNamespace(opts);
+  if (!namespace) {
+    logger.error("LibraVDB flush requires --user-id <userId> or --session-key <sessionKey>.");
     process.exitCode = 1;
     return;
   }
 
   if (!opts?.yes) {
-    const confirmed = await confirm(`Delete durable memory collection user:${userId}? [y/N] `);
+    const confirmed = await confirm(`Delete durable memory collection user:${namespace}? [y/N] `);
     if (!confirmed) {
       console.log("Aborted.");
       return;
@@ -164,8 +168,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 
   try {
     const rpc = await runtime.getRpc();
-    await rpc.call("flush_namespace", { userId });
-    console.log(`Deleted durable memory namespace user:${userId}.`);
+    await rpc.call("flush_namespace", { userId: namespace });
+    console.log(`Deleted durable memory namespace user:${namespace}.`);
   } catch (error) {
     logger.error(`LibraVDB flush failed: ${formatError(error)}`);
     process.exitCode = 1;
@@ -176,7 +180,7 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
   try {
     const rpc = await runtime.getRpc();
     const result = await rpc.call<ExportResult>("export_memory", {
-      userId: opts?.userId?.trim() || undefined,
+      userId: resolveCliNamespace(opts),
     });
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);
@@ -231,6 +235,15 @@ function normalizeLimit(limit: string | number | undefined): number | undefined 
     }
   }
   return undefined;
+}
+
+function resolveCliNamespace(opts: CliOptionBag | undefined): string | undefined {
+  const userId = opts?.userId?.trim();
+  const sessionKey = opts?.sessionKey?.trim();
+  if (!userId && !sessionKey) {
+    return undefined;
+  }
+  return resolveDurableNamespace({ userId, sessionKey });
 }
 
 type CliRegistrar = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,7 +159,7 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
   }
 
   if (!opts?.yes) {
-    const confirmed = await confirm(`Delete durable memory collection user:${namespace}? [y/N] `);
+    const confirmed = await confirm(`Delete durable memory namespace ${namespace}? [y/N] `);
     if (!confirmed) {
       console.log("Aborted.");
       return;
@@ -168,8 +168,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 
   try {
     const rpc = await runtime.getRpc();
-    await rpc.call("flush_namespace", { userId: namespace });
-    console.log(`Deleted durable memory namespace user:${namespace}.`);
+    await rpc.call("flush_namespace", { namespace });
+    console.log(`Deleted durable memory namespace ${namespace}.`);
   } catch (error) {
     logger.error(`LibraVDB flush failed: ${formatError(error)}`);
     process.exitCode = 1;
@@ -180,7 +180,7 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
   try {
     const rpc = await runtime.getRpc();
     const result = await rpc.call<ExportResult>("export_memory", {
-      userId: resolveCliNamespace(opts),
+      namespace: resolveCliNamespace(opts),
     });
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -28,6 +28,7 @@ import type {
   ContextCompactArgs,
   ContextIngestArgs,
   GatingResult,
+  MemoryMessage,
   PluginConfig,
   RecallCache,
   SearchResult,
@@ -53,6 +54,7 @@ export function buildContextEngineFactory(
   let authoredSoftCache: SearchResult[] | null = null;
   let authoredVariantCache: SearchResult[] | null = null;
   const authoredVariantRecallCache = new Map<string, SearchResult[]>();
+  const afterTurnIngestedKeys = new Set<string>();
 
   // Session-scoped elevated-guidance cache keyed by sessionId + generation + durable namespace + queryText
   const elevatedRecallCache = new Map<string, SearchResult[]>();
@@ -105,106 +107,81 @@ export function buildContextEngineFactory(
         return { ingested: false };
       }
 
-      const rpc = await getRpc();
-      const ts = Date.now();
-      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
-      const sessionMeta = {
-        role: message.role,
-        ts,
-        userId: durableNamespace,
+      const result = await ingestCanonicalMessage({
+        getRpc,
+        cfg,
+        recallCache,
+        clearElevatedCacheForSession,
         sessionId,
-        type: "turn",
-        provenance_class: "session_turn",
-        stability_weight: stabilityWeightForMessage(message.role),
-      };
-      // Elevated cache is session-scoped, so invalidate immediately on every ingest
-      clearElevatedCacheForSession(sessionId);
-      const rawSessionId = `${sessionId}:${ts}`;
-      const rawSessionInsert = rpc.call("insert_session_turn", {
-        sessionId,
-        id: rawSessionId,
-        text: message.content,
-        metadata: sessionMeta,
+        sessionKey,
+        userId,
+        message,
       });
-      if (useSessionRecallProjection(cfg)) {
-        try {
-          await rawSessionInsert;
-          await rebuildSessionRecallProjection(rpc, cfg, sessionId);
-        } catch (error) {
-          console.error(error);
-        }
-      } else {
-        void rawSessionInsert.catch(console.error);
-      }
-
-      if (message.role === "user") {
-        try {
-          recallCache.clearUser(durableNamespace);
-          await rpc.call("insert_text", {
-            collection: `turns:${durableNamespace}`,
-            id: `${durableNamespace}:${ts}`,
-            text: message.content,
-            metadata: {
-              ...sessionMeta,
-              provenance_class: "turn_index",
-            },
-          });
-
-          const gating = await rpc.call<GatingResult>("gating_scalar", {
-            userId: durableNamespace,
-            text: message.content,
-          });
-
-          if (gating.g >= (cfg.ingestionGateThreshold ?? 0.35)) {
-            void rpc.call("insert_text", {
-              collection: `user:${durableNamespace}`,
-              id: `${durableNamespace}:${ts}`,
-              text: message.content,
-              metadata: {
-                role: message.role,
-                ts,
-                sessionId,
-                type: "turn",
-                userId: durableNamespace,
-                provenance_class: "durable_user_memory",
-                stability_weight: Math.max(stabilityWeightForMessage(message.role), gating.g),
-                gating_score: gating.g,
-                gating_t: gating.t,
-                gating_h: gating.h,
-                gating_r: gating.r,
-                gating_d: gating.d,
-                gating_p: gating.p,
-                gating_a: gating.a,
-                gating_dtech: gating.dtech,
-                gating_gconv: gating.gconv,
-                gating_gtech: gating.gtech,
-              },
-            }).catch(console.error);
-          }
-        } catch {
-          // Session storage already happened; skip durable promotion on gating failure.
-        }
-      }
-
-      return { ingested: true };
+      return { ingested: result.ingested };
     },
-    async assemble({ sessionId, sessionKey, userId, messages, tokenBudget }: ContextAssembleArgs) {
+    async afterTurn({ sessionId, sessionKey, messages, prePromptMessageCount, isHeartbeat }: {
+      sessionId: string;
+      sessionKey?: string;
+      messages: Array<{ role: string; content: unknown }>;
+      prePromptMessageCount: number;
+      isHeartbeat?: boolean;
+    }) {
+      if (isHeartbeat) {
+        return;
+      }
+
+      const startIndex = Math.max(0, prePromptMessageCount - 1);
+      const turnMessages = messages.slice(startIndex);
+      for (let offset = 0; offset < turnMessages.length; offset++) {
+        const index = startIndex + offset;
+        const normalized = normalizeHostMessage(turnMessages[offset]);
+        if (!normalized) {
+          continue;
+        }
+
+        const dedupeKey = `${sessionId}\n${index}\n${normalized.role}\n${normalized.content}`;
+        if (afterTurnIngestedKeys.has(dedupeKey)) {
+          continue;
+        }
+
+        const result = await ingestCanonicalMessage({
+          getRpc,
+          cfg,
+          recallCache,
+          clearElevatedCacheForSession,
+          sessionId,
+          sessionKey,
+          message: {
+            ...normalized,
+            id: `after-turn:${index}`,
+          },
+          skipProjectionRebuild: offset !== turnMessages.length - 1,
+        });
+        if (result.ingested) {
+          afterTurnIngestedKeys.add(dedupeKey);
+        }
+      }
+    },
+    async assemble({ sessionId, sessionKey, userId, messages, tokenBudget, ...rest }: ContextAssembleArgs & Record<string, unknown>) {
       const PROFILE = process.env.OPENCLAW_PROFILE_ASSEMBLE === "1";
       const DEBUG_RECOVERY = process.env.LONGMEMEVAL_DEBUG_RANKING === "1";
       const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
+      const normalizedMessages = normalizeConversationMessages(messages as Array<{ role: string; content: unknown }>);
 
-      const queryText = messages.at(-1)?.content ?? "";
+      const queryText =
+        (typeof rest.prompt === "string" && rest.prompt.trim() ? rest.prompt : undefined) ??
+        normalizedMessages.at(-1)?.content ?? "";
       if (!queryText) {
         return {
-          messages,
-          estimatedTokens: countTokens(messages),
+          messages: normalizedMessages,
+          estimatedTokens: countTokens(normalizedMessages),
           systemPromptAddition: "",
         } satisfies ContextAssembleResult;
       }
       const temporalQuery = detectTemporalQuerySignal(queryText);
       const temporalSelectorGuard = decideTemporalSelectorGuard(queryText, temporalQuery);
 
-      const excluded = recentIds(messages, 4);
+      const excluded = recentIds(normalizedMessages, 4);
       const cached = recallCache.take({ userId: durableNamespace, queryText });
 
       const rpc = await getRpc();
@@ -270,7 +247,7 @@ export function buildContextEngineFactory(
           temporalSelectorGuard,
           sessionId,
           userId: durableNamespace,
-          messages,
+          messages: normalizedMessages,
           tokenBudget,
           profiler,
           debugRecovery: DEBUG_RECOVERY,
@@ -286,8 +263,8 @@ export function buildContextEngineFactory(
           : result;
       } catch {
         return {
-          messages,
-          estimatedTokens: countTokens(messages),
+          messages: normalizedMessages,
+          estimatedTokens: countTokens(normalizedMessages),
           systemPromptAddition: "",
         } satisfies ContextAssembleResult;
       }
@@ -983,6 +960,177 @@ function clampFraction(value: number | undefined): number {
     return 0;
   }
   return Math.min(1, Math.max(0, value));
+}
+
+async function ingestCanonicalMessage(params: {
+  getRpc: RpcGetter;
+  cfg: PluginConfig;
+  recallCache: RecallCache<SearchResult>;
+  clearElevatedCacheForSession: (sessionId: string) => void;
+  sessionId: string;
+  sessionKey?: string;
+  userId?: string;
+  message: MemoryMessage;
+  skipProjectionRebuild?: boolean;
+}): Promise<{ ingested: boolean }> {
+  const normalized = normalizeMemoryMessage(params.message);
+  if (!normalized) {
+    return { ingested: false };
+  }
+
+  const rpc = await params.getRpc();
+  const ts = Date.now();
+  const durableNamespace = resolveDurableNamespace({ userId: params.userId, sessionKey: params.sessionKey });
+  const turnId = normalized.id ?? `${ts}`;
+  const sessionMeta = {
+    role: normalized.role,
+    ts,
+    userId: durableNamespace,
+    sessionId: params.sessionId,
+    type: "turn",
+    provenance_class: "session_turn",
+    stability_weight: stabilityWeightForMessage(normalized.role),
+    source_turn_id: turnId,
+  };
+
+  params.clearElevatedCacheForSession(params.sessionId);
+  const rawSessionInsert = rpc.call("insert_session_turn", {
+    sessionId: params.sessionId,
+    id: `${params.sessionId}:${turnId}`,
+    text: normalized.content,
+    metadata: sessionMeta,
+  });
+  if (useSessionRecallProjection(params.cfg)) {
+    if (params.skipProjectionRebuild) {
+      void rawSessionInsert.catch(console.error);
+    } else {
+      try {
+        await rawSessionInsert;
+        await rebuildSessionRecallProjection(rpc, params.cfg, params.sessionId);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  } else {
+    void rawSessionInsert.catch(console.error);
+  }
+
+  if (normalized.role !== "user") {
+    return { ingested: true };
+  }
+
+  try {
+    params.recallCache.clearUser(durableNamespace);
+    await rpc.call("insert_text", {
+      collection: `turns:${durableNamespace}`,
+      id: `${durableNamespace}:${turnId}`,
+      text: normalized.content,
+      metadata: {
+        ...sessionMeta,
+        provenance_class: "turn_index",
+      },
+    });
+
+    const gating = await rpc.call<GatingResult>("gating_scalar", {
+      userId: durableNamespace,
+      text: normalized.content,
+    });
+
+    if (gating.g >= (params.cfg.ingestionGateThreshold ?? 0.35)) {
+      void rpc.call("insert_text", {
+        collection: `user:${durableNamespace}`,
+        id: `${durableNamespace}:${turnId}`,
+        text: normalized.content,
+        metadata: {
+          role: normalized.role,
+          ts,
+          sessionId: params.sessionId,
+          type: "turn",
+          userId: durableNamespace,
+          source_turn_id: turnId,
+          provenance_class: "durable_user_memory",
+          stability_weight: Math.max(stabilityWeightForMessage(normalized.role), gating.g),
+          gating_score: gating.g,
+          gating_t: gating.t,
+          gating_h: gating.h,
+          gating_r: gating.r,
+          gating_d: gating.d,
+          gating_p: gating.p,
+          gating_a: gating.a,
+          gating_dtech: gating.dtech,
+          gating_gconv: gating.gconv,
+          gating_gtech: gating.gtech,
+        },
+      }).catch(console.error);
+    }
+  } catch {
+    // Session storage already happened; skip durable promotion on gating failure.
+  }
+
+  return { ingested: true };
+}
+
+function normalizeHostMessage(message: { role: string; content: unknown } | undefined): MemoryMessage | null {
+  if (!message || !shouldIngestRole(message.role)) {
+    return null;
+  }
+  const content = extractMessageText(message.content);
+  if (!content) {
+    return null;
+  }
+  return {
+    role: message.role,
+    content,
+  };
+}
+
+function normalizeConversationMessages(messages: Array<{ role: string; content: unknown }>): MemoryMessage[] {
+  return messages
+    .map((message) => normalizeHostMessage(message))
+    .filter((message): message is MemoryMessage => message !== null);
+}
+
+function normalizeMemoryMessage(message: MemoryMessage): MemoryMessage | null {
+  if (!shouldIngestRole(message.role)) {
+    return null;
+  }
+  const content = extractMessageText(message.content);
+  if (!content) {
+    return null;
+  }
+  return {
+    ...message,
+    content,
+  };
+}
+
+function shouldIngestRole(role: string): boolean {
+  return role === "user" || role === "assistant" || role === "system";
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      const type = (part as { type?: unknown }).type;
+      if (
+        (type === "text" || type === "input_text" || type === "output_text") &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        return [(part as { text: string }).text];
+      }
+      return [];
+    })
+    .join("\n")
+    .trim();
 }
 
 function validateSection7StartupHardReserve(cfg: PluginConfig, authoredHard: SearchResult[]): void {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   DEFAULT_CONTINUITY_MIN_TURNS,
   DEFAULT_CONTINUITY_PRIOR_CONTEXT_TOKENS,
@@ -44,6 +45,8 @@ const SESSION_RAW_COLLECTION_PREFIX = "session_raw:";
 const SESSION_SUMMARY_COLLECTION_PREFIX = "session_summary:";
 const SESSION_EDGE_COLLECTION_PREFIX = "session_edge:";
 const SESSION_STATE_COLLECTION_PREFIX = "session_state:";
+const AFTER_TURN_DEDUPE_TTL_MS = 60 * 60 * 1000;
+const AFTER_TURN_DEDUPE_MAX_ENTRIES = 1024;
 
 export function buildContextEngineFactory(
   getRpc: RpcGetter,
@@ -54,7 +57,7 @@ export function buildContextEngineFactory(
   let authoredSoftCache: SearchResult[] | null = null;
   let authoredVariantCache: SearchResult[] | null = null;
   const authoredVariantRecallCache = new Map<string, SearchResult[]>();
-  const afterTurnIngestedKeys = new Set<string>();
+  const afterTurnIngestedKeys = new Map<string, number>();
 
   // Session-scoped elevated-guidance cache keyed by sessionId + generation + durable namespace + queryText
   const elevatedRecallCache = new Map<string, SearchResult[]>();
@@ -69,7 +72,7 @@ export function buildContextEngineFactory(
     info: { id: "libravdb-memory", name: "LibraVDB Memory", ownsCompaction: true },
     ownsCompaction: true,
     async bootstrap({ sessionId, sessionKey, userId }: ContextBootstrapArgs) {
-      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
+      const durableNamespace = resolveDurableNamespace({ userId, sessionKey, fallback: `session:${sessionId}` });
       const rpc = await getRpc();
       await rpc.call("ensure_collections", {
         collections: [
@@ -132,15 +135,18 @@ export function buildContextEngineFactory(
 
       const startIndex = Math.max(0, prePromptMessageCount - 1);
       const turnMessages = messages.slice(startIndex);
-      for (let offset = 0; offset < turnMessages.length; offset++) {
-        const index = startIndex + offset;
-        const normalized = normalizeHostMessage(turnMessages[offset]);
+      const normalizedTurnMessages = turnMessages.flatMap((turnMessage, offset) => {
+        const normalized = normalizeHostMessage(turnMessage);
         if (!normalized) {
-          continue;
+          return [];
         }
+        return [{ index: startIndex + offset, normalized }] as const;
+      });
+      for (let offset = 0; offset < normalizedTurnMessages.length; offset++) {
+        const { index, normalized } = normalizedTurnMessages[offset];
 
-        const dedupeKey = `${sessionId}\n${index}\n${normalized.role}\n${normalized.content}`;
-        if (afterTurnIngestedKeys.has(dedupeKey)) {
+        const dedupeKey = `${sessionId}\n${index}\n${normalized.role}\n${hashMessageContent(normalized.content)}`;
+        if (hasRecentAfterTurnIngest(afterTurnIngestedKeys, dedupeKey)) {
           continue;
         }
 
@@ -155,17 +161,18 @@ export function buildContextEngineFactory(
             ...normalized,
             id: `after-turn:${index}`,
           },
-          skipProjectionRebuild: offset !== turnMessages.length - 1,
+          skipProjectionRebuild: offset !== normalizedTurnMessages.length - 1,
         });
         if (result.ingested) {
-          afterTurnIngestedKeys.add(dedupeKey);
+          rememberAfterTurnIngest(afterTurnIngestedKeys, dedupeKey);
         }
       }
     },
     async assemble({ sessionId, sessionKey, userId, messages, tokenBudget, ...rest }: ContextAssembleArgs & Record<string, unknown>) {
       const PROFILE = process.env.OPENCLAW_PROFILE_ASSEMBLE === "1";
       const DEBUG_RECOVERY = process.env.LONGMEMEVAL_DEBUG_RANKING === "1";
-      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
+      const durableNamespace = resolveDurableNamespace({ userId, sessionKey, fallback: `session:${sessionId}` });
+      const originalMessages = messages;
       const normalizedMessages = normalizeConversationMessages(messages as Array<{ role: string; content: unknown }>);
 
       const queryText =
@@ -173,8 +180,8 @@ export function buildContextEngineFactory(
         normalizedMessages.at(-1)?.content ?? "";
       if (!queryText) {
         return {
-          messages: normalizedMessages,
-          estimatedTokens: countTokens(normalizedMessages),
+          messages: originalMessages,
+          estimatedTokens: countTokens(originalMessages),
           systemPromptAddition: "",
         } satisfies ContextAssembleResult;
       }
@@ -247,6 +254,7 @@ export function buildContextEngineFactory(
           temporalSelectorGuard,
           sessionId,
           userId: durableNamespace,
+          visibleMessages: originalMessages,
           messages: normalizedMessages,
           tokenBudget,
           profiler,
@@ -263,8 +271,8 @@ export function buildContextEngineFactory(
           : result;
       } catch {
         return {
-          messages: normalizedMessages,
-          estimatedTokens: countTokens(normalizedMessages),
+          messages: originalMessages,
+          estimatedTokens: countTokens(originalMessages),
           systemPromptAddition: "",
         } satisfies ContextAssembleResult;
       }
@@ -283,6 +291,7 @@ export function buildContextEngineFactory(
       temporalSelectorGuard,
       sessionId,
       userId,
+      visibleMessages,
       messages,
       tokenBudget,
       profiler,
@@ -301,6 +310,7 @@ export function buildContextEngineFactory(
       temporalSelectorGuard: ReturnType<typeof decideTemporalSelectorGuard>;
       sessionId: string;
       userId: string;
+      visibleMessages: MemoryMessage[];
       messages: Array<{ role: string; content: string }>;
       tokenBudget: number;
       profiler: { mark(label: string): void; emit(): void } | null;
@@ -350,8 +360,8 @@ export function buildContextEngineFactory(
           content: buildInjectedMemoryMessageContent(item),
         }));
         return {
-          messages: [...selectedMessages, ...messages],
-          estimatedTokens: countTokens(selectedMessages) + countTokens(messages),
+          messages: [...selectedMessages, ...visibleMessages],
+          estimatedTokens: countTokens(selectedMessages) + countTokens(visibleMessages),
           systemPromptAddition: buildDegradedMemoryHeader(degradedReasons, selected),
         };
       }
@@ -687,8 +697,8 @@ export function buildContextEngineFactory(
       }));
 
       return {
-        messages: [...selectedMessages, ...messages],
-        estimatedTokens: countTokens(selectedMessages) + countTokens(messages),
+        messages: [...selectedMessages, ...visibleMessages],
+        estimatedTokens: countTokens(selectedMessages) + countTokens(visibleMessages),
         systemPromptAddition: buildMemoryHeader(selected),
         _debug: debugRecovery
           ? {
@@ -980,7 +990,11 @@ async function ingestCanonicalMessage(params: {
 
   const rpc = await params.getRpc();
   const ts = Date.now();
-  const durableNamespace = resolveDurableNamespace({ userId: params.userId, sessionKey: params.sessionKey });
+  const durableNamespace = resolveDurableNamespace({
+    userId: params.userId,
+    sessionKey: params.sessionKey,
+    fallback: `session:${params.sessionId}`,
+  });
   const turnId = normalized.id ?? `${ts}`;
   const sessionMeta = {
     role: normalized.role,
@@ -1000,19 +1014,13 @@ async function ingestCanonicalMessage(params: {
     text: normalized.content,
     metadata: sessionMeta,
   });
-  if (useSessionRecallProjection(params.cfg)) {
-    if (params.skipProjectionRebuild) {
-      void rawSessionInsert.catch(console.error);
-    } else {
-      try {
-        await rawSessionInsert;
-        await rebuildSessionRecallProjection(rpc, params.cfg, params.sessionId);
-      } catch (error) {
-        console.error(error);
-      }
+  try {
+    await rawSessionInsert;
+    if (useSessionRecallProjection(params.cfg) && !params.skipProjectionRebuild) {
+      await rebuildSessionRecallProjection(rpc, params.cfg, params.sessionId);
     }
-  } else {
-    void rawSessionInsert.catch(console.error);
+  } catch {
+    return { ingested: false };
   }
 
   if (normalized.role !== "user") {
@@ -1068,6 +1076,38 @@ async function ingestCanonicalMessage(params: {
   }
 
   return { ingested: true };
+}
+
+function hashMessageContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function pruneAfterTurnIngestKeys(cache: Map<string, number>, now: number): void {
+  for (const [key, seenAt] of cache) {
+    if (now - seenAt > AFTER_TURN_DEDUPE_TTL_MS) {
+      cache.delete(key);
+    }
+  }
+  while (cache.size > AFTER_TURN_DEDUPE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    cache.delete(oldestKey);
+  }
+}
+
+function hasRecentAfterTurnIngest(cache: Map<string, number>, key: string): boolean {
+  const now = Date.now();
+  pruneAfterTurnIngestKeys(cache, now);
+  return cache.has(key);
+}
+
+function rememberAfterTurnIngest(cache: Map<string, number>, key: string): void {
+  const now = Date.now();
+  cache.delete(key);
+  cache.set(key, now);
+  pruneAfterTurnIngestKeys(cache, now);
 }
 
 function normalizeHostMessage(message: { role: string; content: unknown } | undefined): MemoryMessage | null {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -19,6 +19,7 @@ import {
 } from "./temporal.js";
 import type { TemporalRecoveryRankingResult } from "./temporal.js";
 import { countTokens, estimateTokens, fitPromptBudget, fitPromptBudgetFirstFit } from "./tokens.js";
+import { resolveDurableNamespace } from "./durable-namespace.js";
 import type { RpcGetter } from "./plugin-runtime.js";
 import type {
   ContextAssembleArgs,
@@ -53,7 +54,7 @@ export function buildContextEngineFactory(
   let authoredVariantCache: SearchResult[] | null = null;
   const authoredVariantRecallCache = new Map<string, SearchResult[]>();
 
-  // Session-scoped elevated-guidance cache keyed by sessionId + generation + userId + queryText
+  // Session-scoped elevated-guidance cache keyed by sessionId + generation + durable namespace + queryText
   const elevatedRecallCache = new Map<string, SearchResult[]>();
   const elevatedRecallGeneration = new Map<string, number>();
 
@@ -65,7 +66,8 @@ export function buildContextEngineFactory(
   return {
     info: { id: "libravdb-memory", name: "LibraVDB Memory", ownsCompaction: true },
     ownsCompaction: true,
-    async bootstrap({ sessionId, userId }: ContextBootstrapArgs) {
+    async bootstrap({ sessionId, sessionKey, userId }: ContextBootstrapArgs) {
+      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
       const rpc = await getRpc();
       await rpc.call("ensure_collections", {
         collections: [
@@ -75,8 +77,8 @@ export function buildContextEngineFactory(
           sessionEdgeCollection(sessionId),
           sessionStateCollection(sessionId),
           ...(useSessionRecallProjection(cfg) ? [sessionRecallCollection(sessionId)] : []),
-          `turns:${userId}`,
-          `user:${userId}`,
+          `turns:${durableNamespace}`,
+          `user:${durableNamespace}`,
           "global",
           AUTHORED_HARD_COLLECTION,
           AUTHORED_SOFT_COLLECTION,
@@ -98,17 +100,18 @@ export function buildContextEngineFactory(
       validateSection7StartupHardReserve(cfg, authoredHard);
       return { ok: true };
     },
-    async ingest({ sessionId, userId, message, isHeartbeat }: ContextIngestArgs) {
+    async ingest({ sessionId, sessionKey, userId, message, isHeartbeat }: ContextIngestArgs) {
       if (isHeartbeat) {
         return { ingested: false };
       }
 
       const rpc = await getRpc();
       const ts = Date.now();
+      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
       const sessionMeta = {
         role: message.role,
         ts,
-        userId,
+        userId: durableNamespace,
         sessionId,
         type: "turn",
         provenance_class: "session_turn",
@@ -136,10 +139,10 @@ export function buildContextEngineFactory(
 
       if (message.role === "user") {
         try {
-          recallCache.clearUser(userId);
+          recallCache.clearUser(durableNamespace);
           await rpc.call("insert_text", {
-            collection: `turns:${userId}`,
-            id: `${userId}:${ts}`,
+            collection: `turns:${durableNamespace}`,
+            id: `${durableNamespace}:${ts}`,
             text: message.content,
             metadata: {
               ...sessionMeta,
@@ -148,21 +151,21 @@ export function buildContextEngineFactory(
           });
 
           const gating = await rpc.call<GatingResult>("gating_scalar", {
-            userId,
+            userId: durableNamespace,
             text: message.content,
           });
 
           if (gating.g >= (cfg.ingestionGateThreshold ?? 0.35)) {
             void rpc.call("insert_text", {
-              collection: `user:${userId}`,
-              id: `${userId}:${ts}`,
+              collection: `user:${durableNamespace}`,
+              id: `${durableNamespace}:${ts}`,
               text: message.content,
               metadata: {
                 role: message.role,
                 ts,
                 sessionId,
                 type: "turn",
-                userId,
+                userId: durableNamespace,
                 provenance_class: "durable_user_memory",
                 stability_weight: Math.max(stabilityWeightForMessage(message.role), gating.g),
                 gating_score: gating.g,
@@ -185,9 +188,10 @@ export function buildContextEngineFactory(
 
       return { ingested: true };
     },
-    async assemble({ sessionId, userId, messages, tokenBudget }: ContextAssembleArgs) {
+    async assemble({ sessionId, sessionKey, userId, messages, tokenBudget }: ContextAssembleArgs) {
       const PROFILE = process.env.OPENCLAW_PROFILE_ASSEMBLE === "1";
       const DEBUG_RECOVERY = process.env.LONGMEMEVAL_DEBUG_RANKING === "1";
+      const durableNamespace = resolveDurableNamespace({ userId, sessionKey });
 
       const queryText = messages.at(-1)?.content ?? "";
       if (!queryText) {
@@ -201,7 +205,7 @@ export function buildContextEngineFactory(
       const temporalSelectorGuard = decideTemporalSelectorGuard(queryText, temporalQuery);
 
       const excluded = recentIds(messages, 4);
-      const cached = recallCache.take({ userId, queryText });
+      const cached = recallCache.take({ userId: durableNamespace, queryText });
 
       const rpc = await getRpc();
 
@@ -265,7 +269,7 @@ export function buildContextEngineFactory(
           temporalQuery,
           temporalSelectorGuard,
           sessionId,
-          userId,
+          userId: durableNamespace,
           messages,
           tokenBudget,
           profiler,

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -122,9 +122,10 @@ export function buildContextEngineFactory(
       });
       return { ingested: result.ingested };
     },
-    async afterTurn({ sessionId, sessionKey, messages, prePromptMessageCount, isHeartbeat }: {
+    async afterTurn({ sessionId, sessionKey, userId, messages, prePromptMessageCount, isHeartbeat }: {
       sessionId: string;
       sessionKey?: string;
+      userId?: string;
       messages: Array<{ role: string; content: unknown }>;
       prePromptMessageCount: number;
       isHeartbeat?: boolean;
@@ -157,6 +158,7 @@ export function buildContextEngineFactory(
           clearElevatedCacheForSession,
           sessionId,
           sessionKey,
+          userId,
           message: {
             ...normalized,
             id: `after-turn:${index}`,

--- a/src/durable-namespace.ts
+++ b/src/durable-namespace.ts
@@ -1,0 +1,30 @@
+const SESSION_KEY_NAMESPACE_PREFIX = "session-key:";
+const AGENT_ID_NAMESPACE_PREFIX = "agent-id:";
+
+export function resolveDurableNamespace(params: {
+  userId?: string;
+  sessionKey?: string;
+  agentId?: string;
+  fallback?: string;
+}): string {
+  const explicitUserId = firstNonEmpty(params.userId);
+  if (explicitUserId) {
+    return explicitUserId;
+  }
+
+  const sessionKey = firstNonEmpty(params.sessionKey);
+  if (sessionKey) {
+    return `${SESSION_KEY_NAMESPACE_PREFIX}${sessionKey}`;
+  }
+
+  const agentId = firstNonEmpty(params.agentId);
+  if (agentId) {
+    return `${AGENT_ID_NAMESPACE_PREFIX}${agentId}`;
+  }
+
+  return params.fallback ?? "default";
+}
+
+function firstNonEmpty(value: string | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/durable-namespace.ts
+++ b/src/durable-namespace.ts
@@ -22,9 +22,13 @@ export function resolveDurableNamespace(params: {
     return `${AGENT_ID_NAMESPACE_PREFIX}${agentId}`;
   }
 
-  return params.fallback ?? "default";
+  return firstNonEmpty(params.fallback) ?? "default";
 }
 
 function firstNonEmpty(value: string | undefined): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -1,4 +1,5 @@
 import type { RpcGetter } from "./plugin-runtime.js";
+import { resolveDurableNamespace } from "./durable-namespace.js";
 import type { PluginConfig, SearchResult } from "./types.js";
 
 type MemorySearchParams = {
@@ -12,10 +13,12 @@ type MemorySearchParams = {
   userId?: string;
   agentId?: string;
   sessionId?: string;
+  sessionKey?: string;
   context?: {
     userId?: string;
     agentId?: string;
     sessionId?: string;
+    sessionKey?: string;
   };
 };
 
@@ -32,8 +35,9 @@ type MemoryRuntimeStatus = {
 export function buildMemoryRuntimeBridge(getRpc: RpcGetter, cfg: PluginConfig) {
   return {
     async getMemorySearchManager(params: { agentId?: string; purpose?: string } = {}) {
+      const status = await readStatus(getRpc, params.purpose);
       return {
-        manager: createMemorySearchManager(getRpc, cfg, params),
+        manager: createMemorySearchManager(getRpc, cfg, params, status),
       };
     },
     resolveMemoryBackendConfig() {
@@ -51,22 +55,34 @@ function createMemorySearchManager(
   getRpc: RpcGetter,
   cfg: PluginConfig,
   defaults: { agentId?: string; purpose?: string },
+  initialStatus: MemoryRuntimeStatus & Record<string, unknown>,
 ) {
+  let cachedStatus = initialStatus;
+
   return {
-    async search(params: MemorySearchParams = {}) {
+    async search(queryOrParams: string | MemorySearchParams = {}, opts: MemorySearchParams = {}) {
+      const legacyCall = typeof queryOrParams !== "string";
+      const params = legacyCall
+        ? queryOrParams
+        : {
+            query: queryOrParams,
+            limit: opts.limit ?? opts.k ?? opts.topK,
+            sessionId: opts.sessionId,
+            sessionKey: opts.sessionKey,
+            userId: opts.userId,
+            agentId: opts.agentId,
+            context: opts.context,
+          } satisfies MemorySearchParams;
       const queryText = firstString(params.query, params.text, params.input, params.q);
       if (!queryText) {
-        return { results: [], error: "Missing query text for LibraVDB memory search" };
+        return legacyCall ? { results: [], error: "Missing query text for LibraVDB memory search" } : [];
       }
 
-      const userId = firstString(
-        params.userId,
-        params.context?.userId,
-        params.agentId,
-        params.context?.agentId,
-        defaults.agentId,
-        "default",
-      )!;
+      const userId = resolveDurableNamespace({
+        userId: firstString(params.userId, params.context?.userId),
+        sessionKey: firstString(params.sessionKey, params.context?.sessionKey),
+        agentId: firstString(params.agentId, params.context?.agentId, defaults.agentId),
+      });
       const sessionId = firstString(params.sessionId, params.context?.sessionId);
       const k = normalizePositiveInteger(params.k, params.limit, params.topK, cfg.topK, 8);
       const collections = resolveSearchCollections(cfg, userId, sessionId);
@@ -85,11 +101,24 @@ function createMemorySearchManager(
             excludeByCollection: {},
           });
 
+      const legacyResults = result.results.map((item) => ({
+        ...item,
+        content: item.text,
+      }));
+      if (legacyCall) {
+        return { results: legacyResults };
+      }
+      return result.results.map(toMemorySearchResult);
+    },
+    async readFile(params: { relPath: string; from?: number; lines?: number }) {
+      const located = await loadSearchResultText(getRpc, params.relPath);
+      const fromLine = Math.max(1, params.from ?? 1);
+      const lineCount = Math.max(1, params.lines ?? 200);
+      const lines = located.text.split("\n");
+      const text = lines.slice(fromLine - 1, fromLine - 1 + lineCount).join("\n");
       return {
-        results: result.results.map((item) => ({
-          ...item,
-          content: item.text,
-        })),
+        text,
+        path: located.path,
       };
     },
     async ingest() {
@@ -97,23 +126,25 @@ function createMemorySearchManager(
       return { ingested: false, delegatedToContextEngine: true };
     },
     async sync() {
-      // Projections and compaction sync are already handled inside the existing
-      // context-engine lifecycle.
+      cachedStatus = await readStatus(getRpc, defaults.purpose);
       return { synced: true, delegatedToContextEngine: true };
     },
-    async status() {
-      const rpc = await getRpc();
-      const status = await rpc.call<MemoryRuntimeStatus>("status", {});
+    status() {
+      return cachedStatus;
+    },
+    async probeEmbeddingAvailability() {
       return {
-        ok: status.ok ?? false,
-        message: status.message ?? "ok",
-        turnCount: status.turnCount ?? 0,
-        memoryCount: status.memoryCount ?? 0,
-        gatingThreshold: status.gatingThreshold,
-        abstractiveReady: status.abstractiveReady ?? false,
-        embeddingProfile: status.embeddingProfile ?? "unknown",
-        purpose: defaults.purpose,
+        ok: cachedStatus.ok ?? false,
+        ...(cachedStatus.ok === false && typeof cachedStatus.message === "string"
+          ? { error: cachedStatus.message }
+          : {}),
       };
+    },
+    async probeVectorAvailability() {
+      return cachedStatus.ok ?? false;
+    },
+    async close() {
+      // The sidecar connection is shared by the plugin runtime.
     },
   };
 }
@@ -138,6 +169,83 @@ function resolveSearchCollections(cfg: PluginConfig, userId: string, sessionId?:
 
 function firstString(...values: Array<string | undefined>): string | undefined {
   return values.find((value) => typeof value === "string" && value.length > 0);
+}
+
+function toMemorySearchResult(item: SearchResult) {
+  const collection = typeof item.metadata.collection === "string" ? item.metadata.collection : "memory";
+  return {
+    path: encodeSearchResultPath(collection, item.id),
+    startLine: 1,
+    endLine: Math.max(1, item.text.split("\n").length),
+    score: item.score,
+    snippet: item.text,
+    source: collection.startsWith("session:") || collection.startsWith("session_") ? "sessions" : "memory",
+    citation: `${collection}:${item.id}`,
+  };
+}
+
+async function loadSearchResultText(getRpc: RpcGetter, relPath: string): Promise<{ path: string; text: string }> {
+  const { collection, id } = decodeSearchResultPath(relPath);
+  const rpc = await getRpc();
+  const result = await rpc.call<{ results: SearchResult[] }>("list_collection", { collection });
+  const item = result.results.find((entry) => entry.id === id);
+  if (!item) {
+    throw new Error(`LibraVDB memory path not found: ${relPath}`);
+  }
+  return {
+    path: relPath,
+    text: item.text,
+  };
+}
+
+function encodeSearchResultPath(collection: string, id: string): string {
+  return `${collection}::${encodeURIComponent(id)}`;
+}
+
+function decodeSearchResultPath(relPath: string): { collection: string; id: string } {
+  const separator = relPath.indexOf("::");
+  if (separator <= 0) {
+    throw new Error(`Unsupported LibraVDB memory path: ${relPath}`);
+  }
+  return {
+    collection: relPath.slice(0, separator),
+    id: decodeURIComponent(relPath.slice(separator + 2)),
+  };
+}
+
+async function readStatus(
+  getRpc: RpcGetter,
+  purpose: string | undefined,
+): Promise<MemoryRuntimeStatus & Record<string, unknown>> {
+  try {
+    const rpc = await getRpc();
+    const status = await rpc.call<MemoryRuntimeStatus>("status", {});
+    return {
+      backend: "builtin",
+      provider: "libravdb",
+      model: status.embeddingProfile ?? "unknown",
+      ok: status.ok ?? false,
+      message: status.message ?? "ok",
+      turnCount: status.turnCount ?? 0,
+      memoryCount: status.memoryCount ?? 0,
+      gatingThreshold: status.gatingThreshold,
+      abstractiveReady: status.abstractiveReady ?? false,
+      embeddingProfile: status.embeddingProfile ?? "unknown",
+      purpose,
+    };
+  } catch (error) {
+    return {
+      backend: "builtin",
+      provider: "libravdb",
+      model: "unknown",
+      ok: false,
+      message: error instanceof Error && error.message ? error.message : String(error),
+      turnCount: 0,
+      memoryCount: 0,
+      embeddingProfile: "unknown",
+      purpose,
+    };
+  }
 }
 
 function normalizePositiveInteger(...values: Array<number | undefined>): number {

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -219,8 +219,9 @@ async function readStatus(
 ): Promise<MemoryRuntimeStatus & Record<string, unknown>> {
   try {
     const rpc = await getRpc();
-    const status = await rpc.call<MemoryRuntimeStatus>("status", {});
+    const status = await rpc.call<MemoryRuntimeStatus & Record<string, unknown>>("status", {});
     return {
+      ...status,
       backend: "builtin",
       provider: "libravdb",
       model: status.embeddingProfile ?? "unknown",

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -78,12 +78,13 @@ function createMemorySearchManager(
         return legacyCall ? { results: [], error: "Missing query text for LibraVDB memory search" } : [];
       }
 
+      const sessionId = firstString(params.sessionId, params.context?.sessionId);
       const userId = resolveDurableNamespace({
         userId: firstString(params.userId, params.context?.userId),
         sessionKey: firstString(params.sessionKey, params.context?.sessionKey),
         agentId: firstString(params.agentId, params.context?.agentId, defaults.agentId),
+        fallback: sessionId ? `session:${sessionId}` : undefined,
       });
-      const sessionId = firstString(params.sessionId, params.context?.sessionId);
       const k = normalizePositiveInteger(params.k, params.limit, params.topK, cfg.topK, 8);
       const collections = resolveSearchCollections(cfg, userId, sessionId);
       const rpc = await getRpc();

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -61,10 +61,9 @@ function createMemorySearchManager(
 
   return {
     async search(queryOrParams: string | MemorySearchParams = {}, opts: MemorySearchParams = {}) {
-      const legacyCall = typeof queryOrParams !== "string";
+      const legacyCall = typeof queryOrParams === "string";
       const params = legacyCall
-        ? queryOrParams
-        : {
+        ? {
             query: queryOrParams,
             limit: opts.limit ?? opts.k ?? opts.topK,
             sessionId: opts.sessionId,
@@ -72,7 +71,8 @@ function createMemorySearchManager(
             userId: opts.userId,
             agentId: opts.agentId,
             context: opts.context,
-          } satisfies MemorySearchParams;
+          }
+        : queryOrParams;
       const queryText = firstString(params.query, params.text, params.input, params.q);
       if (!queryText) {
         return legacyCall ? { results: [], error: "Missing query text for LibraVDB memory search" } : [];
@@ -199,7 +199,7 @@ async function loadSearchResultText(getRpc: RpcGetter, relPath: string): Promise
 }
 
 function encodeSearchResultPath(collection: string, id: string): string {
-  return `${collection}::${encodeURIComponent(id)}`;
+  return `${encodeURIComponent(collection)}::${encodeURIComponent(id)}`;
 }
 
 function decodeSearchResultPath(relPath: string): { collection: string; id: string } {
@@ -208,7 +208,7 @@ function decodeSearchResultPath(relPath: string): { collection: string; id: stri
     throw new Error(`Unsupported LibraVDB memory path: ${relPath}`);
   }
   return {
-    collection: relPath.slice(0, separator),
+    collection: decodeURIComponent(relPath.slice(0, separator)),
     id: decodeURIComponent(relPath.slice(separator + 2)),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,19 +174,22 @@ export interface RecallCache<T = unknown> {
 
 export interface ContextBootstrapArgs {
   sessionId: string;
-  userId: string;
+  sessionKey?: string;
+  userId?: string;
 }
 
 export interface ContextIngestArgs {
   sessionId: string;
-  userId: string;
+  sessionKey?: string;
+  userId?: string;
   message: MemoryMessage;
   isHeartbeat?: boolean;
 }
 
 export interface ContextAssembleArgs {
   sessionId: string;
-  userId: string;
+  sessionKey?: string;
+  userId?: string;
   messages: MemoryMessage[];
   tokenBudget: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,24 +172,20 @@ export interface RecallCache<T = unknown> {
   clearUser(userId: string): void;
 }
 
-export interface ContextBootstrapArgs {
+export interface ContextNamespaceArgs {
   sessionId: string;
   sessionKey?: string;
   userId?: string;
 }
 
-export interface ContextIngestArgs {
-  sessionId: string;
-  sessionKey?: string;
-  userId?: string;
+export interface ContextBootstrapArgs extends ContextNamespaceArgs {}
+
+export interface ContextIngestArgs extends ContextNamespaceArgs {
   message: MemoryMessage;
   isHeartbeat?: boolean;
 }
 
-export interface ContextAssembleArgs {
-  sessionId: string;
-  sessionKey?: string;
-  userId?: string;
+export interface ContextAssembleArgs extends ContextNamespaceArgs {
   messages: MemoryMessage[];
   tokenBudget: number;
 }

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -643,6 +643,28 @@ test("context-engine derives the durable namespace from sessionKey when userId i
   assert.equal(userInsert?.metadata?.userId, durableNamespace);
 });
 
+test("context-engine falls back to a session-scoped durable namespace when userId and sessionKey are absent", async () => {
+  const rpc = new FakeRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+    tokenBudgetFraction: 0.25,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+
+  await context.bootstrap({ sessionId: "s-fallback" });
+  await context.ingest({
+    sessionId: "s-fallback",
+    message: { role: "user", content: "remember fallback namespace" },
+  });
+
+  assert.ok(rpc.inserted.some((item) => item.collection === "turns:session:s-fallback"));
+  assert.ok(rpc.inserted.some((item) => item.collection === "user:session:s-fallback"));
+});
+
 test("afterTurn ingests the current user prompt even when OpenClaw persists it before post-turn ingest", async () => {
   const rpc = new FakeRpc();
   const recallCache = createRecallCache<SearchResult>();
@@ -738,6 +760,60 @@ test("assemble uses the sessionKey-derived durable namespace without changing re
   assert.ok(userIndex >= 0, "expected derived durable namespace memory in assembled recall");
   assert.ok(globalIndex >= 0, "expected stale global summary in assembled recall");
   assert.ok(userIndex < globalIndex, "expected fresher durable namespace memory to outrank stale global summary");
+});
+
+test("assemble preserves original host-visible messages even when retrieval normalizes its query surface", async () => {
+  const rpc = new FakeRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+    tokenBudgetFraction: 0.25,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+
+  await context.bootstrap({ sessionId: "s1", userId: "u1" });
+  const assembled = await context.assemble({
+    sessionId: "s1",
+    userId: "u1",
+    messages: [
+      { role: "user", content: "search for the last tool result" },
+      { role: "tool", content: "tool output that should remain visible" },
+    ],
+    tokenBudget: 1000,
+  });
+
+  assert.ok(assembled.messages.some((message) => message.role === "tool" && message.content === "tool output that should remain visible"));
+});
+
+test("ingest reports failure when raw session storage fails", async () => {
+  const rpc = {
+    async call<T>(method: string): Promise<T> {
+      switch (method) {
+        case "ensure_collections":
+          return { ok: true } as T;
+        case "list_collection":
+          return { results: [] } as T;
+        case "insert_session_turn":
+          throw new Error("session insert failed");
+        default:
+          throw new Error(`unexpected rpc method: ${method}`);
+      }
+    },
+  };
+  const recallCache = createRecallCache<SearchResult>();
+  const context = buildContextEngineFactory(async () => rpc as never, { topK: 8 }, recallCache);
+
+  await context.bootstrap({ sessionId: "s1", userId: "u1" });
+  const result = await context.ingest({
+    sessionId: "s1",
+    userId: "u1",
+    message: { role: "user", content: "should fail" },
+  });
+
+  assert.deepEqual(result, { ingested: false });
 });
 
 test("real sidecar mid-sized session search benchmark", async (t) => {

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -643,6 +643,41 @@ test("context-engine derives the durable namespace from sessionKey when userId i
   assert.equal(userInsert?.metadata?.userId, durableNamespace);
 });
 
+test("afterTurn ingests the current user prompt even when OpenClaw persists it before post-turn ingest", async () => {
+  const rpc = new FakeRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+    useSessionRecallProjection: true,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+  const sessionKey = "agent:main:main";
+  const durableNamespace = resolveDurableNamespace({ sessionKey });
+
+  await context.bootstrap({ sessionId: "s1", sessionKey });
+  await context.afterTurn({
+    sessionId: "s1",
+    sessionKey,
+    prePromptMessageCount: 2,
+    messages: [
+      { role: "assistant", content: "older context" },
+      { role: "user", content: "remember this through afterTurn" },
+      { role: "assistant", content: "stored" },
+    ],
+  });
+
+  const sessionTexts = rpc.inserted
+    .filter((item) => item.collection === "session:s1")
+    .map((item) => item.text);
+  assert.deepEqual(sessionTexts, ["remember this through afterTurn", "stored"]);
+  assert.ok(rpc.inserted.some((item) => item.collection === `turns:${durableNamespace}` && item.text === "remember this through afterTurn"));
+  assert.ok(rpc.inserted.some((item) => item.collection === `user:${durableNamespace}` && item.text === "remember this through afterTurn"));
+  assert.ok(!rpc.inserted.some((item) => item.collection === `turns:${durableNamespace}` && item.text === "stored"));
+});
+
 test("assemble uses the sessionKey-derived durable namespace without changing retrieval weighting", async () => {
   const rpc = new ProjectionStoreRpc();
   const recallCache = createRecallCache<SearchResult>();

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -700,6 +700,31 @@ test("afterTurn ingests the current user prompt even when OpenClaw persists it b
   assert.ok(!rpc.inserted.some((item) => item.collection === `turns:${durableNamespace}` && item.text === "stored"));
 });
 
+test("afterTurn keeps using the explicit user-scoped namespace when userId is available", async () => {
+  const rpc = new FakeRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+
+  await context.bootstrap({ sessionId: "s1", userId: "u-explicit" });
+  await context.afterTurn({
+    sessionId: "s1",
+    userId: "u-explicit",
+    prePromptMessageCount: 1,
+    messages: [
+      { role: "user", content: "remember explicit user namespace" },
+    ],
+  });
+
+  assert.ok(rpc.inserted.some((item) => item.collection === "turns:u-explicit" && item.text === "remember explicit user namespace"));
+  assert.ok(rpc.inserted.some((item) => item.collection === "user:u-explicit" && item.text === "remember explicit user namespace"));
+});
+
 test("assemble uses the sessionKey-derived durable namespace without changing retrieval weighting", async () => {
   const rpc = new ProjectionStoreRpc();
   const recallCache = createRecallCache<SearchResult>();

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildContextEngineFactory } from "../../src/context-engine.js";
+import { resolveDurableNamespace } from "../../src/durable-namespace.js";
 import { acquireTestDaemonHandle } from "./daemon-harness.js";
 import { buildMemoryPromptSection } from "../../src/memory-provider.js";
 import { createPluginRuntime } from "../../src/plugin-runtime.js";
@@ -613,6 +614,95 @@ test("context-engine bootstrap -> ingest -> assemble -> compact host flow", asyn
   assert.equal(userInsert?.metadata?.gating_a, 0.5);
   assert.equal(userInsert?.metadata?.gating_gconv, 0.65);
   assert.equal(userInsert?.metadata?.gating_gtech, 0.85);
+});
+
+test("context-engine derives the durable namespace from sessionKey when userId is absent", async () => {
+  const rpc = new FakeRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+    tokenBudgetFraction: 0.25,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+  const sessionKey = "agent:main:channel:conversation";
+  const durableNamespace = resolveDurableNamespace({ sessionKey });
+
+  await context.bootstrap({ sessionId: "s1", sessionKey });
+  await context.ingest({
+    sessionId: "s1",
+    sessionKey,
+    message: { role: "user", content: "remember this" },
+  });
+
+  assert.ok(rpc.inserted.some((item) => item.collection === `turns:${durableNamespace}`));
+  assert.ok(rpc.inserted.some((item) => item.collection === `user:${durableNamespace}`));
+  const userInsert = rpc.inserted.find((item) => item.collection === `user:${durableNamespace}`);
+  assert.equal(userInsert?.metadata?.userId, durableNamespace);
+});
+
+test("assemble uses the sessionKey-derived durable namespace without changing retrieval weighting", async () => {
+  const rpc = new ProjectionStoreRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const now = Date.now();
+  const sessionKey = "agent:main:channel:conversation";
+  const durableNamespace = resolveDurableNamespace({ sessionKey });
+
+  rpc.collections.set(`user:${durableNamespace}`, [
+    {
+      id: "user-fresh",
+      score: 0.72,
+      text: "durable namespace memory winner",
+      metadata: {
+        userId: durableNamespace,
+        ts: now,
+        collection: `user:${durableNamespace}`,
+        token_estimate: 4,
+      },
+    },
+  ]);
+  rpc.collections.set("global", [
+    {
+      id: "global-stale-summary",
+      score: 0.96,
+      text: "stale global summary loser",
+      metadata: {
+        ts: now - 21 * 24 * 60 * 60 * 1000,
+        collection: "global",
+        type: "summary",
+        decay_rate: 1,
+        token_estimate: 4,
+      },
+    },
+  ]);
+
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    topK: 8,
+    alpha: 0.7,
+    beta: 0.2,
+    gamma: 0.1,
+  };
+
+  const getRpc = async () => rpc as never;
+  const context = buildContextEngineFactory(getRpc, cfg, recallCache);
+  await context.bootstrap({ sessionId: "s1", sessionKey });
+
+  const assembled = await context.assemble({
+    sessionId: "s1",
+    sessionKey,
+    messages: [{ role: "user", content: "winner" }],
+    tokenBudget: 200,
+  });
+
+  const rendered = assembled.systemPromptAddition;
+  const userIndex = rendered.indexOf("durable namespace memory winner");
+  const globalIndex = rendered.indexOf("stale global summary loser");
+  assert.ok(userIndex >= 0, "expected derived durable namespace memory in assembled recall");
+  assert.ok(globalIndex >= 0, "expected stale global summary in assembled recall");
+  assert.ok(userIndex < globalIndex, "expected fresher durable namespace memory to outrank stale global summary");
 });
 
 test("real sidecar mid-sized session search benchmark", async (t) => {

--- a/test/unit/durable-namespace.test.ts
+++ b/test/unit/durable-namespace.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveDurableNamespace } from "../../src/durable-namespace.js";
+
+test("resolveDurableNamespace trims inputs and prefers sessionKey over agentId", () => {
+  assert.equal(
+    resolveDurableNamespace({ userId: "  user-1  ", sessionKey: "session-1", agentId: "agent-1" }),
+    "user-1",
+  );
+  assert.equal(
+    resolveDurableNamespace({ sessionKey: "  session-1  ", agentId: "agent-1" }),
+    "session-key:session-1",
+  );
+  assert.equal(
+    resolveDurableNamespace({ agentId: "  agent-1  " }),
+    "agent-id:agent-1",
+  );
+});
+
+test("resolveDurableNamespace trims fallback values and rejects blank fallback strings", () => {
+  assert.equal(resolveDurableNamespace({ fallback: "  custom-fallback  " }), "custom-fallback");
+  assert.equal(resolveDurableNamespace({ fallback: "   " }), "default");
+});

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -34,6 +34,7 @@ class FakeRpc {
           gatingThreshold: 0.35,
           abstractiveReady: false,
           embeddingProfile: "nomic-embed-text-v1.5",
+          sessionTurnCount: 7,
         } as T;
       case "list_collection":
         return {
@@ -113,6 +114,7 @@ test("memory runtime bridge exposes cached status and keeps legacy helpers deleg
   assert.equal(status.provider, "libravdb");
   assert.equal(status.turnCount, 12);
   assert.equal(status.embeddingProfile, "nomic-embed-text-v1.5");
+  assert.equal(status.sessionTurnCount, 7);
   assert.deepEqual(ingest, { ingested: false, delegatedToContextEngine: true });
   assert.deepEqual(sync, { synced: true, delegatedToContextEngine: true });
   assert.deepEqual(probe, { ok: true });

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -1,7 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveDurableNamespace } from "../../src/durable-namespace.js";
 import { buildMemoryRuntimeBridge } from "../../src/memory-runtime.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 
@@ -13,16 +12,19 @@ class FakeRpc {
 
     switch (method) {
       case "search_text_collections":
+        {
+          const collections = params.collections as string[] | undefined;
         return {
           results: [
             {
               id: "m1",
               score: 0.91,
               text: "remembered item",
-              metadata: { collection: "user:u1" },
+              metadata: { collection: collections?.[0] ?? "user:u1" },
             },
           ],
         } as T;
+        }
       case "status":
         return {
           ok: true,
@@ -32,6 +34,17 @@ class FakeRpc {
           gatingThreshold: 0.35,
           abstractiveReady: false,
           embeddingProfile: "nomic-embed-text-v1.5",
+        } as T;
+      case "list_collection":
+        return {
+          results: [
+            {
+              id: "m1",
+              score: 0.91,
+              text: "remembered item",
+              metadata: { collection: String(params.collection) },
+            },
+          ],
         } as T;
       default:
         throw new Error(`unexpected rpc method: ${method}`);
@@ -43,20 +56,45 @@ test("memory runtime bridge searches the resolved durable namespace under the la
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { topK: 6, useSessionRecallProjection: true };
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
-  const { manager } = await runtime.getMemorySearchManager({ agentId: "u1" });
-  const sessionKey = "agent:main:cli:memory-search";
-  const namespace = resolveDurableNamespace({ sessionKey, agentId: "u1" });
+  const { manager } = await runtime.getMemorySearchManager();
+  const sessionKey = "fixed-session";
 
-  const result = await manager.search("find prior context", { sessionKey });
+  const result = await manager.search({ query: "find prior context", sessionKey });
   assert.ok(Array.isArray(result));
 
   assert.equal(rpc.calls[0]?.method, "status");
   assert.equal(rpc.calls[1]?.method, "search_text_collections");
-  assert.deepEqual(rpc.calls[1]?.params.collections, [`user:${namespace}`, "global"]);
+  assert.deepEqual(rpc.calls[1]?.params.collections, ["user:session-key:fixed-session", "global"]);
   assert.equal(rpc.calls[1]?.params.k, 6);
   assert.equal(result.length, 1);
   assert.equal(result[0]?.snippet, "remembered item");
   assert.equal(result[0]?.source, "memory");
+});
+
+test("memory runtime bridge keeps the legacy string search shape", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search("find prior context", { sessionKey: "fixed-session" }) as {
+    results: Array<{ content: string }>;
+  };
+
+  assert.equal(Array.isArray(result), false);
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0]?.content, "remembered item");
+});
+
+test("memory runtime bridge round-trips encoded collection names in result paths", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find prior context", userId: "u1::nested" }) as Array<{ path: string }>;
+  const path = result[0]?.path;
+  assert.equal(typeof path, "string");
+  const loaded = await manager.readFile({ relPath: path ?? "", from: 1, lines: 1 });
+  assert.equal(loaded.text, "remembered item");
 });
 
 test("memory runtime bridge exposes cached status and keeps legacy helpers delegated", async () => {

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -72,6 +72,18 @@ test("memory runtime bridge searches the resolved durable namespace under the la
   assert.equal(result[0]?.source, "memory");
 });
 
+test("memory runtime bridge falls back to session-scoped namespace when no other identity is present", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find prior context", sessionId: "s-fallback" });
+
+  assert.ok(Array.isArray(result));
+  assert.equal(rpc.calls[1]?.method, "search_text_collections");
+  assert.deepEqual(rpc.calls[1]?.params.collections, ["session:s-fallback", "user:session:s-fallback", "global"]);
+});
+
 test("memory runtime bridge keeps the legacy string search shape", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { resolveDurableNamespace } from "../../src/durable-namespace.js";
 import { buildMemoryRuntimeBridge } from "../../src/memory-runtime.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 
@@ -38,37 +39,43 @@ class FakeRpc {
   }
 }
 
-test("memory runtime bridge registers a manager that searches session and durable collections", async () => {
+test("memory runtime bridge searches the resolved durable namespace under the latest host contract", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { topK: 6, useSessionRecallProjection: true };
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
   const { manager } = await runtime.getMemorySearchManager({ agentId: "u1" });
+  const sessionKey = "agent:main:cli:memory-search";
+  const namespace = resolveDurableNamespace({ sessionKey, agentId: "u1" });
 
-  const result = await manager.search({
-    query: "find prior context",
-    sessionId: "s1",
-  });
+  const result = await manager.search("find prior context", { sessionKey });
+  assert.ok(Array.isArray(result));
 
-  assert.equal(rpc.calls[0]?.method, "search_text_collections");
-  assert.deepEqual(rpc.calls[0]?.params.collections, ["session_recall:s1", "user:u1", "global"]);
-  assert.equal(rpc.calls[0]?.params.k, 6);
-  assert.equal(result.results.length, 1);
-  assert.equal(result.results[0]?.content, "remembered item");
+  assert.equal(rpc.calls[0]?.method, "status");
+  assert.equal(rpc.calls[1]?.method, "search_text_collections");
+  assert.deepEqual(rpc.calls[1]?.params.collections, [`user:${namespace}`, "global"]);
+  assert.equal(rpc.calls[1]?.params.k, 6);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.snippet, "remembered item");
+  assert.equal(result[0]?.source, "memory");
 });
 
-test("memory runtime bridge exposes sidecar status and keeps ingest delegated", async () => {
+test("memory runtime bridge exposes cached status and keeps legacy helpers delegated", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = {};
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
   const { manager } = await runtime.getMemorySearchManager({ purpose: "status" });
 
-  const status = await manager.status();
+  const status = manager.status();
   const ingest = await manager.ingest();
   const sync = await manager.sync();
+  const probe = await manager.probeEmbeddingAvailability();
 
   assert.equal(status.ok, true);
+  assert.equal(status.backend, "builtin");
+  assert.equal(status.provider, "libravdb");
   assert.equal(status.turnCount, 12);
   assert.equal(status.embeddingProfile, "nomic-embed-text-v1.5");
   assert.deepEqual(ingest, { ingested: false, delegatedToContextEngine: true });
   assert.deepEqual(sync, { synced: true, delegatedToContextEngine: true });
+  assert.deepEqual(probe, { ok: true });
 });


### PR DESCRIPTION
## Summary
- derive the durable memory namespace from `sessionKey` when the host does not supply `userId`, while preserving the existing scoring and gating fields used by retrieval math
- update the memory runtime bridge and CLI namespace operations to resolve the same durable namespace under the latest OpenClaw release contract
- add regression coverage for session-key fallback in context assembly and refresh the math docs to clarify that durable memory can be session-key-derived without changing the formulas

## Testing
- `pnpm run test:ts`
- `pnpm run test:integration`
- `pnpm check` still fails before tests on the pre-existing `scripts/setup.ts` missing declaration for `./child-env.js`

Closes #20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: optional session-key for memory flush/export; resolved durable namespace shown.
  * Search: legacy string-query maintained; can load stored-item text via encoded path; status cached for faster probes.

* **Behavior Changes**
  * Durable-namespace resolution (userId → sessionKey → agentId → fallback) now governs ingestion, recall, assembly, and flush; improved ingestion ordering and dedupe.

* **Documentation**
  * Clarified durable-namespace semantics, selection priority, and decay/weighting when userId is absent.

* **Tests**
  * Added unit and integration tests covering durable-namespace, ingestion/assembly, search/read, and export/flush.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->