### PR TITLE
fix: use runtime token counts for predictive compaction

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -147,6 +147,17 @@ function approximateMessagesTokens(messages: OpenClawCompatibleMessage[]): numbe
   return messages.reduce((sum, message) => sum + approximateMessageTokens(message), 0);
 }
 
+function normalizeCurrentTokenCount(currentTokenCount: number | undefined): number | undefined {
+  if (
+    typeof currentTokenCount !== "number" ||
+    !Number.isFinite(currentTokenCount) ||
+    currentTokenCount <= 0
+  ) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(currentTokenCount));
+}
+
 function normalizeTokenBudget(tokenBudget: number | undefined): number | undefined {
   if (typeof tokenBudget !== "number" || !Number.isFinite(tokenBudget) || tokenBudget <= 0) {
     return undefined;
@@ -263,6 +274,17 @@ function buildBudgetFallbackContext(
     estimatedTokens: approximateMessagesTokens(fallbackMessages),
     systemPromptAddition: "",
   };
+}
+
+function resolvePredictiveCompactionTokenCount(args: {
+  currentTokenCount?: number;
+  messages: OpenClawCompatibleMessage[];
+  prompt?: string;
+}): number {
+  return (
+    normalizeCurrentTokenCount(args.currentTokenCount) ??
+    approximateMessagesTokens(args.messages) + approximateTokenCount(args.prompt ?? "")
+  );
 }
 
 export function normalizeKernelMessage(message: {
@@ -456,10 +478,14 @@ export function buildContextEngineFactory(
       messages: Array<{ role: string; content: unknown; id?: string }>;
       tokenBudget: number;
       prompt?: string;
+      currentTokenCount?: number;
     }): Promise<OpenClawCompatibleAssembleResult> {
       const messages = normalizeKernelMessages(args.messages);
-      const currentContextTokens =
-        approximateMessagesTokens(messages) + approximateTokenCount(args.prompt ?? "");
+      const currentContextTokens = resolvePredictiveCompactionTokenCount({
+        currentTokenCount: args.currentTokenCount,
+        messages,
+        prompt: args.prompt,
+      });
       const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
       if (
         dynamicCompactThreshold != null &&
@@ -546,8 +572,13 @@ export function buildContextEngineFactory(
     }) {
       const messages = normalizeKernelMessages(args.messages);
       const kernel = runtime.getKernel();
+      const currentTokenCount = normalizeCurrentTokenCount(
+        typeof args.runtimeContext?.currentTokenCount === "number"
+          ? args.runtimeContext.currentTokenCount
+          : undefined,
+      );
       if (kernel) {
-        return await kernel.afterTurn({
+        const result = await kernel.afterTurn({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           userId: args.userId,
@@ -555,12 +586,52 @@ export function buildContextEngineFactory(
           prePromptMessageCount: args.prePromptMessageCount,
           isHeartbeat: args.isHeartbeat,
         });
+        const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
+        if (
+          dynamicCompactThreshold != null &&
+          currentTokenCount != null &&
+          currentTokenCount >= dynamicCompactThreshold
+        ) {
+          const compactionResult = await runCompaction({
+            sessionId: args.sessionId,
+            tokenBudget: args.tokenBudget,
+            force: true,
+            currentTokenCount,
+          });
+          if (!compactionResult.ok || !compactionResult.compacted) {
+            logger.warn?.(
+              `LibraVDB afterTurn predictive compaction did not compact at ${currentTokenCount} tokens ` +
+              `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction declined"}`,
+            );
+          }
+        }
+        return result;
       }
       const rpc = await runtime.getRpc();
-      return await rpc.call("after_turn_kernel", {
+      const result = await rpc.call("after_turn_kernel", {
         ...args,
         messages,
       });
+      const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
+      if (
+        dynamicCompactThreshold != null &&
+        currentTokenCount != null &&
+        currentTokenCount >= dynamicCompactThreshold
+      ) {
+        const compactionResult = await runCompaction({
+          sessionId: args.sessionId,
+          tokenBudget: args.tokenBudget,
+          force: true,
+          currentTokenCount,
+        });
+        if (!compactionResult.ok || !compactionResult.compacted) {
+          logger.warn?.(
+            `LibraVDB afterTurn predictive compaction did not compact at ${currentTokenCount} tokens ` +
+            `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction declined"}`,
+          );
+        }
+      }
+      return result;
     }
   };
 }

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -193,6 +193,61 @@ function resolveDynamicCompactThreshold(
   return Math.max(1, Math.floor(normalizedBudget * fraction));
 }
 
+function resolvePredictiveCompactionTarget(params: {
+  currentTokenCount: number | undefined;
+  threshold: number | undefined;
+}): number | undefined {
+  const currentTokenCount = normalizeCurrentTokenCount(params.currentTokenCount);
+  const threshold = normalizeTokenBudget(params.threshold);
+  if (currentTokenCount == null || threshold == null || currentTokenCount < threshold) {
+    return undefined;
+  }
+
+  const belowThresholdTarget = Math.max(1, threshold - 1);
+  return belowThresholdTarget < currentTokenCount
+    ? belowThresholdTarget
+    : Math.max(1, currentTokenCount - 1);
+}
+
+function logPredictiveCompactionAttempt(params: {
+  logger: LoggerLike;
+  phase: "assemble" | "afterTurn";
+  sessionId: string;
+  currentTokenCount: number;
+  threshold: number;
+  targetSize: number;
+  tokenBudget: number | undefined;
+}) {
+  params.logger.info?.(
+    `LibraVDB predictive compaction trigger phase=${params.phase} sessionId=${params.sessionId} ` +
+      `currentTokenCount=${params.currentTokenCount} threshold=${params.threshold} ` +
+      `targetSize=${params.targetSize} tokenBudget=${params.tokenBudget ?? "unknown"}`,
+  );
+}
+
+function logPredictiveCompactionOutcome(params: {
+  logger: LoggerLike;
+  phase: "assemble" | "afterTurn";
+  sessionId: string;
+  currentTokenCount: number;
+  threshold: number;
+  targetSize: number;
+  tokenBudget: number | undefined;
+  compacted: boolean;
+  reason?: string;
+}) {
+  const message =
+    `LibraVDB predictive compaction ${params.compacted ? "completed" : "did not compact"} ` +
+    `phase=${params.phase} sessionId=${params.sessionId} currentTokenCount=${params.currentTokenCount} ` +
+    `threshold=${params.threshold} targetSize=${params.targetSize} tokenBudget=${params.tokenBudget ?? "unknown"}` +
+    (params.reason ? ` reason=${params.reason}` : "");
+  if (params.compacted) {
+    params.logger.info?.(message);
+    return;
+  }
+  params.logger.warn?.(message);
+}
+
 function truncateContentToTokenBudget(content: string, tokenBudget: number): string {
   if (tokenBudget <= 0) return "";
   const maxChars = Math.max(1, tokenBudget * APPROX_CHARS_PER_TOKEN);
@@ -487,21 +542,39 @@ export function buildContextEngineFactory(
         prompt: args.prompt,
       });
       const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
-      if (
-        dynamicCompactThreshold != null &&
-        currentContextTokens >= dynamicCompactThreshold
-      ) {
+      const predictiveTargetSize = resolvePredictiveCompactionTarget({
+        currentTokenCount: currentContextTokens,
+        threshold: dynamicCompactThreshold,
+      });
+      if (dynamicCompactThreshold != null && predictiveTargetSize != null) {
+        logPredictiveCompactionAttempt({
+          logger,
+          phase: "assemble",
+          sessionId: args.sessionId,
+          currentTokenCount: currentContextTokens,
+          threshold: dynamicCompactThreshold,
+          targetSize: predictiveTargetSize,
+          tokenBudget: args.tokenBudget,
+        });
         const compactionResult = await runCompaction({
           sessionId: args.sessionId,
+          targetSize: predictiveTargetSize,
           tokenBudget: args.tokenBudget,
           force: true,
           currentTokenCount: currentContextTokens,
         });
+        logPredictiveCompactionOutcome({
+          logger,
+          phase: "assemble",
+          sessionId: args.sessionId,
+          currentTokenCount: currentContextTokens,
+          threshold: dynamicCompactThreshold,
+          targetSize: predictiveTargetSize,
+          tokenBudget: args.tokenBudget,
+          compacted: compactionResult.compacted,
+          reason: compactionResult.reason,
+        });
         if (!compactionResult.ok || !compactionResult.compacted) {
-          logger.warn?.(
-            `LibraVDB predictive compaction blocked assemble path at ${currentContextTokens} tokens (threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction declined"
-            }`,
-          );
           return buildBudgetFallbackContext(messages, args.tokenBudget);
         }
       }
@@ -587,23 +660,42 @@ export function buildContextEngineFactory(
           isHeartbeat: args.isHeartbeat,
         });
         const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
+        const predictiveTargetSize = resolvePredictiveCompactionTarget({
+          currentTokenCount,
+          threshold: dynamicCompactThreshold,
+        });
         if (
-          dynamicCompactThreshold != null &&
           currentTokenCount != null &&
-          currentTokenCount >= dynamicCompactThreshold
+          dynamicCompactThreshold != null &&
+          predictiveTargetSize != null
         ) {
+          logPredictiveCompactionAttempt({
+            logger,
+            phase: "afterTurn",
+            sessionId: args.sessionId,
+            currentTokenCount,
+            threshold: dynamicCompactThreshold,
+            targetSize: predictiveTargetSize,
+            tokenBudget: args.tokenBudget,
+          });
           const compactionResult = await runCompaction({
             sessionId: args.sessionId,
+            targetSize: predictiveTargetSize,
             tokenBudget: args.tokenBudget,
             force: true,
             currentTokenCount,
           });
-          if (!compactionResult.ok || !compactionResult.compacted) {
-            logger.warn?.(
-              `LibraVDB afterTurn predictive compaction did not compact at ${currentTokenCount} tokens ` +
-              `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction declined"}`,
-            );
-          }
+          logPredictiveCompactionOutcome({
+            logger,
+            phase: "afterTurn",
+            sessionId: args.sessionId,
+            currentTokenCount,
+            threshold: dynamicCompactThreshold,
+            targetSize: predictiveTargetSize,
+            tokenBudget: args.tokenBudget,
+            compacted: compactionResult.compacted,
+            reason: compactionResult.reason,
+          });
         }
         return result;
       }
@@ -613,23 +705,42 @@ export function buildContextEngineFactory(
         messages,
       });
       const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
+      const predictiveTargetSize = resolvePredictiveCompactionTarget({
+        currentTokenCount,
+        threshold: dynamicCompactThreshold,
+      });
       if (
-        dynamicCompactThreshold != null &&
         currentTokenCount != null &&
-        currentTokenCount >= dynamicCompactThreshold
+        dynamicCompactThreshold != null &&
+        predictiveTargetSize != null
       ) {
+        logPredictiveCompactionAttempt({
+          logger,
+          phase: "afterTurn",
+          sessionId: args.sessionId,
+          currentTokenCount,
+          threshold: dynamicCompactThreshold,
+          targetSize: predictiveTargetSize,
+          tokenBudget: args.tokenBudget,
+        });
         const compactionResult = await runCompaction({
           sessionId: args.sessionId,
+          targetSize: predictiveTargetSize,
           tokenBudget: args.tokenBudget,
           force: true,
           currentTokenCount,
         });
-        if (!compactionResult.ok || !compactionResult.compacted) {
-          logger.warn?.(
-            `LibraVDB afterTurn predictive compaction did not compact at ${currentTokenCount} tokens ` +
-            `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction declined"}`,
-          );
-        }
+        logPredictiveCompactionOutcome({
+          logger,
+          phase: "afterTurn",
+          sessionId: args.sessionId,
+          currentTokenCount,
+          threshold: dynamicCompactThreshold,
+          targetSize: predictiveTargetSize,
+          tokenBudget: args.tokenBudget,
+          compacted: compactionResult.compacted,
+          reason: compactionResult.reason,
+        });
       }
       return result;
     }

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -448,7 +448,12 @@ export function buildContextEngineFactory(
       sessionId: requireSessionId(args.sessionId, "compact"),
       force: args.force,
       ...(typeof targetSize === "number" ? { targetSize } : {}),
-      ...(typeof args.currentTokenCount === "number" ? { currentTokenCount: args.currentTokenCount } : {}),
+      ...(() => {
+        const normalizedCurrentTokenCount = normalizeCurrentTokenCount(args.currentTokenCount);
+        return normalizedCurrentTokenCount != null
+          ? { currentTokenCount: normalizedCurrentTokenCount }
+          : {};
+      })(),
       ...(typeof cfg.continuityMinTurns === "number"
         ? { continuityMinTurns: cfg.continuityMinTurns }
         : {}),
@@ -483,6 +488,52 @@ export function buildContextEngineFactory(
         reason: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  async function performAfterTurnPredictiveCompaction(args: {
+    sessionId: string;
+    tokenBudget?: number;
+    currentTokenCount?: number;
+  }): Promise<void> {
+    const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
+    const predictiveTargetSize = resolvePredictiveCompactionTarget({
+      currentTokenCount: args.currentTokenCount,
+      threshold: dynamicCompactThreshold,
+    });
+    if (
+      args.currentTokenCount == null ||
+      dynamicCompactThreshold == null ||
+      predictiveTargetSize == null
+    ) {
+      return;
+    }
+    logPredictiveCompactionAttempt({
+      logger,
+      phase: "afterTurn",
+      sessionId: args.sessionId,
+      currentTokenCount: args.currentTokenCount,
+      threshold: dynamicCompactThreshold,
+      targetSize: predictiveTargetSize,
+      tokenBudget: args.tokenBudget,
+    });
+    const compactionResult = await runCompaction({
+      sessionId: args.sessionId,
+      targetSize: predictiveTargetSize,
+      tokenBudget: args.tokenBudget,
+      force: true,
+      currentTokenCount: args.currentTokenCount,
+    });
+    logPredictiveCompactionOutcome({
+      logger,
+      phase: "afterTurn",
+      sessionId: args.sessionId,
+      currentTokenCount: args.currentTokenCount,
+      threshold: dynamicCompactThreshold,
+      targetSize: predictiveTargetSize,
+      tokenBudget: args.tokenBudget,
+      compacted: compactionResult.compacted,
+      reason: compactionResult.reason,
+    });
   }
 
   return {
@@ -574,7 +625,11 @@ export function buildContextEngineFactory(
           compacted: compactionResult.compacted,
           reason: compactionResult.reason,
         });
-        if (!compactionResult.ok || !compactionResult.compacted) {
+        if (!compactionResult.ok) {
+          logger.warn?.(
+            `LibraVDB predictive compaction blocked assemble path at ${currentContextTokens} tokens ` +
+            `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction failed"}`,
+          );
           return buildBudgetFallbackContext(messages, args.tokenBudget);
         }
       }
@@ -659,44 +714,11 @@ export function buildContextEngineFactory(
           prePromptMessageCount: args.prePromptMessageCount,
           isHeartbeat: args.isHeartbeat,
         });
-        const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
-        const predictiveTargetSize = resolvePredictiveCompactionTarget({
+        await performAfterTurnPredictiveCompaction({
+          sessionId: args.sessionId,
+          tokenBudget: args.tokenBudget,
           currentTokenCount,
-          threshold: dynamicCompactThreshold,
         });
-        if (
-          currentTokenCount != null &&
-          dynamicCompactThreshold != null &&
-          predictiveTargetSize != null
-        ) {
-          logPredictiveCompactionAttempt({
-            logger,
-            phase: "afterTurn",
-            sessionId: args.sessionId,
-            currentTokenCount,
-            threshold: dynamicCompactThreshold,
-            targetSize: predictiveTargetSize,
-            tokenBudget: args.tokenBudget,
-          });
-          const compactionResult = await runCompaction({
-            sessionId: args.sessionId,
-            targetSize: predictiveTargetSize,
-            tokenBudget: args.tokenBudget,
-            force: true,
-            currentTokenCount,
-          });
-          logPredictiveCompactionOutcome({
-            logger,
-            phase: "afterTurn",
-            sessionId: args.sessionId,
-            currentTokenCount,
-            threshold: dynamicCompactThreshold,
-            targetSize: predictiveTargetSize,
-            tokenBudget: args.tokenBudget,
-            compacted: compactionResult.compacted,
-            reason: compactionResult.reason,
-          });
-        }
         return result;
       }
       const rpc = await runtime.getRpc();
@@ -704,44 +726,11 @@ export function buildContextEngineFactory(
         ...args,
         messages,
       });
-      const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
-      const predictiveTargetSize = resolvePredictiveCompactionTarget({
+      await performAfterTurnPredictiveCompaction({
+        sessionId: args.sessionId,
+        tokenBudget: args.tokenBudget,
         currentTokenCount,
-        threshold: dynamicCompactThreshold,
       });
-      if (
-        currentTokenCount != null &&
-        dynamicCompactThreshold != null &&
-        predictiveTargetSize != null
-      ) {
-        logPredictiveCompactionAttempt({
-          logger,
-          phase: "afterTurn",
-          sessionId: args.sessionId,
-          currentTokenCount,
-          threshold: dynamicCompactThreshold,
-          targetSize: predictiveTargetSize,
-          tokenBudget: args.tokenBudget,
-        });
-        const compactionResult = await runCompaction({
-          sessionId: args.sessionId,
-          targetSize: predictiveTargetSize,
-          tokenBudget: args.tokenBudget,
-          force: true,
-          currentTokenCount,
-        });
-        logPredictiveCompactionOutcome({
-          logger,
-          phase: "afterTurn",
-          sessionId: args.sessionId,
-          currentTokenCount,
-          threshold: dynamicCompactThreshold,
-          targetSize: predictiveTargetSize,
-          tokenBudget: args.tokenBudget,
-          compacted: compactionResult.compacted,
-          reason: compactionResult.reason,
-        });
-      }
       return result;
     }
   };

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -290,6 +290,37 @@ test("assemble prefers authoritative currentTokenCount for predictive compaction
   assert.equal(compactParams.targetSize, 799);
 });
 
+test("assemble proceeds to assembly when server legitimately declines compaction", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: false });
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "recalled" }],
+    estimatedTokens: 40,
+    systemPromptAddition: "<recalled>x</recalled>",
+  });
+
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    compactionThresholdFraction: 0.8,
+  };
+  const logger = createMemoryLogger();
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache, logger);
+
+  const assembled = await context.assemble({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "X".repeat(4000) }],
+    tokenBudget: 1000,
+  });
+
+  const assembleParams = rpc.getLastCall("assemble_context_internal");
+  assert.ok(assembleParams, "assemble_context_internal must be called when compaction declines");
+  assert.equal(assembled.messages[0]?.content, "recalled");
+  assert.equal(assembled.systemPromptAddition, "<recalled>x</recalled>");
+  assert.match(logger.warns[0] ?? "", /did not compact.*phase=assemble/);
+});
+
 test("assemble blocks daemon assembly when predictive compaction fails", async () => {
   const rpc = new StaticContractRpc();
   rpc.mockResponses.set("compact_session", new Error("transaction conflict"));
@@ -397,6 +428,23 @@ test("compact rejects empty sessionId to prevent accidental session rollover", a
   assert.equal(rpc.getLastCall("compact_session"), null);
 });
 
+test("compact omits invalid currentTokenCount values from the wire request", async () => {
+  const rpc = new StaticContractRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+
+  await context.compact({
+    sessionId: "test-session",
+    tokenBudget: 2048,
+    currentTokenCount: Number.NaN,
+  });
+
+  const params = rpc.getLastCall("compact_session");
+  assert.ok(params, "Expected compact_session to be called");
+  assert.equal("currentTokenCount" in params, false);
+});
+
 test("afterTurn forwards message arrays and pre-prompt counts correctly", async () => {
   const rpc = new StaticContractRpc();
   const recallCache = createRecallCache<SearchResult>();
@@ -459,4 +507,30 @@ test("afterTurn triggers predictive compaction from runtimeContext currentTokenC
   assert.equal(logger.warns.length, 0);
   assert.match(logger.infos[0] ?? "", /predictive compaction trigger phase=afterTurn/);
   assert.match(logger.infos[1] ?? "", /predictive compaction completed phase=afterTurn/);
+});
+
+test("afterTurn does not trigger predictive compaction without authoritative currentTokenCount", async () => {
+  const rpc = new StaticContractRpc();
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    compactionThresholdFraction: 0.8,
+  };
+
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+
+  await context.afterTurn({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    prePromptMessageCount: 1,
+    tokenBudget: 1000,
+    runtimeContext: { currentTokenCount: Number.NaN },
+  });
+
+  assert.deepEqual(
+    rpc.calls.map((call) => call.method),
+    ["after_turn_kernel"],
+  );
+  assert.equal(rpc.getLastCall("compact_session"), null);
 });

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { buildContextEngineFactory as createContextEngineFactory } from "../../src/context-engine.js";
 import { createRecallCache } from "../../src/recall-cache.js";
+import { createMemoryLogger } from "../helpers/logger.js";
 import type { LoggerLike, PluginConfig, SearchResult } from "../../src/types.js";
 
 const NOOP_LOGGER: LoggerLike = {
@@ -233,7 +234,8 @@ test("assemble triggers force compaction at dynamic 80% threshold before daemon 
     rpcTimeoutMs: 1000,
     compactionThresholdFraction: 0.8,
   };
-  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+  const logger = createMemoryLogger();
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache, logger);
 
   const assembled = await context.assemble({
     sessionId: "test-session",
@@ -246,12 +248,16 @@ test("assemble triggers force compaction at dynamic 80% threshold before daemon 
   assert.ok(compactParams, "Expected compact_session to be called");
   assert.equal(compactParams.sessionId, "test-session");
   assert.equal(compactParams.force, true);
-  assert.equal(compactParams.targetSize, 1000);
+  assert.equal(compactParams.targetSize, 799);
+  assert.equal(compactParams.currentTokenCount, 1008);
 
   const assembleParams = rpc.getLastCall("assemble_context_internal");
   assert.ok(assembleParams, "Expected assemble_context_internal to be called after compaction");
   assert.equal(assembleParams.config.compactThreshold, 800);
   assert.equal(assembled.messages[0]?.content, "ok");
+  assert.equal(logger.warns.length, 0);
+  assert.match(logger.infos[0] ?? "", /predictive compaction trigger phase=assemble/);
+  assert.match(logger.infos[1] ?? "", /predictive compaction completed phase=assemble/);
 });
 
 test("assemble prefers authoritative currentTokenCount for predictive compaction", async () => {
@@ -281,6 +287,7 @@ test("assemble prefers authoritative currentTokenCount for predictive compaction
   const compactParams = rpc.getLastCall("compact_session");
   assert.ok(compactParams, "Expected compact_session to be called");
   assert.equal(compactParams.currentTokenCount, 900);
+  assert.equal(compactParams.targetSize, 799);
 });
 
 test("assemble blocks daemon assembly when predictive compaction fails", async () => {
@@ -427,8 +434,9 @@ test("afterTurn triggers predictive compaction from runtimeContext currentTokenC
     rpcTimeoutMs: 1000,
     compactionThresholdFraction: 0.8,
   };
+  const logger = createMemoryLogger();
 
-  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache, logger);
 
   await context.afterTurn({
     sessionId: "test-session",
@@ -447,5 +455,8 @@ test("afterTurn triggers predictive compaction from runtimeContext currentTokenC
   const compactParams = rpc.getLastCall("compact_session");
   assert.ok(compactParams, "Expected compact_session to be called");
   assert.equal(compactParams.currentTokenCount, 900);
-  assert.equal(compactParams.targetSize, 1000);
+  assert.equal(compactParams.targetSize, 799);
+  assert.equal(logger.warns.length, 0);
+  assert.match(logger.infos[0] ?? "", /predictive compaction trigger phase=afterTurn/);
+  assert.match(logger.infos[1] ?? "", /predictive compaction completed phase=afterTurn/);
 });

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -254,6 +254,35 @@ test("assemble triggers force compaction at dynamic 80% threshold before daemon 
   assert.equal(assembled.messages[0]?.content, "ok");
 });
 
+test("assemble prefers authoritative currentTokenCount for predictive compaction", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "ok" }],
+    estimatedTokens: 32,
+    systemPromptAddition: "",
+  });
+
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    compactionThresholdFraction: 0.8,
+  };
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+
+  await context.assemble({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    tokenBudget: 1000,
+    currentTokenCount: 900,
+  });
+
+  const compactParams = rpc.getLastCall("compact_session");
+  assert.ok(compactParams, "Expected compact_session to be called");
+  assert.equal(compactParams.currentTokenCount, 900);
+});
+
 test("assemble blocks daemon assembly when predictive compaction fails", async () => {
   const rpc = new StaticContractRpc();
   rpc.mockResponses.set("compact_session", new Error("transaction conflict"));
@@ -388,4 +417,35 @@ test("afterTurn forwards message arrays and pre-prompt counts correctly", async 
   assert.equal(params.prePromptMessageCount, 2);
   assert.equal(params.isHeartbeat, false);
   assert.deepEqual(params.messages, mockMessages);
+});
+
+test("afterTurn triggers predictive compaction from runtimeContext currentTokenCount", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  const recallCache = createRecallCache<SearchResult>();
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    compactionThresholdFraction: 0.8,
+  };
+
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, recallCache);
+
+  await context.afterTurn({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    prePromptMessageCount: 1,
+    tokenBudget: 1000,
+    runtimeContext: { currentTokenCount: 900 },
+  });
+
+  assert.deepEqual(
+    rpc.calls.map((call) => call.method),
+    ["after_turn_kernel", "compact_session"],
+  );
+
+  const compactParams = rpc.getLastCall("compact_session");
+  assert.ok(compactParams, "Expected compact_session to be called");
+  assert.equal(compactParams.currentTokenCount, 900);
+  assert.equal(compactParams.targetSize, 1000);
 });


### PR DESCRIPTION
## Summary
- prefer authoritative `currentTokenCount` for predictive compaction when the host provides it instead of relying only on the plugin's char-based approximation
- trigger proactive compaction from `afterTurn()` using `runtimeContext.currentTokenCount` so current OpenClaw builds can compact before the next prompt without a core API change
- add integration coverage for both the explicit `assemble()` token-count path and the `afterTurn()` runtime-context path

## Testing
- `npm run test:ts`
- `npx tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/host-flow.test.js`
- `npm run build`
- local runtime validation: patched the installed plugin dist, restarted the gateway, then ran the monitored minimax compaction harness twice; both runs stalled on turn 1 in `opencode-go/minimax-m2.5` before any transcript was written, so the runtime signal is currently blocked by a provider-side timeout rather than the plugin path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Predictive context compaction: accept or estimate current token counts to compute a dynamic compaction target, force compaction when appropriate, omit invalid counts from requests, and run phase-specific compaction after turn completion. Improved informational logging for compaction attempts and outcomes.

* **Tests**
  * Integration tests covering predictive compaction parameters, use of provided token counts, post-turn compaction behavior, request hygiene for invalid counts, and related logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->