### PR TITLE
fix: wait for sidecar reconnect before rpc send

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -37,36 +37,66 @@ export class RpcClient {
     return await new Promise<T>((resolve, reject) => {
       const id = ++this.seq;
       const timeoutMs = callOptions.timeoutMs ?? this.options.timeoutMs;
+      const deadline = Date.now() + timeoutMs;
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`RPC timeout: ${method} (${timeoutMs}ms)`));
       }, timeoutMs);
 
       this.pending.set(id, { resolve, reject, timer, decodeResult: codec.decodeResult });
-      const envelope = new (RpcRequest as any)({
-        id,
-        method,
-        params: codec.encodeParams(params),
-      });
-      const payload = Buffer.from(envelope.toBinary());
-      const header = Buffer.alloc(4);
-      header.writeUInt32BE(payload.byteLength, 0);
 
-      const chunks: Buffer[] = [];
-      if (!this.sentMagic) {
-        chunks.push(Buffer.from([0x02]));
-        this.sentMagic = true;
-      }
-      chunks.push(header, payload);
-      const frame = Buffer.concat(chunks);
+      const buildFrame = () => {
+        const envelope = new (RpcRequest as any)({
+          id,
+          method,
+          params: codec.encodeParams(params),
+        });
+        const payload = Buffer.from(envelope.toBinary());
+        const header = Buffer.alloc(4);
+        header.writeUInt32BE(payload.byteLength, 0);
+        const chunks: Buffer[] = [];
+        const includesMagic = !this.sentMagic;
+        if (includesMagic) {
+          chunks.push(Buffer.from([0x02]));
+        }
+        chunks.push(header, payload);
+        return { frame: Buffer.concat(chunks), includesMagic };
+      };
+
       const send = (allowReconnectRetry: boolean) => {
+        if (!this.pending.has(id)) {
+          return;
+        }
+        const { frame, includesMagic } = buildFrame();
         try {
           this.socket.write(frame);
+          if (includesMagic) {
+            this.sentMagic = true;
+          }
         } catch (error) {
           if (allowReconnectRetry && isReconnectableSocketGap(error)) {
-            void this.waitForReconnect(timeoutMs)
-              .then(() => send(false))
+            this.sentMagic = false;
+            const remainingMs = Math.max(0, deadline - Date.now());
+            if (remainingMs <= 0) {
+              if (!this.pending.has(id)) {
+                return;
+              }
+              clearTimeout(timer);
+              this.pending.delete(id);
+              reject(new Error(`RPC timeout: ${method} (${timeoutMs}ms)`));
+              return;
+            }
+            void this.waitForReconnect(remainingMs)
+              .then(() => {
+                if (!this.pending.has(id)) {
+                  return;
+                }
+                send(false);
+              })
               .catch((reconnectError) => {
+                if (!this.pending.has(id)) {
+                  return;
+                }
                 clearTimeout(timer);
                 this.pending.delete(id);
                 reject(
@@ -90,25 +120,30 @@ export class RpcClient {
   private async waitForReconnect(timeoutMs: number): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       let settled = false;
+      const onConnect = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.socket.off("error", onError);
+        resolve();
+      };
+      const onError = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.socket.off("connect", onConnect);
+        reject(error);
+      };
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
+        this.socket.off("connect", onConnect);
+        this.socket.off("error", onError);
         reject(new Error(`Sidecar reconnect timed out (${timeoutMs}ms)`));
       }, timeoutMs);
 
-      this.socket.once("connect", () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve();
-      });
-
-      this.socket.once("error", (error: Error) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        reject(error);
-      });
+      this.socket.once("connect", onConnect);
+      this.socket.once("error", onError);
     });
   }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -43,29 +43,72 @@ export class RpcClient {
       }, timeoutMs);
 
       this.pending.set(id, { resolve, reject, timer, decodeResult: codec.decodeResult });
