### PR TITLE
fix: preserve empty assemble response messages

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -67,13 +67,22 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 }
 ```
 
+When `sidecarPath` is set to `"auto"`, the plugin resolves endpoints in this order on macOS/Linux:
+
+1. `LIBRAVDB_RPC_ENDPOINT` if it is set to a valid daemon endpoint
+2. `$HOME/.clawdb/run/libravdb.sock` if it exists
+3. `/opt/homebrew/var/clawdb/run/libravdb.sock` if it exists
+4. `/usr/local/var/clawdb/run/libravdb.sock` if it exists
+5. fallback to `$HOME/.clawdb/run/libravdb.sock`
+
 ## Sidecar Daemon Install
 
 The daemon owns the local database, embeddings, and JSON-RPC endpoint.
 
 Default endpoints:
 
-- macOS/Linux: `unix:$HOME/.clawdb/run/libravdb.sock`
+- Homebrew on macOS: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
+- macOS/Linux user-local installs: `unix:$HOME/.clawdb/run/libravdb.sock`
 - Windows: `tcp:127.0.0.1:37421`
 
 Default data path:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -142,7 +142,8 @@ Install and start `libravdbd` separately for the same user account that runs Ope
 
 Default endpoints:
 
-- macOS/Linux: `unix:$HOME/.clawdb/run/libravdb.sock`
+- Homebrew on macOS: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
+- macOS/Linux user-local installs: `unix:$HOME/.clawdb/run/libravdb.sock`
 - Windows: `tcp:127.0.0.1:37421`
 
 If you run the daemon on a different endpoint, set `plugins.configs.libravdb-memory.sidecarPath` in `~/.openclaw/openclaw.json`.
@@ -174,6 +175,18 @@ Homebrew users should normally install from the published tap:
 brew tap xDarkicex/homebrew-openclaw-libravdb-memory
 brew install libravdbd
 brew services start libravdbd
+```
+
+With `sidecarPath: "auto"`, Homebrew installs on Apple Silicon should resolve to:
+
+```text
+unix:/opt/homebrew/var/clawdb/run/libravdb.sock
+```
+
+User-local installs still default to:
+
+```text
+unix:$HOME/.clawdb/run/libravdb.sock
 ```
 
 The daemon release pipeline generates a publish-ready `libravdbd.rb` formula asset for release assets named:

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -33,6 +33,15 @@ type OpenClawCompatibleAssembleResult = {
   debug?: AssembleContextInternalResponse["debug"];
 };
 
