### PR TITLE
install: add one-line bootstrap setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,35 +62,39 @@ These are the core differentiators the project is built around:
 
 ## Quick Start
 
-The supported install flow is:
+The shortest supported setup is a single bootstrap command:
 
 ```bash
-brew tap xDarkicex/openclaw-libravdb-memory
-brew install libravdbd
+curl -fsSL https://raw.githubusercontent.com/xDarkicex/openclaw-memory-libravdb/main/install.sh | bash
+```
+
+Prerequisites: Homebrew and the `openclaw` CLI must already be installed and on
+your `PATH`.
+
+That script:
+
+- installs `libravdbd` from the published Homebrew tap
+- starts the managed `libravdbd` service
+- installs `@xdarkicex/openclaw-memory-libravdb`
+- restarts the OpenClaw gateway when it is already running
+
+If you prefer to run the steps yourself, the manual equivalent is:
+
+```bash
+brew install xDarkicex/openclaw-libravdb-memory/libravdbd
 brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+openclaw gateway restart
 ```
 
-The Homebrew formula installs the daemon plus the bundled ONNX Runtime, embedding assets, and T5 summarizer assets it needs to boot cleanly on supported platforms.
+On current supported OpenClaw builds, `openclaw plugins install` auto-selects
+both required slots for this dual-kind plugin. You only need manual
+`plugins.configs.libravdb-memory.sidecarPath` config when you run the daemon on
+a non-default endpoint.
 
-Then assign the plugin to both required OpenClaw slots in
-`~/.openclaw/openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
-    },
-    "configs": {
-      "libravdb-memory": {
-        "sidecarPath": "auto"
-      }
-    }
-  }
-}
-```
+The Homebrew formula installs the daemon plus the bundled ONNX Runtime,
+embedding assets, and T5 summarizer assets it needs to boot cleanly on
+supported platforms.
 
 Verify the setup:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,15 +7,28 @@ daemon endpoint when you need a non-default location.
 For deeper operational detail, use the full
 [installation reference](./installation.md).
 
-## Recommended Path: Homebrew + OpenClaw Plugin
+## Recommended Path: One-Liner Bootstrap
 
 On macOS, the shortest supported path is:
 
 ```bash
-brew tap xDarkicex/openclaw-libravdb-memory
-brew install libravdbd
+curl -fsSL https://raw.githubusercontent.com/xDarkicex/openclaw-memory-libravdb/main/install.sh | bash
+```
+
+Prerequisites: Homebrew and the `openclaw` CLI must already be installed and on
+your `PATH`.
+
+That bootstrap script installs the published Homebrew formula, starts the
+managed `libravdbd` service, installs the OpenClaw plugin, and restarts the
+gateway when it is already running.
+
+If you prefer the explicit commands, the equivalent manual flow is:
+
+```bash
+brew install xDarkicex/openclaw-libravdb-memory/libravdbd
 brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+openclaw gateway restart
 ```
 
 This gives you:
@@ -32,22 +45,12 @@ Install the plugin package with the OpenClaw CLI:
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-If you use the OpenClaw.ai plugin UI instead of the CLI, install the same
-package and then assign the plugin id `libravdb-memory` to both the `memory`
-and `contextEngine` slots.
+On current supported OpenClaw builds, the CLI install path auto-selects the
+plugin for both required slots because the manifest declares
+`kind: ["memory", "context-engine"]`.
 
-Activate the plugin in `~/.openclaw/openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
-    }
-  }
-}
-```
+If you use the OpenClaw.ai plugin UI instead of the CLI, confirm that the
+plugin id `libravdb-memory` owns both the `memory` and `contextEngine` slots.
 
 If you run the daemon on a non-default endpoint, add a plugin config:
 
@@ -85,8 +88,7 @@ Default data path:
 Homebrew is the preferred daemon lifecycle on macOS:
 
 ```bash
-brew tap xDarkicex/openclaw-libravdb-memory
-brew install libravdbd
+brew install xDarkicex/openclaw-libravdb-memory/libravdbd
 brew services start libravdbd
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -120,13 +120,24 @@ extractive compaction. The only optional runtime network path is:
 ### Fastest Path on macOS
 
 ```bash
-brew tap xDarkicex/openclaw-libravdb-memory
-brew install libravdbd
-brew services start libravdbd
-openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+curl -fsSL https://raw.githubusercontent.com/xDarkicex/openclaw-memory-libravdb/main/install.sh | bash
 ```
 
-This is the preferred install flow for macOS users. It gives you a managed `libravdbd` service and a scanner-clean OpenClaw plugin package.
+Prerequisites: Homebrew and the `openclaw` CLI must already be installed and on
+your `PATH`.
+
+This bootstrap path installs the published Homebrew formula, starts the managed
+`libravdbd` service, installs the scanner-clean OpenClaw plugin package, and
+restarts the gateway when it is already running.
+
+Manual equivalent:
+
+```bash
+brew install xDarkicex/openclaw-libravdb-memory/libravdbd
+brew services start libravdbd
+openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+openclaw gateway restart
+```
 
 ### Plugin Package
 
@@ -171,8 +182,7 @@ openclaw memory status
 Homebrew users should normally install from the published tap:
 
 ```bash