-      try {
-        const envelope = new (RpcRequest as any)({
-          id,
-          method,
-          params: codec.encodeParams(params),
-        });
-        const payload = Buffer.from(envelope.toBinary());
-        const header = Buffer.alloc(4);
-        header.writeUInt32BE(payload.byteLength, 0);
+      const envelope = new (RpcRequest as any)({
+        id,
+        method,
+        params: codec.encodeParams(params),
+      });
+      const payload = Buffer.from(envelope.toBinary());
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(payload.byteLength, 0);
 
-        const chunks: Buffer[] = [];
-        if (!this.sentMagic) {
-          chunks.push(Buffer.from([0x02]));
-          this.sentMagic = true;
-        }
-        chunks.push(header, payload);
-
-        this.socket.write(Buffer.concat(chunks));
-      } catch (error) {
-        clearTimeout(timer);
-        this.pending.delete(id);
-        reject(error instanceof Error ? error : new Error(String(error)));
+      const chunks: Buffer[] = [];
+      if (!this.sentMagic) {
+        chunks.push(Buffer.from([0x02]));
+        this.sentMagic = true;
       }
+      chunks.push(header, payload);
+      const frame = Buffer.concat(chunks);
+      const send = (allowReconnectRetry: boolean) => {
+        try {
+          this.socket.write(frame);
+        } catch (error) {
+          if (allowReconnectRetry && isReconnectableSocketGap(error)) {
+            void this.waitForReconnect(timeoutMs)
+              .then(() => send(false))
+              .catch((reconnectError) => {
+                clearTimeout(timer);
+                this.pending.delete(id);
+                reject(
+                  reconnectError instanceof Error
+                    ? reconnectError
+                    : new Error(String(reconnectError)),
+                );
+              });
+            return;
+          }
+          clearTimeout(timer);
+          this.pending.delete(id);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+
+      send(true);
+    });
+  }
+
+  private async waitForReconnect(timeoutMs: number): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(`Sidecar reconnect timed out (${timeoutMs}ms)`));
+      }, timeoutMs);
+
+      this.socket.once("connect", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      });
+
+      this.socket.once("error", (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      });
     });
   }
 
@@ -145,4 +188,8 @@ export class RpcClient {
       pending.reject(error);
     }
   }
+}
+
+function isReconnectableSocketGap(error: unknown): boolean {
+  return error instanceof Error && /Sidecar socket unavailable/i.test(error.message);
 }

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -57,6 +57,14 @@ class PlaceholderSocket implements SidecarSocket {
     this.errorOnce.add(handler as ErrorHandler);
   }
 
+  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+    if (event === "connect") {
+      this.connectOnce.delete(handler as CloseHandler);
+      return;
+    }
+    this.errorOnce.delete(handler as ErrorHandler);
+  }
+
   write(chunk: Buffer | string): void {
     try {
       const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8");
@@ -197,6 +205,14 @@ class SupervisorSocket implements SidecarSocket {
       return;
     }
     this.errorOnce.add(handler as ErrorHandler);
+  }
+
+  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+    if (event === "connect") {
+      this.connectOnce.delete(handler as CloseHandler);
+      return;
+    }
+    this.errorOnce.delete(handler as ErrorHandler);
   }
 
   write(chunk: Buffer | string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface SidecarSocket {
   on(event: "error", handler: (error: Error) => void): void;
   once(event: "connect", handler: () => void): void;
   once(event: "error", handler: (error: Error) => void): void;
+  off(event: "connect", handler: () => void): void;
+  off(event: "error", handler: (error: Error) => void): void;
   write(chunk: Buffer | string): void;
   destroy(err?: Error): void;
 }
@@ -169,4 +171,3 @@ export interface RecallCache<T = unknown> {
   take(key: Pick<RecallCacheEntry<T>, "userId" | "queryText">): RecallCacheEntry<T> | undefined;
   clearUser(userId: string): void;
 }
-

--- a/test/integration/sidecar-lifecycle.test.ts
+++ b/test/integration/sidecar-lifecycle.test.ts
@@ -53,6 +53,14 @@ class ControlledSocket implements SidecarSocket {
     this.errorOnce.add(handler as ErrorHandler);
   }
 
+  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+    if (event === "connect") {
+      this.connectOnce.delete(handler as CloseHandler);
+      return;
+    }
+    this.errorOnce.delete(handler as ErrorHandler);
+  }
+
   write(chunk: Buffer | string): void {
     if (!this.autoRespond) {
       return;
@@ -223,6 +231,7 @@ test("missing daemon errors point users at libravdbd instead of spawn internals"
         queueMicrotask(() => (handler as (error: Error) => void)(Object.assign(new Error("missing"), { code: "ENOENT" })));
       }
     },
+    off() {},
     write() {},
     destroy() {},
   });
