### PR TITLE
fix: map budget compaction requests to legacy sidecar fields

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -20,6 +20,33 @@ export function buildContextEngineFactory(
   recallCache: RecallCache<SearchResult>,
   logger: LoggerLike = console,
 ) {
+  function buildCompactSessionRequest(args: {
+    sessionId: string;
+    force?: boolean;
+    targetSize?: number;
+    tokenBudget?: number;
+  }): Partial<CompactSessionRequest> {
+    // OpenClaw core now requests budget-style compaction using tokenBudget,
+    // but the current LibraVDB compact_session wire contract still expects
+    // targetSize. Use tokenBudget as the compatibility target so overflow and
+    // timeout retries still compact toward the host's requested prompt budget.
+    const targetSize = args.targetSize ?? args.tokenBudget;
+    return {
+      sessionId: args.sessionId,
+      force: args.force,
+      ...(typeof targetSize === "number" ? { targetSize } : {}),
+      ...(typeof cfg.continuityMinTurns === "number"
+        ? { continuityMinTurns: cfg.continuityMinTurns }
+        : {}),
+      ...(typeof cfg.continuityTailBudgetTokens === "number"
+        ? { continuityTailBudgetTokens: cfg.continuityTailBudgetTokens }
+        : {}),
+      ...(typeof cfg.continuityPriorContextTokens === "number"
+        ? { continuityPriorContextTokens: cfg.continuityPriorContextTokens }
+        : {}),
+    };
+  }
+
   return {
     info: { id: "libravdb-memory", name: "LibraVDB Memory", ownsCompaction: true },
     ownsCompaction: true,
@@ -122,17 +149,19 @@ export function buildContextEngineFactory(
       });
       return resp;
     },
-    async compact(args: { sessionId: string; force?: boolean; targetSize?: number }) {
+    async compact(args: {
+      sessionId: string;
+      force?: boolean;
+      targetSize?: number;
+      tokenBudget?: number;
+    }) {
+      const request = buildCompactSessionRequest(args);
       const kernel = runtime.getKernel();
       if (kernel) {
-        return await kernel.compactSession({
-          sessionId: args.sessionId,
-          force: args.force,
-          targetSize: args.targetSize,
-        });
+        return await kernel.compactSession(request);
       }
       const rpc = await runtime.getRpc();
-      return await rpc.call("compact_session", args);
+      return await rpc.call("compact_session", request);
     },
     async afterTurn(args: {
       sessionId: string;
@@ -141,6 +170,8 @@ export function buildContextEngineFactory(
       messages: Array<{ role: string; content: string; id?: string }>;
       prePromptMessageCount?: number;
       isHeartbeat?: boolean;
+      tokenBudget?: number;
+      runtimeContext?: Record<string, unknown>;
     }) {
       const kernel = runtime.getKernel();
       if (kernel) {

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -164,17 +164,22 @@ test("assemble passes correct configuration mapping and returns expected payload
   assert.equal(assembled.debug?.recoveryTriggerFired, true);
 });
 
-test("compact forwards target size and force flags", async () => {
+test("compact maps host budget requests onto legacy sidecar fields", async () => {
   const rpc = new StaticContractRpc();
   const recallCache = createRecallCache<SearchResult>();
-  const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    continuityMinTurns: 4,
+    continuityTailBudgetTokens: 640,
+    continuityPriorContextTokens: 320,
+  };
 
   const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
 
   await context.compact({
     sessionId: "test-session",
     force: true,
-    targetSize: 2048,
+    tokenBudget: 2048,
   });
 
   const params = rpc.getLastCall("compact_session");
@@ -182,6 +187,9 @@ test("compact forwards target size and force flags", async () => {
   assert.equal(params.sessionId, "test-session");
   assert.equal(params.force, true);
   assert.equal(params.targetSize, 2048);
+  assert.equal(params.continuityMinTurns, 4);
+  assert.equal(params.continuityTailBudgetTokens, 640);
+  assert.equal(params.continuityPriorContextTokens, 320);
 });
 
 test("afterTurn forwards message arrays and pre-prompt counts correctly", async () => {


### PR DESCRIPTION
## Summary
- map OpenClaw's newer budget-style `contextEngine.compact()` calls onto LibraVDB's older `compact_session` wire contract by deriving `targetSize` from `tokenBudget`
- forward continuity compaction settings that the sidecar already understands during explicit compaction requests
- add focused host-flow coverage for the compatibility mapping so overflow/timeout retry requests keep working against the current sidecar API

## Testing
- `./node_modules/.bin/tsc -p tsconfig.tests.json`
- `./node_modules/.bin/tsc -p tsconfig.build.json --pretty false`
- `node --test .ts-build/test/integration/host-flow.test.js`
- live runtime smoke test after swapping the built `dist/context-engine.js` into the installed extension and restarting the gateway: a patched throwaway session stayed healthy through oversized follow-up probes and continued normal tool/assistant cycles instead of immediately reproducing the old `400 Your input exceeds the context window of this model` loop

## Notes
- `pnpm check` is currently blocked by an unrelated existing upstream type issue in `scripts/setup.ts` (`child-env.js` declaration missing), so I used the narrower compile/test path above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Extended session compaction API to accept optional token budget parameter.
  - Extended session state update API to support optional token budget and runtime context parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->