### PR TITLE
docs: clarify install quick start and slot setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,58 @@ to the same libraVDB sidecar instead of leaving that tool inert.
 For local development, this repo can target a running daemon or a manual local
 daemon binary.
 
+## Quick Start
+
+Fastest supported install on macOS:
+
+```bash
+brew tap xDarkicex/homebrew-openclaw-libravdb-memory
+brew install libravdbd
+brew services start libravdbd
+openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+```
+
+Then make sure the plugin owns both required OpenClaw slots:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    },
+    "entries": {
+      "libravdb-memory": {
+        "enabled": true,
+        "config": {
+          "sidecarPath": "auto"
+        }
+      }
+    }
+  }
+}
+```
+
+Important install note:
+
+- Current OpenClaw installs may switch `contextEngine` automatically when the plugin is installed, but still leave `memory` on the previous provider. Set `memory` to `libravdb-memory` explicitly until the published plugin metadata is updated to auto-claim both slots during install.
+
+Verify the setup:
+
+```bash
+brew services list
+openclaw plugins list
+openclaw memory status
+```
+
+Healthy state means:
+
+- `libravdbd` is running
+- `libravdb-memory` is loaded
+- both `memory` and `contextEngine` point to `libravdb-memory`
+
+If `openclaw memory status` is unavailable because your host excludes the bundled `memory` CLI surface via `plugins.allow`, use `openclaw plugins list` plus the daemon service status instead.
+
 ## Why This Exists
 
 The stock "single memory bucket" pattern is good for simple persistence, but it
@@ -62,50 +114,6 @@ These are the core differentiators the project is built around:
 - Automatic compaction: long sessions compact behind a protected recent tail.
 - Crash-resilient IPC: the host talks to a sidecar over a stable local socket
   or loopback TCP endpoint with degraded-mode fallback.
-
-## Quick Start
-
-The supported install flow is:
-
-```bash
-brew tap xDarkicex/homebrew-openclaw-libravdb-memory
-brew install libravdbd
-brew services start libravdbd
-openclaw plugins install @xdarkicex/openclaw-memory-libravdb
-```
-
-The Homebrew formula installs the daemon plus the bundled ONNX Runtime, embedding assets, and T5 summarizer assets it needs to boot cleanly on supported platforms.
-
-Then assign the plugin to both required OpenClaw slots in
-`~/.openclaw/openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
-    },
-    "configs": {
-      "libravdb-memory": {
-        "sidecarPath": "auto"
-      }
-    }
-  }
-}
-```
-
-Verify the setup:
-
-```bash
-openclaw memory status
-```
-
-Expected healthy state:
-
-- the daemon is reachable
-- the plugin is active as the memory provider
-- the runtime can report stored counts and model readiness
 
 ## Markdown Ingestion
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,6 +36,10 @@ If you use the OpenClaw.ai plugin UI instead of the CLI, install the same
 package and then assign the plugin id `libravdb-memory` to both the `memory`
 and `contextEngine` slots.
 
+Current install note:
+
+- On current OpenClaw builds, `openclaw plugins install` may auto-switch `contextEngine` but leave `memory` unchanged. Always verify both slots after install.
+
 Activate the plugin in `~/.openclaw/openclaw.json`:
 
 ```json
@@ -44,23 +48,13 @@ Activate the plugin in `~/.openclaw/openclaw.json`:
     "slots": {
       "memory": "libravdb-memory",
       "contextEngine": "libravdb-memory"
-    }
-  }
-}
-```
-
-If you run the daemon on a non-default endpoint, add a plugin config:
-
-```json
-{
-  "plugins": {
-    "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
     },
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "auto"
+        }
       }
     }
   }