@@ -249,6 +258,7 @@ test("startup connect retries ENOENT until the daemon becomes available", async 
             queueMicrotask(() => (handler as (error: Error) => void)(Object.assign(new Error("missing"), { code: "ENOENT" })));
           }
         },
+        off() {},
         write() {},
         destroy() {},
       };

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -50,6 +50,16 @@ class FakeSocket implements SidecarSocket {
     }
   }
 
+  off(event: "connect" | "error", handler: (() => void) | ((error: Error) => void)): void {
+    if (event === "connect") {
+      const idx = this.connectOnce.indexOf(handler as () => void);
+      if (idx >= 0) this.connectOnce.splice(idx, 1);
+      return;
+    }
+    const idx = this.errorOnce.indexOf(handler as (error: Error) => void);
+    if (idx >= 0) this.errorOnce.splice(idx, 1);
+  }
+
   write(chunk: Buffer | string): void {
     this.writes.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
@@ -96,6 +106,16 @@ class ReconnectingSocket extends FakeSocket {
     this.reconnectErrorHandlers.push(handler as (error: Error) => void);
   }
 
+  override off(event: "connect" | "error", handler: (() => void) | ((error: Error) => void)): void {
+    if (event === "connect") {
+      const index = this.reconnectHandlers.indexOf(handler as () => void);
+      if (index >= 0) this.reconnectHandlers.splice(index, 1);
+      return;
+    }
+    const index = this.reconnectErrorHandlers.indexOf(handler as (error: Error) => void);
+    if (index >= 0) this.reconnectErrorHandlers.splice(index, 1);
+  }
+
   override write(chunk: Buffer | string): void {
     if (!this.available) {
       throw new Error("Sidecar socket unavailable");
@@ -114,6 +134,11 @@ class ReconnectingSocket extends FakeSocket {
     for (const handler of this.reconnectErrorHandlers.splice(0)) {
       handler(error);
     }
+  }
+
+  emitClose(): void {
+    this.available = false;
+    super.destroy();
   }
 }
 
@@ -210,15 +235,29 @@ test("RpcClient waits for reconnect when the supervisor socket is temporarily un
   const socket = new ReconnectingSocket();
   const client = new RpcClient(socket, { timeoutMs: 100 });
 
+  socket.emitConnect();
+  const first = client.call<{ ok?: boolean }>("health", {});
+  assert.equal(socket.writes.length, 1);
+  let request = RpcRequest.fromBinary(parseClientFrame(socket.writes[0]!));
+  let response = new (RpcResponse as any)({
+    id: request.id,
+    result: HealthResponse.fromJson({ ok: true }).toBinary(),
+  });
+  socket.emitData(frameServerPayload(response.toBinary()));
+  assert.equal((await first).ok, true);
+
+  socket.emitClose();
+
   const pending = client.call<{ ok?: boolean }>("health", {});
 
-  assert.equal(socket.writes.length, 0);
+  assert.equal(socket.writes.length, 1);
   socket.emitConnect();
   await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(socket.writes.length, 1);
+  assert.equal(socket.writes.length, 2);
 
-  const request = RpcRequest.fromBinary(parseClientFrame(socket.writes[0]!));
-  const response = new (RpcResponse as any)({
+  request = RpcRequest.fromBinary(parseClientFrame(socket.writes[1]!));
+  assert.equal(socket.writes[1]![0], 0x02);
+  response = new (RpcResponse as any)({
     id: request.id,
     result: HealthResponse.fromJson({ ok: true }).toBinary(),
   });
@@ -226,6 +265,18 @@ test("RpcClient waits for reconnect when the supervisor socket is temporarily un
 
   const result = await pending;
   assert.equal(result.ok, true);
+});
+
+test("RpcClient does not resend after the original call has already timed out", async () => {
+  const socket = new ReconnectingSocket();
+  const client = new RpcClient(socket, { timeoutMs: 20 });
+
+  const pending = client.call<{ ok?: boolean }>("health", {});
+  await assert.rejects(pending, /RPC timeout: health \(20ms\)/);
+
+  socket.emitConnect();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(socket.writes.length, 0);
 });
 
 test("normalizeKernelMessages flattens rich message blocks before assemble encoding", () => {

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -5,6 +5,7 @@ import {
   AssembleContextInternalResponse,
   AssembleContextInternalRequest,
   AfterTurnKernelRequest,
+  HealthResponse,
   IngestMessageKernelRequest,
   RpcRequest,
   RpcResponse,
@@ -75,6 +76,44 @@ class FakeSocket implements SidecarSocket {
       handler(error);
     }
     this.errorOnce = [];
+  }
+}
+
+class ReconnectingSocket extends FakeSocket {
+  private available = false;
+  private readonly reconnectHandlers: Array<() => void> = [];
+  private reconnectErrorHandlers: Array<(error: Error) => void> = [];
+
+  override once(event: "connect" | "error", handler: (() => void) | ((error: Error) => void)): void {
+    if (event === "connect") {
+      if (this.available) {
+        (handler as () => void)();
+        return;
+      }
+      this.reconnectHandlers.push(handler as () => void);
+      return;
+    }
+    this.reconnectErrorHandlers.push(handler as (error: Error) => void);
+  }
+
+  override write(chunk: Buffer | string): void {
+    if (!this.available) {
+      throw new Error("Sidecar socket unavailable");
+    }
+    super.write(chunk);
+  }
+
+  emitConnect(): void {
+    this.available = true;
+    for (const handler of this.reconnectHandlers.splice(0)) {
+      handler();
+    }
+  }
+
+  emitReconnectError(error: Error): void {
+    for (const handler of this.reconnectErrorHandlers.splice(0)) {
+      handler(error);
+    }
   }
 }
 
@@ -165,6 +204,28 @@ test("RpcClient preserves empty result arrays and debug payloads", async () => {
   assert.equal(result.estimatedTokens, 12);
   assert.equal(result.systemPromptAddition, "sys");
   assert.ok(result.debug !== undefined, "debug payload should be preserved");
+});
+
+test("RpcClient waits for reconnect when the supervisor socket is temporarily unavailable", async () => {
+  const socket = new ReconnectingSocket();
+  const client = new RpcClient(socket, { timeoutMs: 100 });
+
+  const pending = client.call<{ ok?: boolean }>("health", {});
+
+  assert.equal(socket.writes.length, 0);
+  socket.emitConnect();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(socket.writes.length, 1);
+
+  const request = RpcRequest.fromBinary(parseClientFrame(socket.writes[0]!));
+  const response = new (RpcResponse as any)({
+    id: request.id,
+    result: HealthResponse.fromJson({ ok: true }).toBinary(),
+  });
+  socket.emitData(frameServerPayload(response.toBinary()));
+
+  const result = await pending;
+  assert.equal(result.ok, true);
 });
 
 test("normalizeKernelMessages flattens rich message blocks before assemble encoding", () => {


### PR DESCRIPTION
## Summary
- wait for the sidecar supervisor socket to reconnect when a transient `Sidecar socket unavailable` gap happens between long-running turns
- retry the pending RPC send once after reconnect instead of surfacing the temporary socket gap immediately
- add a focused RPC unit test that simulates the reconnect window and verifies the original call succeeds after reconnect

## Testing
- `pnpm build`
- `pnpm exec tsc -p tsconfig.tests.json && mkdir -p .ts-build/src/generated && cp -rf src/generated/. .ts-build/src/generated/ && node --test .ts-build/test/unit/rpc.test.js`

## Context
This PR is intentionally separate from the already-merged adapter normalization work in #30. It addresses the next remaining plugin-side issue observed in long monitored compaction runs: transient sidecar reconnect gaps could still abort a turn with `Sidecar socket unavailable` even when the daemon came back quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC client resilience with automatic reconnection retry handling for temporary socket unavailability issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->