+function describeUnexpectedContent(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}
+
 function stringifyKernelBlock(block: unknown): string {
   if (!block || typeof block !== "object") {
     return "";
@@ -61,6 +70,10 @@ function stringifyKernelBlock(block: unknown): string {
     case "image":
       return "[image omitted]";
     default:
+      console.warn("[libravdb] unsupported kernel content block", {
+        type: record.type,
+        block: describeUnexpectedContent(record),
+      });
       return typeof record.text === "string" ? record.text : "";
   }
 }
@@ -70,6 +83,10 @@ function normalizeKernelContent(content: unknown): string {
     return content;
   }
   if (!Array.isArray(content)) {
+    console.warn("[libravdb] unexpected kernel content shape", {
+      kind: typeof content,
+      value: describeUnexpectedContent(content),
+    });
     return "";
   }
   return content.map(stringifyKernelBlock).filter((part) => part.length > 0).join("\n");
@@ -101,6 +118,10 @@ export function normalizeAssembleResult(result: {
 }): OpenClawCompatibleAssembleResult {
   const messages = Array.isArray(result.messages)
     ? result.messages.map((message) => ({
+        // OpenClaw replay only expects conversational turns here, so assemble output
+        // is collapsed to user/assistant even though normalizeKernelMessage preserves
+        // richer inbound roles. If kernel.assembleContext starts emitting other roles,
+        // this coercion point is where that contract needs to be revisited.
         role: message.role === "user" ? "user" : "assistant",
         content: normalizeKernelContent(message.content),
         ...(typeof message.id === "string" ? { id: message.id } : {}),
@@ -112,7 +133,7 @@ export function normalizeAssembleResult(result: {
       typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
     systemPromptAddition:
       typeof result.systemPromptAddition === "string" ? result.systemPromptAddition : "",
-    ...(result.debug !== undefined ? { debug: result.debug } : {}),
+    ...(result.debug != null ? { debug: result.debug } : {}),
   };
 }
 

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -22,7 +22,7 @@ type KernelCompatibleMessage = {
 
 type OpenClawCompatibleMessage = {
   role: string;
-  content: Array<{ type: "text"; text: string }>;
+  content: string;
   id?: string;
 };
 
@@ -102,7 +102,7 @@ export function normalizeAssembleResult(result: {
   const messages = Array.isArray(result.messages)
     ? result.messages.map((message) => ({
         role: message.role === "user" ? "user" : "assistant",
-        content: [{ type: "text" as const, text: normalizeKernelContent(message.content) }],
+        content: normalizeKernelContent(message.content),
         ...(typeof message.id === "string" ? { id: message.id } : {}),
       }))
     : [];

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -14,6 +14,108 @@ import {
 } from "./generated/libravdb/ipc/v1/rpc_pb.js";
 import { resolveDurableNamespace } from "./durable-namespace.js";
 
+type KernelCompatibleMessage = {
+  role: string;
+  content: string;
+  id?: string;
+};
+
+type OpenClawCompatibleMessage = {
+  role: string;
+  content: Array<{ type: "text"; text: string }>;
+  id?: string;
+};
+
+type OpenClawCompatibleAssembleResult = {
+  messages: OpenClawCompatibleMessage[];
+  estimatedTokens: number;
+  systemPromptAddition: string;
+  debug?: AssembleContextInternalResponse["debug"];
+};
+
+function stringifyKernelBlock(block: unknown): string {
+  if (!block || typeof block !== "object") {
+    return "";
+  }
+  const record = block as Record<string, unknown>;
+  switch (record.type) {
+    case "text":
+      return typeof record.text === "string" ? record.text : "";
+    case "thinking":
+      return typeof record.thinking === "string" ? record.thinking : "";
+    case "toolCall": {
+      const name = typeof record.name === "string" ? record.name : "tool";
+      const args = record.arguments;
+      let renderedArgs = "";
+      if (typeof args === "string") {
+        renderedArgs = args;
+      } else if (args !== undefined) {
+        try {
+          renderedArgs = JSON.stringify(args);
+        } catch {
+          renderedArgs = String(args);
+        }
+      }
+      return renderedArgs ? `[tool:${name}] ${renderedArgs}` : `[tool:${name}]`;
+    }
+    case "image":
+      return "[image omitted]";
+    default:
+      return typeof record.text === "string" ? record.text : "";
+  }
+}
+
+function normalizeKernelContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content.map(stringifyKernelBlock).filter((part) => part.length > 0).join("\n");
+}
+
+export function normalizeKernelMessage(message: {
+  role: string;
+  content: unknown;
+  id?: string;
+}): KernelCompatibleMessage {
+  return {
+    role: message.role,
+    content: normalizeKernelContent(message.content),
+    ...(typeof message.id === "string" ? { id: message.id } : {}),
+  };
+}
+
+export function normalizeKernelMessages(
+  messages: Array<{ role: string; content: unknown; id?: string }>,
+): KernelCompatibleMessage[] {
+  return messages.map((message) => normalizeKernelMessage(message));
+}
+
+export function normalizeAssembleResult(result: {
+  messages?: Array<{ role: string; content?: unknown; id?: string }>;
+  estimatedTokens?: number;
+  systemPromptAddition?: string;
+  debug?: AssembleContextInternalResponse["debug"];
+}): OpenClawCompatibleAssembleResult {
+  const messages = Array.isArray(result.messages)
+    ? result.messages.map((message) => ({
+        role: message.role === "user" ? "user" : "assistant",
+        content: [{ type: "text" as const, text: normalizeKernelContent(message.content) }],
+        ...(typeof message.id === "string" ? { id: message.id } : {}),
+      }))
+    : [];
+  return {
+    messages,
+    estimatedTokens:
+      typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
+    systemPromptAddition:
+      typeof result.systemPromptAddition === "string" ? result.systemPromptAddition : "",
+    ...(result.debug !== undefined ? { debug: result.debug } : {}),
+  };
+}
+
 export function buildContextEngineFactory(
   runtime: PluginRuntime,
   cfg: PluginConfig,
@@ -43,40 +145,45 @@ export function buildContextEngineFactory(
       const rpc = await runtime.getRpc();
       return await rpc.call("bootstrap_session_kernel", args);
     },
-    async ingest(args: { sessionId: string; sessionKey?: string; userId?: string; message: { role: string; content: string; id?: string }; isHeartbeat?: boolean }) {
+    async ingest(args: { sessionId: string; sessionKey?: string; userId?: string; message: { role: string; content: unknown; id?: string }; isHeartbeat?: boolean }) {
+      const message = normalizeKernelMessage(args.message);
       const kernel = runtime.getKernel();
       if (kernel) {
         return await kernel.ingestMessage({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           userId: args.userId,
-          message: args.message,
+          message,
           isHeartbeat: args.isHeartbeat,
         });
       }
       const rpc = await runtime.getRpc();
-      return await rpc.call("ingest_message_kernel", args);
+      return await rpc.call("ingest_message_kernel", {
+        ...args,
+        message,
+      });
     },
     async assemble(args: {
       sessionId: string;
       sessionKey?: string;
       userId?: string;
-      messages: Array<{ role: string; content: string; id?: string }>;
+      messages: Array<{ role: string; content: unknown; id?: string }>;
       tokenBudget: number;
       prompt?: string;
-    }): Promise<AssembleContextInternalResponse> {
+    }): Promise<OpenClawCompatibleAssembleResult> {
+      const messages = normalizeKernelMessages(args.messages);
       const kernel = runtime.getKernel();
       if (kernel) {
-        return await kernel.assembleContext({
+        return normalizeAssembleResult(await kernel.assembleContext({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           userId: args.userId,
           queryText: args.prompt ?? "",
-          visibleMessages: args.messages,
+          visibleMessages: messages,
           tokenBudget: args.tokenBudget,
           config: {},
           emitDebug: true
-        });
+        }));
       }
 
       const rpc = await runtime.getRpc();
@@ -84,7 +191,7 @@ export function buildContextEngineFactory(
         sessionId: args.sessionId,
         sessionKey: args.sessionKey,
         userId: args.userId,
-        messages: args.messages,
+        messages,
         tokenBudget: args.tokenBudget,
         prompt: args.prompt,
         emitDebug: true,
@@ -120,7 +227,7 @@ export function buildContextEngineFactory(
           ingestionGateThreshold: cfg.ingestionGateThreshold,
         },
       });
-      return resp;
+      return normalizeAssembleResult(resp);
     },
     async compact(args: { sessionId: string; force?: boolean; targetSize?: number }) {
       const kernel = runtime.getKernel();
@@ -138,23 +245,27 @@ export function buildContextEngineFactory(
       sessionId: string;
       sessionKey?: string;
       userId?: string;
-      messages: Array<{ role: string; content: string; id?: string }>;
+      messages: Array<{ role: string; content: unknown; id?: string }>;
       prePromptMessageCount?: number;
       isHeartbeat?: boolean;
     }) {
+      const messages = normalizeKernelMessages(args.messages);
       const kernel = runtime.getKernel();
       if (kernel) {
         return await kernel.afterTurn({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           userId: args.userId,
-          messages: args.messages,
+          messages,
           prePromptMessageCount: args.prePromptMessageCount,
           isHeartbeat: args.isHeartbeat,
         });
       }
       const rpc = await runtime.getRpc();
-      return await rpc.call("after_turn_kernel", args);
+      return await rpc.call("after_turn_kernel", {
+        ...args,
+        messages,
+      });
     }
   };
 }

--- a/src/rpc-protobuf-codecs.ts
+++ b/src/rpc-protobuf-codecs.ts
@@ -71,6 +71,19 @@ function normalizeSearchTextResponse(bytes: Uint8Array): SearchTextResponse {
   return response;
 }
 
+function normalizeAssembleContextInternalResponse(
+  bytes: Uint8Array,
+): AssembleContextInternalResponse {
+  const response = decodeProtobufResult<AssembleContextInternalResponse>(
+    AssembleContextInternalResponse,
+    bytes,
+  );
+  if (!Array.isArray(response.messages)) {
+    response.messages = [];
+  }
+  return response;
+}
+
 function normalizeExcludeByCollection(
   value: Record<string, unknown> | undefined,
 ): Record<string, StringList> {
@@ -248,7 +261,7 @@ export const rpcProtobufCodecs = {
     AssembleContextInternalResponse
   >(
     (params) => encodeMessage(AssembleContextInternalRequest, params),
-    (bytes) => decodeProtobufResult<AssembleContextInternalResponse>(AssembleContextInternalResponse, bytes),
+    normalizeAssembleContextInternalResponse,
   ),
   compact_session: codec<CompactSessionRequest, CompactSessionResponse>(
     (params) => encodeMessage(CompactSessionRequest, params),

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -374,7 +374,11 @@ export function daemonProvisioningHint(): string {
   return "If you installed the npm package, install and start libravdbd separately; the package does not provision the daemon binary, ONNX Runtime, or model assets.";
 }
 
-export function defaultEndpoint(platform = process.platform, homeDir = os.homedir()): string {
+export function defaultEndpoint(
+  platform = process.platform,
+  homeDir = os.homedir(),
+  pathExists: (path: string) => boolean = fs.existsSync,
+): string {
   // Honour the daemon's own env var first (set by Homebrew LaunchAgent / systemd unit).
   const envEndpoint = process.env.LIBRAVDB_RPC_ENDPOINT?.trim();
   if (envEndpoint && isConfiguredEndpoint(envEndpoint)) {
@@ -398,7 +402,7 @@ export function defaultEndpoint(platform = process.platform, homeDir = os.homedi
   for (const dir of candidateDirs) {
     const sockPath = path.join(dir, sockName);
     try {
-      if (fs.existsSync(sockPath)) {
+      if (pathExists(sockPath)) {
         return `unix:${sockPath}`;
       }
     } catch {

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -215,7 +215,7 @@ test("normalizeKernelMessage prevents object-string coercion in ingest and after
   assert.equal(afterTurnRoundtrip.messages[0]?.content, 'Done\n[tool:memory_search] {"q":"needle"}');
 });
 
-test("normalizeAssembleResult converts kernel string messages into OpenClaw text blocks", () => {
+test("normalizeAssembleResult preserves kernel string messages for existing callers", () => {
   const normalized = normalizeAssembleResult({
     messages: [{ role: "assistant", content: "OK", id: "m1" }],
     estimatedTokens: 7,
@@ -225,7 +225,7 @@ test("normalizeAssembleResult converts kernel string messages into OpenClaw text
   assert.deepEqual(normalized.messages, [
     {
       role: "assistant",
-      content: [{ type: "text", text: "OK" }],
+      content: "OK",
       id: "m1",
     },
   ]);
@@ -233,7 +233,7 @@ test("normalizeAssembleResult converts kernel string messages into OpenClaw text
   assert.equal(normalized.systemPromptAddition, "sys");
 });
 
-test("normalizeAssembleResult coerces non-replay-safe roles to assistant text messages", () => {
+test("normalizeAssembleResult coerces non-replay-safe roles to assistant string messages", () => {
   const normalized = normalizeAssembleResult({
     messages: [{ role: "toolResult", content: "tool output", id: "m2" }],
   });
@@ -241,7 +241,7 @@ test("normalizeAssembleResult coerces non-replay-safe roles to assistant text me
   assert.deepEqual(normalized.messages, [
     {
       role: "assistant",
-      content: [{ type: "text", text: "tool output" }],
+      content: "tool output",
       id: "m2",
     },
   ]);

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -152,7 +152,10 @@ test("RpcClient preserves empty result arrays and debug payloads", async () => {
   socket.emitData(frameServerPayload(response.toBinary()));
 
   const result = await pending;
-  assert.deepEqual(result.messages ?? [], []);
+  assert.ok(Array.isArray(result.messages), "messages should be preserved as an array");
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.estimatedTokens, 12);
+  assert.equal(result.systemPromptAddition, "sys");
   assert.ok(result.debug !== undefined, "debug payload should be preserved");
 });
 

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -3,10 +3,18 @@ import test from "node:test";
 
 import {
   AssembleContextInternalResponse,
+  AssembleContextInternalRequest,
+  AfterTurnKernelRequest,
+  IngestMessageKernelRequest,
   RpcRequest,
   RpcResponse,
   SearchTextResponse,
 } from "../../src/generated/libravdb/ipc/v1/rpc_pb.js";
+import {
+  normalizeAssembleResult,
+  normalizeKernelMessage,
+  normalizeKernelMessages,
+} from "../../src/context-engine.js";
 import { RpcClient } from "../../src/rpc.js";
 import type { SidecarSocket } from "../../src/types.js";
 
@@ -157,6 +165,86 @@ test("RpcClient preserves empty result arrays and debug payloads", async () => {
   assert.equal(result.estimatedTokens, 12);
   assert.equal(result.systemPromptAddition, "sys");
   assert.ok(result.debug !== undefined, "debug payload should be preserved");
+});
+
+test("normalizeKernelMessages flattens rich message blocks before assemble encoding", () => {
+  const richMessages = normalizeKernelMessages([
+    {
+      role: "user",
+      content: [{ type: "text", text: "Reply with exactly: OK" }],
+      id: "m1",
+    },
+  ] as Array<{ role: string; content: unknown; id?: string }>);
+
+  const roundtrip = AssembleContextInternalRequest.fromBinary(
+    new AssembleContextInternalRequest({
+      sessionId: "s1",
+      messages: richMessages,
+      tokenBudget: 100,
+      prompt: "ignored",
+    }).toBinary(),
+  );
+
+  assert.equal(roundtrip.messages[0]?.content, "Reply with exactly: OK");
+});
+
+test("normalizeKernelMessage prevents object-string coercion in ingest and after-turn requests", () => {
+  const richMessage = normalizeKernelMessage({
+    role: "assistant",
+    content: [
+      { type: "text", text: "Done" },
+      { type: "toolCall", name: "memory_search", arguments: { q: "needle" } },
+    ],
+    id: "m2",
+  });
+
+  const ingestRoundtrip = IngestMessageKernelRequest.fromBinary(
+    new IngestMessageKernelRequest({
+      sessionId: "s1",
+      message: richMessage,
+    }).toBinary(),
+  );
+  assert.equal(ingestRoundtrip.message?.content, 'Done\n[tool:memory_search] {"q":"needle"}');
+
+  const afterTurnRoundtrip = AfterTurnKernelRequest.fromBinary(
+    new AfterTurnKernelRequest({
+      sessionId: "s1",
+      messages: [richMessage],
+    }).toBinary(),
+  );
+  assert.equal(afterTurnRoundtrip.messages[0]?.content, 'Done\n[tool:memory_search] {"q":"needle"}');
+});
+
+test("normalizeAssembleResult converts kernel string messages into OpenClaw text blocks", () => {
+  const normalized = normalizeAssembleResult({
+    messages: [{ role: "assistant", content: "OK", id: "m1" }],
+    estimatedTokens: 7,
+    systemPromptAddition: "sys",
+  });
+
+  assert.deepEqual(normalized.messages, [
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "OK" }],
+      id: "m1",
+    },
+  ]);
+  assert.equal(normalized.estimatedTokens, 7);
+  assert.equal(normalized.systemPromptAddition, "sys");
+});
+
+test("normalizeAssembleResult coerces non-replay-safe roles to assistant text messages", () => {
+  const normalized = normalizeAssembleResult({
+    messages: [{ role: "toolResult", content: "tool output", id: "m2" }],
+  });
+
+  assert.deepEqual(normalized.messages, [
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "tool output" }],
+      id: "m2",
+    },
+  ]);
 });
 
 test("RpcClient rejects on timeout", async () => {

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -233,6 +233,27 @@ test("normalizeAssembleResult preserves kernel string messages for existing call
   assert.equal(normalized.systemPromptAddition, "sys");
 });
 
+test("normalizeAssembleResult stringifies rich content blocks consistently", () => {
+  const normalized = normalizeAssembleResult({
+    messages: [{
+      role: "assistant",
+      content: [
+        { type: "text", text: "Done" },
+        { type: "toolCall", name: "memory_search", arguments: { q: "needle" } },
+      ],
+      id: "m-rich",
+    }],
+  });
+
+  assert.deepEqual(normalized.messages, [
+    {
+      role: "assistant",
+      content: 'Done\n[tool:memory_search] {"q":"needle"}',
+      id: "m-rich",
+    },
+  ]);
+});
+
 test("normalizeAssembleResult coerces non-replay-safe roles to assistant string messages", () => {
   const normalized = normalizeAssembleResult({
     messages: [{ role: "toolResult", content: "tool output", id: "m2" }],
@@ -245,6 +266,15 @@ test("normalizeAssembleResult coerces non-replay-safe roles to assistant string 
       id: "m2",
     },
   ]);
+});
+
+test("normalizeAssembleResult omits null debug payloads", () => {
+  const normalized = normalizeAssembleResult({
+    messages: [],
+    debug: null as any,
+  });
+
+  assert.equal("debug" in normalized, false);
 });
 
 test("RpcClient rejects on timeout", async () => {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -52,6 +52,16 @@ test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", (
   }
 });
 
+test("defaultEndpoint prefers the Homebrew socket when the user-local socket is absent", () => {
+  const endpoint = defaultEndpoint(
+    "darwin",
+    "/Users/demo",
+    (candidate) => candidate === "/opt/homebrew/var/clawdb/run/libravdb.sock",
+  );
+
+  assert.equal(endpoint, "unix:/opt/homebrew/var/clawdb/run/libravdb.sock");
+});
+
 test("computeBackoffMs applies capped exponential backoff", () => {
   assert.equal(computeBackoffMs(0), 500);
   assert.equal(computeBackoffMs(1), 1000);


### PR DESCRIPTION
## Summary
- normalize `assemble_context_internal` protobuf responses so `messages` is always preserved as an array, even when the daemon returns an empty repeated field
- strengthen the RPC unit test so it fails if empty assemble responses drop `messages`, `estimatedTokens`, or `systemPromptAddition`
- prevent OpenClaw from hitting `Cannot read properties of undefined (reading 'slice')` when the LibraVDB context engine returns an otherwise-valid empty assemble result

## Testing
- `pnpm build`
- `pnpm exec tsc -p tsconfig.tests.json && mkdir -p .ts-build/src/generated && cp -rf src/generated/. .ts-build/src/generated/ && node --test .ts-build/test/unit/rpc.test.js`

## Local validation
- packed and installed the patched plugin into the live OpenClaw runtime
- restarted the gateway and reran a fresh `sessions.send` verification session
- confirmed the previous `context engine assemble failed ... Cannot read properties of undefined (reading 'slice')` warning no longer appeared in `~/.openclaw/logs/gateway.err.log`
- note: the separate `[object Object]` prompt-interpretation issue still reproduces and is not addressed by this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now accept richer content (not just plain text) and are normalized for consistent display and exchange.
  * Roles are normalized so non-user roles are treated as assistant for consistent playback.

* **Bug Fixes**
  * Response messages are always returned as arrays; empty arrays are provided by default when no messages exist.
  * Empty result arrays and debug payloads are preserved reliably.

* **Tests**
  * Added tests validating message normalization, roundtrip safety, and role/content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->