-brew tap xDarkicex/openclaw-libravdb-memory
-brew install libravdbd
+brew install xDarkicex/openclaw-libravdb-memory/libravdbd
 brew services start libravdbd
 ```
 
@@ -220,9 +230,16 @@ Installed plugin: libravdb-memory
 
 ## Activation
 
-The plugin declares `kind: ["memory", "context-engine"]` and is intended to own both the `memory` and `contextEngine` slots together. Treat partial slot assignment as a misconfiguration.
+The plugin declares `kind: ["memory", "context-engine"]` and is intended to
+own both the `memory` and `contextEngine` slots together. Treat partial slot
+assignment as a misconfiguration.
 
-Add this to `~/.openclaw/openclaw.json`:
+On current supported OpenClaw builds,
+`openclaw plugins install @xdarkicex/openclaw-memory-libravdb` auto-selects
+both slots.
+
+If you need to repair stale config or are activating the plugin through a UI
+flow that does not assign slots automatically, set:
 
 ```json
 {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SPEC="@xdarkicex/openclaw-memory-libravdb"
+FORMULA_SPEC="xDarkicex/openclaw-libravdb-memory/libravdbd"
+FORMULA_NAME="libravdbd"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { printf "${CYAN}[install]${NC} %s\n" "$*"; }
+ok()    { printf "${GREEN}[install]${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}[install]${NC} %s\n" "$*" >&2; }
+die()   { printf "${RED}[install]${NC} %s\n" "$*" >&2; exit 1; }
+
+require_command() {
+  local cmd="$1"
+  local help="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "$cmd is required. $help"
+  fi
+}
+
+require_command brew "Install Homebrew first: https://brew.sh"
+require_command openclaw "Install the OpenClaw CLI first."
+
+info "Installing ${FORMULA_NAME} from Homebrew..."
+brew install "${FORMULA_SPEC}"
+
+info "Starting the ${FORMULA_NAME} service..."
+brew services start "${FORMULA_NAME}"
+
+info "Installing the OpenClaw plugin and selecting its slots..."
+openclaw plugins install "${PLUGIN_SPEC}"
+
+if openclaw health >/dev/null 2>&1; then
+  info "Restarting the OpenClaw gateway so the plugin loads immediately..."
+  openclaw gateway restart
+else
+  warn "OpenClaw gateway is not currently running; skipping automatic restart."
+fi
+
+info "Verifying memory status..."
+if openclaw memory status; then
+  ok "LibraVDB Memory is installed and ready."
+else
+  warn "Verification did not pass yet."
+  warn "If the gateway was not running, start or restart it, then rerun: openclaw memory status"
+fi


### PR DESCRIPTION
## Summary
- add a root `install.sh` bootstrap so users can set up LibraVDB Memory with a single `curl ... | bash` command
- update the README and install docs to use the new one-liner, the full Homebrew formula path, and `openclaw gateway restart` in the manual flow
- clarify that `openclaw plugins install @xdarkicex/openclaw-memory-libravdb` now auto-selects the dual memory/context-engine slots on supported OpenClaw builds

## Testing
- `bash -n install.sh`
- `bash -lc 'brew(){ printf \"brew %s\\n\" \"$*\"; }; openclaw(){ case \"$1 ${2-}\" in \"health \") return 0 ;; \"gateway restart\") printf \"openclaw gateway restart\\n\" ;; \"memory status\") printf \"openclaw memory status\\n\" ;; *) printf \"openclaw %s\\n\" \"$*\" ;; esac; }; export -f brew openclaw; ./install.sh'`
- `bash -lc 'brew(){ printf \"brew %s\\n\" \"$*\"; }; openclaw(){ case \"$1 ${2-}\" in \"health \") return 1 ;; \"memory status\") return 1 ;; *) printf \"openclaw %s\\n\" \"$*\" ;; esac; }; export -f brew openclaw; ./install.sh'`
- `pnpm check` *(currently fails on the existing repo issue `scripts/setup.ts(11,31): Could not find a declaration file for module './child-env.js'`; unrelated to this PR)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated bootstrap installation script for streamlined setup

* **Documentation**
  * Updated macOS installation instructions with simplified single-command bootstrap setup
  * Plugin slots now auto-configured on supported builds; manual configuration no longer required
  * Simplified Homebrew daemon installation commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->