@@ -167,11 +161,20 @@ After the plugin and daemon are both in place, run:
 openclaw memory status
 ```
 
+Also verify:
+
+```bash
+brew services list
+openclaw plugins list
+```
+
 Healthy output should show that:
 
 - the daemon answered the local health check
 - the memory slot is active
 - the plugin can read stored counts and runtime settings
+
+If `openclaw memory status` is unavailable because your host excludes the bundled `memory` CLI surface via `plugins.allow`, use `openclaw plugins list` plus `brew services list` instead.
 
 If OpenClaw cannot reach the daemon, verify the endpoint first:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,7 +145,7 @@ Default endpoints:
 - macOS/Linux: `unix:$HOME/.clawdb/run/libravdb.sock`
 - Windows: `tcp:127.0.0.1:37421`
 
-If you run the daemon on a different endpoint, set `plugins.configs.libravdb-memory.sidecarPath` in `~/.openclaw/openclaw.json`.
+If you run the daemon on a different endpoint, set `plugins.entries.libravdb-memory.config.sidecarPath` in `~/.openclaw/openclaw.json`.
 
 ### Linux
 
@@ -200,9 +200,12 @@ Example plugin config:
       "memory": "libravdb-memory",
       "contextEngine": "libravdb-memory"
     },
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        }
       }
     }
   }
@@ -219,7 +222,7 @@ Installed plugin: libravdb-memory
 
 ## Activation
 
-The manifest declares `kind: "context-engine"` and the runtime registers the memory prompt and memory runtime surfaces in code. It is still intended to own both the `memory` and `contextEngine` slots together. Treat partial slot assignment as a misconfiguration.
+The published install flow currently behaves like a `context-engine` plugin for automatic slot assignment, even though the runtime also registers the memory prompt and memory runtime surfaces in code. It is still intended to own both the `memory` and `contextEngine` slots together. Treat partial slot assignment as a misconfiguration.
 
 Add this to `~/.openclaw/openclaw.json`:
 
@@ -237,11 +240,12 @@ Add this to `~/.openclaw/openclaw.json`:
 Notes:
 
 - This plugin should own both `memory` and `contextEngine`. Do not assign only one of them.
+- `openclaw plugins install` may auto-switch `contextEngine` and still leave `memory` unchanged. Verify both slots after installation.
 - The plugin id is `libravdb-memory`. The npm package name used at install time is `@xdarkicex/openclaw-memory-libravdb`.
 - On newer OpenClaw versions, the plugin also registers a memory runtime bridge so the built-in `memory_search` tool can query libraVDB through the same sidecar-backed retrieval path.
 - On newer OpenClaw versions, the plugin also listens for `before_reset` and `session_end` so it can send best-effort lifecycle hints into the sidecar.
 - Those hints are journaled internally by the sidecar and can be inspected with `openclaw memory journal` without exposing them to normal memory export or recall.
-- The journal keeps only a bounded number of newest entries. Override that cap with `plugins.configs.libravdb-memory.lifecycleJournalMaxEntries` if you need a different retention window.
+- The journal keeps only a bounded number of newest entries. Override that cap with `plugins.entries.libravdb-memory.config.lifecycleJournalMaxEntries` if you need a different retention window.
 - The plugin does not currently register `registerMemoryFlushPlan`; transcript ingest and compaction remain owned by the context-engine lifecycle and the sidecar.
 
 Without a slot entry, OpenClaw's default memory can continue to run in parallel.
@@ -252,6 +256,13 @@ Run:
 
 ```bash
 openclaw memory status
+```
+
+Also check:
+
+```bash
+brew services list
+openclaw plugins list
 ```
 
 Expected output shape:
@@ -273,6 +284,8 @@ Interpretation:
 - `Sidecar=running` means the local `libravdbd` daemon answered JSON-RPC `health`.
 - `Gate threshold=0.35` confirms the default gating scalar boundary is active.
 - `Abstractive model=not provisioned` is acceptable. The system degrades to extractive compaction.
+
+If `openclaw memory status` is unavailable because your host excludes the bundled `memory` CLI surface via `plugins.allow`, use `openclaw plugins list` plus your daemon service status instead.
 
 ## Contributor Install
 


### PR DESCRIPTION
## Summary
- move the quick-start install flow to the top of the README and make the supported macOS path more obvious
- correct the install/config examples to match the current working OpenClaw plugin config shape and verification flow
- document that current installs may auto-switch `contextEngine` but still require manually setting the `memory` slot

## Testing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides with streamlined quick-start instructions and revised macOS setup procedures
  * Restructured plugin configuration schema for improved clarity and consistent settings management across environments
  * Enhanced post-installation verification with expanded service status checks and plugin diagnostics
  * Added detailed troubleshooting guidance addressing common installation scenarios and verification edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->