### PR TITLE
docs: refresh README and plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Runtime requirements:
 - Node.js `>= 22`
 - a separately installed `libravdbd` daemon
 
+Compatibility note:
+
+- this plugin is currently verified against OpenClaw `2026.4.23`
+
 Default endpoints:
 
 - macOS/Linux user-local daemon: `unix:$HOME/.clawdb/run/libravdb.sock`
@@ -141,7 +145,7 @@ Use [Install](./docs/install.md) for daemon lifecycle commands and
 - Understand the design: [Problem](./docs/problem.md), [Architecture](./docs/architecture.md), [ADRs](./docs/architecture-decisions/README.md)
 - Operate safely: [Security](./docs/security.md), [Uninstall](./docs/uninstall.md)
 - Configure optional inputs: [Features](./docs/features.md), [Embedding profiles](./docs/embedding-profiles.md), [Models](./docs/models.md)
-- Tune or benchmark: [Performance and tuning](./docs/performance-and-tuning.md)
+- Advanced operations: [Performance and tuning](./docs/performance-and-tuning.md)
 - Work from source: [Development](./docs/development.md), [Contributing](./docs/contributing.md)
 
 ## From Source

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Runtime requirements:
 - Node.js `>= 22`
 - a separately installed `libravdbd` daemon
 
+Compatibility note:
+
+- this plugin is currently only verified against OpenClaw `2026.4.23`
+- newer or older OpenClaw builds may work, but they are not covered by the current test matrix
+
 Default endpoints:
 
 - macOS/Linux user-local daemon: `unix:$HOME/.clawdb/run/libravdb.sock`

--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@ Runtime requirements:
 - Node.js `>= 22`
 - a separately installed `libravdbd` daemon
 
-Compatibility note:
-
-- this plugin is currently only verified against OpenClaw `2026.4.23`
-- newer or older OpenClaw builds may work, but they are not covered by the current test matrix
-
 Default endpoints:
 
 - macOS/Linux user-local daemon: `unix:$HOME/.clawdb/run/libravdb.sock`

--- a/README.md
+++ b/README.md
@@ -1,71 +1,28 @@
-# LibraVDB Memory for OpenClaw
+# ♎ LibraVDB - Memory and Context Management
 
-[![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://github.com/xDarkicex/libravdbd)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](./package.json)
-[![OpenClaw](https://img.shields.io/badge/OpenClaw-memory%20plugin-111827)](./openclaw.plugin.json)
+<div align="center">
+  <img src="./docs/assets/libravdb-logo.svg" alt="LibraVDB" width="640">
+</div>
 
-`@xdarkicex/openclaw-memory-libravdb` is a local-first OpenClaw memory system
-for people who want more than "top-k vectors plus a prompt footer."
+<div align="center">
+  <a href="https://github.com/xDarkicex/libravdbd"><img src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white" alt="Go 1.25+"></a>
+  <a href="./package.json"><img src="https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript 5.x"></a>
+  <a href="./openclaw.plugin.json"><img src="https://img.shields.io/badge/OpenClaw-memory%20plugin-111827" alt="OpenClaw memory plugin"></a>
+  <a href="https://www.npmjs.com/package/@xdarkicex/openclaw-memory-libravdb"><img src="https://img.shields.io/npm/v/%40xdarkicex%2Fopenclaw-memory-libravdb?label=release&color=5B21B6" alt="Release"></a>
+</div>
 
-It replaces the default lightweight memory path with a full context lifecycle:
+`@xdarkicex/openclaw-memory-libravdb` is a local-first OpenClaw memory plugin
+backed by the `libravdbd` daemon. It replaces the lightweight default memory
+path with scoped session, user, and global memory; continuity-aware prompt
+assembly; durable recall; and sidecar-owned compaction.
 
-- active session memory
-- durable per-user memory
-- shared global memory
-- continuity-aware compaction
-- authored context partitioning
-- hybrid scoring across scope, recency, and similarity
+[Install](./docs/install.md) · [Full installation reference](./docs/installation.md) · [Architecture](./docs/architecture.md) · [Security](./docs/security.md) · [Performance and tuning](./docs/performance-and-tuning.md) · [Contributing](./docs/contributing.md)
 
-This repository pairs a TypeScript OpenClaw plugin with a Go daemon backed by
-`libraVDB`. The plugin owns both the `memory` and `contextEngine` slots, while
-the daemon handles embeddings, retrieval, storage, and compaction.
-On newer OpenClaw builds, it also bridges the built-in `memory_search` runtime
-to the same libraVDB sidecar instead of leaving that tool inert.
+New install? Start here: [Install guide](./docs/install.md). Preferred setup on
+macOS: install `libravdbd` with Homebrew, install the OpenClaw plugin, then
+assign the plugin to both required slots.
 
-For local development, this repo can target a running daemon or a manual local
-daemon binary.
-
-## Why This Exists
-
-The stock "single memory bucket" pattern is good for simple persistence, but it
-starts to break down when you care about:
-
-- keeping the newest working context raw and intact
-- separating ephemeral session state from durable memory
-- avoiding long-session prompt collapse
-- preserving authored instructions differently from recalled user content
-- treating memory retrieval as a ranked assembly problem instead of plain
-  nearest-neighbor lookup
-
-LibraVDB Memory exists for that harder class of memory problem.
-
-## What Makes It Different
-
-These are the core differentiators the project is built around:
-
-- Dual slot ownership: the plugin owns both memory prompt injection and the
-  full context lifecycle.
-- Built-in `memory_search` bridge: newer OpenClaw memory runtime calls are
-  routed into the same sidecar-backed retrieval path.
-- Lifecycle hint adoption: `before_reset` and `session_end` are used as
-  advisory signals into the sidecar without giving OpenClaw control of ingest
-  or compaction.
-- Sidecar-owned lifecycle journal: reset/end hints are recorded internally for
-  debugging and auditing without entering normal memory retrieval.
-  The journal is bounded by a sidecar retention cap so it does not grow
-  forever.
-- Local-first runtime: the core path does not depend on external embedding
-  services.
-- Three-tier memory: session, durable user, and global memory stay distinct.
-- Hybrid scoring: retrieval is ranked by semantic similarity, recency, scope,
-  and summary quality instead of cosine alone.
-- Automatic compaction: long sessions compact behind a protected recent tail.
-- Crash-resilient IPC: the host talks to a sidecar over a stable local socket
-  or loopback TCP endpoint with degraded-mode fallback.
-
-## Quick Start
-
-The supported install flow is:
+## Install
 
 ```bash
 brew tap xDarkicex/homebrew-openclaw-libravdb-memory
@@ -74,10 +31,7 @@ brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-The Homebrew formula installs the daemon plus the bundled ONNX Runtime, embedding assets, and T5 summarizer assets it needs to boot cleanly on supported platforms.
-
-Then assign the plugin to both required OpenClaw slots in
-`~/.openclaw/openclaw.json`:
+Then activate both plugin slots in `~/.openclaw/openclaw.json`:
 
 ```json
 {
@@ -95,332 +49,119 @@ Then assign the plugin to both required OpenClaw slots in
 }
 ```
 
-Verify the setup:
+Verify the daemon and plugin:
 
 ```bash
 openclaw memory status
 ```
 
-Expected healthy state:
+Healthy output should show `Sidecar=running`, stored memory counts, the active
+gate threshold, and the loaded embedding profile.
 
-- the daemon is reachable
-- the plugin is active as the memory provider
-- the runtime can report stored counts and model readiness
+## Quick Start
 
-## Markdown Ingestion
+Runtime requirements:
 
-LibraVDB Memory can watch markdown roots and sync changed notes into vector
-memory without changing the Go sidecar RPC contract.
+- OpenClaw `>= 2026.3.22`
+- Node.js `>= 22`
+- a separately installed `libravdbd` daemon
 
-The two built-in source adapters are:
+Default endpoints:
 
-- `generic`: for OpenClaw-owned markdown, including stock files like
-  `MEMORY.md`
-- `obsidian`: for Obsidian vault roots, with tag-aware defaults
+- macOS/Linux user-local daemon: `unix:$HOME/.clawdb/run/libravdb.sock`
+- Homebrew daemon on Apple Silicon: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
+- Windows daemon: `tcp:127.0.0.1:37421`
 
-Configuration is driven through the plugin config fields in
-`openclaw.plugin.json`:
+If your daemon runs elsewhere, set `sidecarPath`:
 
-- `markdownIngestionEnabled`
-- `markdownIngestionRoots`
-- `markdownIngestionInclude`
-- `markdownIngestionExclude`
-- `markdownIngestionDebounceMs`
-- `markdownIngestionObsidianEnabled`
-- `markdownIngestionObsidianRoots`
-- `markdownIngestionObsidianInclude`
-- `markdownIngestionObsidianExclude`
-- `markdownIngestionObsidianDebounceMs`
-
-Typical usage:
-
-- point `markdownIngestionRoots` at OpenClaw-owned markdown roots, such as
-  `.openclaw/skills/*/*.md` or a stock memory directory that contains
-  `MEMORY.md`
-- enable the Obsidian adapter separately with
-  `markdownIngestionObsidianEnabled: true` and one or more vault roots
-- use include/exclude globs to narrow what gets watched when needed
-
-By default, the Obsidian adapter only auto-ingests notes that look like memory
-notes, using frontmatter tags or inline tags like `#project`. The OpenClaw
-stock `MEMORY.md` file is always eligible through the generic adapter path.
-
-## Dream Promotion
-
-Dream promotion is a separate, opt-in path for promoting vetted dream diary
-entries directly into a dedicated `dream:{userId}` collection.
-
-It does not use `MEMORY.md`. Instead, it expects a dream diary markdown file
-that contains explicit candidate bullets under promotion-oriented headings such
-as `## Deep Sleep`. Each promoted bullet should include a trailing metadata
-block with the gating fields:
-
-```md
-- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}
+```json
+{
+  "plugins": {
+    "configs": {
+      "libravdb-memory": {
+        "sidecarPath": "tcp:127.0.0.1:37421"
+      }
+    }
+  }
+}
 ```
 
-Only bullets that satisfy the sidecar gates are inserted. The dream collection
-is isolated from normal `user:` and `global` retrieval by default, and dream
-phrasing in chat or search queries routes there automatically.
+## Highlights
 
-Configure automatic diary watching with:
+- **Dual slot ownership** - owns both OpenClaw `memory` and `contextEngine`.
+- **Memory runtime bridge** - routes built-in `memory_search` calls to the same
+  libraVDB-backed sidecar on hosts that expose the runtime API.
+- **Three memory scopes** - keeps active session, durable user, and global memory
+  separate.
+- **Hybrid retrieval** - blends semantic similarity, scope, recency, and summary
+  quality instead of relying on cosine similarity alone.
+- **Continuity-aware assembly** - preserves the recent working tail while fitting
+  recalled memory into a bounded prompt budget.
+- **Sidecar compaction** - summarizes older session turns without flattening the
+  newest working context.
+- **Local-first inference** - uses local embedding and compaction paths by
+  default, with optional external summarizer configuration.
+- **Explicit daemon lifecycle** - the npm/OpenClaw package stays connect-only;
+  `libravdbd` is installed and supervised separately.
 
-- `dreamPromotionEnabled`
-- `dreamPromotionDiaryPath`
-- `dreamPromotionUserId`
-- `dreamPromotionDebounceMs`
+## Security Defaults
 
-For a manual run, use:
+Stored memory is treated as untrusted historical context. Retrieved memory is
+framed before it reaches the downstream model, memory collections are scoped by
+session/user/global namespace, and daemon installation is outside the npm plugin
+package.
+
+Before exposing OpenClaw over remote channels, read [Security](./docs/security.md).
+
+## Operator Quick Refs
 
 ```bash
+openclaw memory status
+openclaw memory export --user-id <userId>
+openclaw memory flush --user-id <userId>
+openclaw memory journal --limit 50
 openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
 ```
 
-The manual command and the automatic watcher both go through the same sidecar
-promotion RPC, so the admission gates and provenance metadata are identical.
+Use [Install](./docs/install.md) for daemon lifecycle commands and
+[Uninstall](./docs/uninstall.md) for safe shutdown and removal.
 
-## Install Model
+## Optional Features
 
-This plugin is intentionally **connect-only** at install time.
+- **Markdown ingestion** watches OpenClaw-owned markdown roots or Obsidian vaults
+  and syncs eligible notes into memory. See [Features](./docs/features.md).
+- **Dream promotion** promotes vetted dream diary bullets into an isolated
+  `dream:{userId}` collection. See [Features](./docs/features.md).
+- **Embedding profiles** expose local model metadata defaults for MiniLM and
+  Nomic. See [Embedding profiles](./docs/embedding-profiles.md).
 
-It does not compile Go code during plugin installation, and it does not manage
-daemon lifecycle automatically from the npm package. That is deliberate: some
-OpenClaw environments are strict about postinstall behavior, daemon spawning,
-and anything that looks like binary bootstrap or process management.
+## Docs By Goal
 
-Current model:
+- New install: [Install](./docs/install.md), [Installation reference](./docs/installation.md)
+- Understand the design: [Problem](./docs/problem.md), [Architecture](./docs/architecture.md), [ADRs](./docs/architecture-decisions/README.md)
+- Operate safely: [Security](./docs/security.md), [Uninstall](./docs/uninstall.md)
+- Configure optional inputs: [Features](./docs/features.md), [Embedding profiles](./docs/embedding-profiles.md), [Models](./docs/models.md)
+- Tune or benchmark: [Performance and tuning](./docs/performance-and-tuning.md)
+- Work from source: [Development](./docs/development.md), [Contributing](./docs/contributing.md)
 
-- npm/OpenClaw package: plugin code and docs
-- `libravdbd`: installed and managed separately
-- default daemon endpoint on macOS/Linux:
-  `unix:$HOME/.clawdb/run/libravdb.sock`
-- default daemon endpoint on Windows:
-  `tcp:127.0.0.1:37421`
-
-If your daemon runs elsewhere, set an explicit `sidecarPath`, for example:
-
-- `unix:/custom/path/libravdb.sock`
-- `tcp:127.0.0.1:9999`
-
-## Architecture At A Glance
-
-```text
-OpenClaw host
-  -> memoryPromptSection (static capability header)
-  -> memory runtime bridge (built-in memory_search)
-  -> context engine (bootstrap / ingest / assemble / compact)
-  -> plugin runtime
-  -> JSON-RPC
-  -> libravdbd
-  -> libraVDB + local embedding/summarization stack
-```
-
-The main runtime split is:
-
-- TypeScript host layer:
-  - OpenClaw plugin registration
-  - prompt assembly
-  - hybrid ranking
-  - continuity-aware token budgeting
-  - degraded-mode behavior
-- Go daemon layer:
-  - vector storage
-  - embeddings
-  - search RPCs
-  - compaction and summarization
-  - stable local IPC endpoint
-
-For the implemented architecture map, read [docs/architecture.md](./docs/architecture.md).
-
-## Retrieval Model
-
-The assembly path is not "just search some vectors and paste the top hits."
-
-It combines:
-
-- session search for current-work relevance
-- durable user recall for long-lived personal context
-- global recall for shared facts
-- authored invariant and variant context
-- continuity-preserving recent-tail injection
-- token-budgeted fitting
-
-The ranking model currently blends:
-
-- semantic similarity
-- scope weighting
-- recency decay
-- summary quality attenuation
-
-The formal math and deeper design notes are kept out of the public index on
-purpose.
-
-## LongMemEval Harness
-
-For internal tuning, the repo includes a local LongMemEval harness that runs the
-dataset through the plugin layer and measures whether the assembled prompt still
-contains the evidence turns.
-
-The benchmark runner is committed, but the dataset and generated reports are not.
-Keep downloaded data and local outputs under `benchmarks/longmemeval/`, which is
-ignored by default.
-
-The harness writes JSONL incrementally, so partial results survive if a transient
-daemon failure interrupts a long run.
-
-The run summary now prints a compact table with total questions, processed rows,
-skipped abstentions, errors, session hit rate, turn hit rate, and average prompt
-size.
-
-Run it with:
+## From Source
 
 ```bash
-LONGMEMEVAL_DATA_FILE=/path/to/longmemeval_oracle.json pnpm run benchmark:longmemeval
+pnpm install
+pnpm check
+bash scripts/build-daemon.sh
 ```
 
-If you already have a daemon running and do not want the benchmark to spawn
-another one, set:
-
-```bash
-LONGMEMEVAL_USE_EXISTING_DAEMON=1 LONGMEMEVAL_SIDECAR_PATH=unix:/path/to/libravdb.sock
-```
-
-If the local test daemon drops mid-run, the benchmark will restart it and retry
-the current instance once before recording an error result.
-
-Optional outputs:
-
-- `LONGMEMEVAL_LIMIT` to cap the number of questions
-- `LONGMEMEVAL_TOPK` to change the search budget
-- `LONGMEMEVAL_OUT_FILE` to write JSONL records for analysis
-
-To score a hypothesis JSONL file with the official LongMemEval evaluator, point
-the repo at a local checkout of the benchmark and run:
-
-```bash
-LONGMEMEVAL_EVAL_REPO=/path/to/LongMemEval \
-LONGMEMEVAL_HYPOTHESIS_FILE=/path/to/hypotheses.jsonl \
-LONGMEMEVAL_DATA_FILE=/path/to/longmemeval_oracle.json \
-OPENAI_API_KEY=... \
-pnpm run benchmark:longmemeval:score
-```
-
-That scorer wrapper shells out to the official Python evaluation script and then
-prints the aggregate metrics from the generated log when available.
-
-## Compaction Model
-
-This system does not treat long chats as append-only forever.
-
-Older session turns compact behind a protected recent tail, so the plugin can:
-
-- keep the newest working context raw
-- preserve adjacency-sensitive continuity near the boundary
-- promote older material into summaries
-- avoid letting long sessions drown their own prompt budget
-
-Compaction is designed as part of the memory system itself, not as a separate
-maintenance convenience.
-
-## For Power Users
-
-If you are evaluating this as an operator or advanced OpenClaw user, the key
-practical points are:
-
-- This plugin should own both `memory` and `contextEngine`. Partial slot
-  assignment is a misconfiguration.
-- On hosts that expose `registerMemoryRuntime`, the built-in `memory_search`
-  tool now searches the same libraVDB-backed memory stores.
-- The daemon is a separate operational unit. Treat plugin lifecycle and daemon
-  lifecycle as different concerns.
-- The system is local-first by design. The critical retrieval path does not
-  require a remote embedding service.
-- The sidecar transport is stable and explicit, which makes it service-manager
-  friendly on macOS, Linux, and Windows.
-
-Good entry points:
-
-- [docs/install.md](./docs/install.md)
-- [docs/installation.md](./docs/installation.md)
-- [docs/uninstall.md](./docs/uninstall.md)
-- [docs/architecture.md](./docs/architecture.md)
-
-## For Researchers And Builders
-
-If you are studying retrieval, memory systems, or agent architecture, the
-interesting parts of this repo are:
-
-- continuity-aware assembly:
-  `C_total(q) = I union T_recent union Proj(V_rest, q)`
-- hybrid ranking instead of pure cosine retrieval
-- separation of authored invariants from searchable authored lore
-- durable-memory admission via domain-adaptive gating
-- local daemon architecture rather than in-process TS vector plumbing
-- compaction that preserves recent working context instead of flattening the
-  whole transcript
-
-Start here:
-
-- [docs/problem.md](./docs/problem.md)
-- [docs/architecture.md](./docs/architecture.md)
+`scripts/build-daemon.sh` prepares `.daemon-bin/libravdbd` for local plugin
+testing when you have a published daemon binary, a Homebrew daemon, or a local
+daemon checkout. For the full source workflow, read [Development](./docs/development.md).
 
 ## Runtime Facts
 
 - npm package: `@xdarkicex/openclaw-memory-libravdb`
 - OpenClaw plugin id: `libravdb-memory`
-- minimum host version: `openclaw >= 2026.3.22`
-- default daemon data path: `$HOME/.clawdb/data.libravdb`
-- default daemon endpoint on macOS/Linux:
-  `unix:$HOME/.clawdb/run/libravdb.sock`
-- default daemon endpoint on Windows:
-  `tcp:127.0.0.1:37421`
-
-## Repository Guide
-
-- [docs/install.md](./docs/install.md): quick install and lifecycle guide
-- [docs/installation.md](./docs/installation.md): full installation and
-  packaging reference
-- [docs/uninstall.md](./docs/uninstall.md): clean shutdown and removal
-- [docs/architecture.md](./docs/architecture.md): current implemented system
-  architecture
-
-## Current Constraint
-
-Because OpenClaw environments can be strict about postinstall downloads,
-daemon spawning, and scanner-visible binary bootstrap behavior, the cleanest
-supported user path today is:
-
-- install plugin
-- install daemon
-- assign both slots
-- let the plugin connect to a stable local endpoint
-
-That tradeoff is intentional. It keeps the plugin installation surface simple
-and auditable while preserving the full local memory engine at runtime.
-
-## Generated Contract Types
-
-TypeScript code in this plugin imports generated LibraVDB IPC types via the
-`@xdarkicex/libravdb-contracts` package:
-
-```typescript
-import { RpcRequest, RpcResponse } from "@xdarkicex/libravdb-contracts";
-```
-
-The generated types live in `libravdb-contracts/gen/ts/` and are produced by
-`buf generate` in that repository. A local `paths` alias in `tsconfig.json`
-wires the package name to that directory, so imports resolve without a
-`node_modules` install in the contracts repo.
-
-To regenerate after a proto change:
-
-```bash
-cd ../libravdb-contracts && buf generate
-# or from this repo:
-pnpm run generate:contracts
-```
-
-The alias is configured in both `tsconfig.json` (type-checking) and
-`tsconfig.build.json` (declaration emission). The generated `.ts` files use
-`@bufbuild/protobuf` at runtime, which must be available in the plugin's
-`node_modules`.
+- plugin kind: `memory`, `context-engine`
+- minimum OpenClaw host version: `>= 2026.3.22`
+- default data path: `$HOME/.clawdb/data.libravdb`
+- default macOS/Linux endpoint: `unix:$HOME/.clawdb/run/libravdb.sock`
+- default Windows endpoint: `tcp:127.0.0.1:37421`

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,8 @@ deeper by goal.
 - [Embedding profiles](./embedding-profiles.md) - shipped embedding profile metadata and defaults.
 - [Models](./models.md) - local ONNX model strategy and summarization roles.
 
-## Tune, Test, And Build
+## Advanced And Source Docs
 
-- [Performance and tuning](./performance-and-tuning.md) - resource expectations, tuning knobs, and LongMemEval harness.
+- [Performance and tuning](./performance-and-tuning.md) - resource expectations and tuning knobs.
 - [Development](./development.md) - source setup, local daemon builds, generated IPC files, and validation commands.
-- [Contributing](./contributing.md) - contributor expectations and gating-test invariants.
+- [Contributing](./contributing.md) - contributor workflow and repository expectations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,31 @@
-# Documentation Index
+# LibraVDB Memory Docs
 
-This index lists the public docs that remain in the main repo. Detailed math
-and private design notes are kept out of the public index on purpose.
+This directory holds the operational and design docs for the LibraVDB Memory
+OpenClaw plugin. The root README is the public entry point; these files go
+deeper by goal.
 
-- [installation.md](./installation.md) - Complete install, activation, verification, and troubleshooting reference.
-- [install.md](./install.md) - Practical lifecycle guide for Homebrew, the OpenClaw plugin, and manual daemon management.
-- [uninstall.md](./uninstall.md) - Clean shutdown and removal guide for the plugin, daemon, and optional local data.
-- [architecture.md](./architecture.md) - Public system overview covering the plugin, daemon, storage, retrieval, and compaction flow.
-- [problem.md](./problem.md) - Technical argument for replacing the stock OpenClaw memory lifecycle in this use case.
-- [dependencies.md](./dependencies.md) - Why LibraVDB and slab-based storage were chosen for this plugin.
-- [models.md](./models.md) - ONNX model strategy, latency trade-offs, and shipped model roles.
-- [security.md](./security.md) - Security model, untrusted-memory framing, isolation guarantees, and deletion boundaries.
-- [contributing.md](./contributing.md) - Contributor workflow, prerequisites, and invariant test expectations.
-- [architecture-decisions/README.md](./architecture-decisions/README.md) - Index of the repository ADRs.
-- [embedding-profiles.md](./embedding-profiles.md) - Shipped embedding profile baseline and current profile metadata.
+## Start Here
+
+- [Install](./install.md) - shortest supported install and daemon lifecycle path.
+- [Installation reference](./installation.md) - requirements, activation, verification, and troubleshooting.
+- [Uninstall](./uninstall.md) - safe disable, daemon shutdown, package removal, and optional data cleanup.
+
+## Understand The System
+
+- [Problem](./problem.md) - why this plugin replaces the stock memory lifecycle.
+- [Architecture](./architecture.md) - plugin, sidecar, storage, retrieval, and compaction overview.
+- [Dependency rationale](./dependencies.md) - why LibraVDB and slab-style storage fit this workload.
+- [Architecture decisions](./architecture-decisions/README.md) - accepted ADRs.
+
+## Configure And Operate
+
+- [Features](./features.md) - markdown ingestion, Obsidian ingestion, dream promotion, and memory CLI commands.
+- [Security](./security.md) - trust boundaries, untrusted-memory framing, collection isolation, and deletion limits.
+- [Embedding profiles](./embedding-profiles.md) - shipped embedding profile metadata and defaults.
+- [Models](./models.md) - local ONNX model strategy and summarization roles.
+
+## Tune, Test, And Build
+
+- [Performance and tuning](./performance-and-tuning.md) - resource expectations, tuning knobs, and LongMemEval harness.
+- [Development](./development.md) - source setup, local daemon builds, generated IPC files, and validation commands.
+- [Contributing](./contributing.md) - contributor expectations and gating-test invariants.

--- a/docs/assets/libravdb-logo.svg
+++ b/docs/assets/libravdb-logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="170" viewBox="0 0 1280 170" role="img" aria-labelledby="title desc">
+  <title id="title">LibraVDB</title>
+  <desc id="desc">Dark purple LibraVDB wordmark.</desc>
+  <rect width="1280" height="170" fill="none"/>
+  <text
+    x="640"
+    y="128"
+    text-anchor="middle"
+    fill="#5B21B6"
+    font-family="Inter, Avenir Next, Helvetica Neue, Arial, sans-serif"
+    font-size="150"
+    font-weight="800"
+    letter-spacing="0">LibraVDB</text>
+</svg>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,39 +20,16 @@ Use:
 bash scripts/build-daemon.sh
 ```
 
-## Gating Invariants
+## Behavioral Changes
 
-Do not weaken the gate invariants casually. The daemon-owned tests in
-`libravdbd/compact/gate_test.go` check structural properties:
-
-- empty-memory novelty
-- saturation veto
-- convex boundedness
-- conversational collapse at `T = 0`
-- technical collapse at `T = 1`
-- non-overfiring conversational structure on code
-
-If you add a new signal, it must preserve those invariants.
-
-## Calibration Coverage
-
-There is not yet a dedicated `gate_calibration_test.go` golden set in this
-repository. Current gating correctness is enforced by the invariant suite in
-`libravdbd/compact/gate_test.go`.
-
-If you introduce new signals or change weighting behavior, add one of:
-
-- a new invariant if the change alters a structural gate property
-- a calibration or golden test if the change adds labeled examples or expected
-  decompositions
-
-Do not rewrite expectations just to make regressions disappear.
+If you change retrieval, compaction, or ranking behavior, add or update the
+matching validation coverage and avoid weakening checks just to hide a
+regression.
 
 ## PR Expectations
 
 - Keep plugin lifecycle and daemon lifecycle separate.
 - Include focused docs updates for user-visible behavior or config changes.
-- Keep retrieval math and gating changes reflected in the appropriate design
-  notes.
+- Keep internal design changes reflected in the appropriate design notes.
 - Do not add install-time daemon bootstrap to the npm/OpenClaw package without
   documenting the security and distribution trade-off.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,50 +1,29 @@
 # Contributing
 
-## Prerequisites
+Use [Development](./development.md) for source setup, local daemon preparation,
+generated IPC files, and validation commands. This document covers contribution
+expectations.
 
-- Node.js `>= 22`
-- `pnpm`
-- OpenClaw CLI for end-to-end plugin testing
+## Baseline Checks
 
-## Core Validation Commands
-
-TypeScript and unit checks:
+Before opening a PR:
 
 ```bash
 pnpm check
-```
-
-Integration tests:
-
-```bash
 npm run test:integration
 ```
 
-Plugin integration tests:
-
-```bash
-npm run test:integration
-```
-
-## Local Daemon Build
+Integration tests require a running daemon or a prepared local daemon binary.
+Use:
 
 ```bash
 bash scripts/build-daemon.sh
 ```
 
-This prepares `.daemon-bin/libravdbd` for local plugin testing and copies locally available bundled assets into `.daemon-bin/`.
-
-Supported inputs:
-
-- installed daemon on `PATH` such as `brew install libravdbd`
-- `LIBRAVDBD_BINARY_PATH=/path/to/libravdbd`
-- `LIBRAVDBD_SOURCE_DIR=/path/to/libravdbd` to build from your private local daemon repo
-
-For daemon-internal Go development and release work, use the separate `libravdbd` repository.
-
 ## Gating Invariants
 
-Do not weaken the gate invariants casually. The daemon-owned tests in `libravdbd/compact/gate_test.go` check structural properties:
+Do not weaken the gate invariants casually. The daemon-owned tests in
+`libravdbd/compact/gate_test.go` check structural properties:
 
 - empty-memory novelty
 - saturation veto
@@ -57,32 +36,23 @@ If you add a new signal, it must preserve those invariants.
 
 ## Calibration Coverage
 
-There is not yet a dedicated `gate_calibration_test.go` golden set in the
+There is not yet a dedicated `gate_calibration_test.go` golden set in this
 repository. Current gating correctness is enforced by the invariant suite in
 `libravdbd/compact/gate_test.go`.
 
-If you introduce new signals or change weighting behavior, do not only update
-the implementation. Add one of:
+If you introduce new signals or change weighting behavior, add one of:
 
-- a new invariant if the change alters a structural property of the gate
-- a dedicated calibration/golden test file if the change adds new labeled
-  examples or expected decompositions
+- a new invariant if the change alters a structural gate property
+- a calibration or golden test if the change adds labeled examples or expected
+  decompositions
 
 Do not rewrite expectations just to make regressions disappear.
 
 ## PR Expectations
 
-Before opening a PR:
-
-- `pnpm check` must pass
-- plugin integration coverage must pass against a running daemon or a prepared local daemon binary
-- any new gating signal must come with calibration or invariant coverage
-- any retrieval math or gating change must be reflected in the private design notes
-
-## Release Versioning
-
-`package.json` is the source of truth for the release version.
-
-The release automation syncs `openclaw.plugin.json` from `package.json` during the
-auto-bump/tag flow, and the publish workflow refuses to publish if the Git tag,
-`package.json`, and `openclaw.plugin.json` versions do not all match.
+- Keep plugin lifecycle and daemon lifecycle separate.
+- Include focused docs updates for user-visible behavior or config changes.
+- Keep retrieval math and gating changes reflected in the appropriate design
+  notes.
+- Do not add install-time daemon bootstrap to the npm/OpenClaw package without
+  documenting the security and distribution trade-off.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,98 @@
+# Development
+
+This document covers source setup and repository maintenance tasks. For user
+installation, use [Install](./install.md).
+
+## Prerequisites
+
+- Node.js `>= 22`
+- `pnpm`
+- OpenClaw CLI for end-to-end plugin testing
+- a published or locally built `libravdbd` daemon for integration tests
+
+Go is only required when building the daemon from a local daemon checkout or
+regenerating Go gRPC stubs.
+
+## Source Setup
+
+```bash
+pnpm install
+pnpm check
+```
+
+`pnpm check` runs TypeScript validation and unit tests:
+
+```bash
+tsc --noEmit
+tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js
+```
+
+## Local Daemon Build
+
+Prepare `.daemon-bin/libravdbd` for local plugin testing:
+
+```bash
+bash scripts/build-daemon.sh
+```
+
+Supported inputs:
+
+- installed daemon on `PATH`, such as `brew install libravdbd`
+- `LIBRAVDBD_BINARY_PATH=/path/to/libravdbd`
+- `LIBRAVDBD_SOURCE_DIR=/path/to/libravdbd` to build from a local daemon repo
+
+For daemon-internal Go development and release work, use the separate
+`libravdbd` repository.
+
+## Validation Commands
+
+```bash
+pnpm check
+npm run test:integration
+```
+
+Benchmark and tuning commands are documented in
+[Performance and tuning](./performance-and-tuning.md).
+
+## Generated IPC Files
+
+The plugin imports generated IPC envelope and RPC payload classes from
+`src/generated/libravdb/ipc/v1/rpc_pb.js`.
+
+Those generated files are checked in and copied into `dist/generated/` during
+`npm run build`:
+
+```bash
+npm run build
+```
+
+Do not replace those imports with the older external
+`@xdarkicex/libravdb-contracts` path. The current package resolves generated
+types from this repository.
+
+## Proto Generation
+
+The repo also contains `api/proto/intelligence_kernel/v1/kernel.proto` and a
+small `Makefile` target for Go gRPC stub generation:
+
+```bash
+make proto
+```
+
+That target assumes Homebrew-style locations for `go`, `protoc`, and the Go
+plugins. Adjust the Makefile locally if your toolchain lives elsewhere.
+
+## Release Shape
+
+The npm package contains:
+
+- `README.md`
+- `HOOK.md`
+- `index.js`
+- `openclaw.plugin.json`
+- `package.json`
+- `docs/`
+- `dist/`
+
+The package is connect-only. It does not compile Go code, download models, or
+manage the daemon process during plugin installation.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,125 @@
+# Features
+
+This document covers optional plugin features that do not belong in the root
+README: markdown ingestion, Obsidian ingestion, dream promotion, and memory CLI
+commands.
+
+## Markdown Ingestion
+
+LibraVDB Memory can watch markdown roots and sync changed notes into vector
+memory without changing the sidecar RPC contract.
+
+The built-in source adapters are:
+
+- `generic` for OpenClaw-owned markdown, including stock files like `MEMORY.md`
+- `obsidian` for Obsidian vault roots, with tag-aware defaults
+
+Typical usage:
+
+- point `markdownIngestionRoots` at OpenClaw-owned markdown roots, such as
+  `.openclaw/skills/*/*.md` or a directory that contains `MEMORY.md`
+- enable the Obsidian adapter with `markdownIngestionObsidianEnabled: true` and
+  one or more vault roots
+- use include/exclude globs to narrow what gets watched
+
+Example:
+
+```json
+{
+  "plugins": {
+    "configs": {
+      "libravdb-memory": {
+        "markdownIngestionEnabled": true,
+        "markdownIngestionRoots": [
+          "/Users/<you>/.openclaw/memory"
+        ],
+        "markdownIngestionObsidianEnabled": true,
+        "markdownIngestionObsidianRoots": [
+          "/Users/<you>/Documents/Obsidian/Main"
+        ]
+      }
+    }
+  }
+}
+```
+
+Relevant config fields:
+
+| Field | Purpose |
+|---|---|
+| `markdownIngestionEnabled` | Enables or disables generic markdown ingestion. |
+| `markdownIngestionRoots` | Generic markdown roots to watch. |
+| `markdownIngestionInclude` | Optional include globs for generic roots. |
+| `markdownIngestionExclude` | Optional exclude globs for generic roots. |
+| `markdownIngestionCollection` | Target collection for generic markdown, default `global`. |
+| `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
+| `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
+| `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
+| `markdownIngestionObsidianInclude` | Optional include globs for Obsidian roots. |
+| `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots. |
+| `markdownIngestionObsidianDebounceMs` | Obsidian watch debounce window, default `150`. |
+
+By default, the Obsidian adapter auto-ingests notes that look like memory notes,
+using frontmatter tags or inline tags such as `#project`. The stock OpenClaw
+`MEMORY.md` file is always eligible through the generic adapter path.
+
+## Dream Promotion
+
+Dream promotion is an opt-in path for promoting vetted dream diary entries into
+a dedicated `dream:{userId}` collection.
+
+It does not use `MEMORY.md`. It expects a dream diary markdown file with
+candidate bullets under promotion-oriented headings such as `## Deep Sleep`.
+Each promoted bullet should include trailing metadata with the gating fields:
+
+```md
+- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}
+```
+
+Only bullets that satisfy the sidecar gates are inserted. The dream collection
+is isolated from normal `user:` and `global` retrieval by default, and dream
+phrasing in chat or search queries routes there automatically.
+
+Automatic diary watching:
+
+```json
+{
+  "plugins": {
+    "configs": {
+      "libravdb-memory": {
+        "dreamPromotionEnabled": true,
+        "dreamPromotionDiaryPath": "/Users/<you>/DREAMS.md",
+        "dreamPromotionUserId": "<userId>",
+        "dreamPromotionDebounceMs": 150
+      }
+    }
+  }
+}
+```
+
+Manual run:
+
+```bash
+openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
+```
+
+The manual command and watcher both use the same sidecar promotion RPC, so
+admission gates and provenance metadata are identical.
+
+## Memory CLI
+
+The plugin registers `openclaw memory` commands when the host exposes the plugin
+CLI API.
+
+| Command | Purpose |
+|---|---|
+| `openclaw memory status` | Show sidecar health, counts, active thresholds, and model readiness. |
+| `openclaw memory export --user-id <userId>` | Stream stored memories as newline-delimited JSON for one durable namespace. |
+| `openclaw memory export --session-key <sessionKey>` | Export a namespace derived from a session key. |
+| `openclaw memory flush --user-id <userId>` | Delete one durable user namespace after confirmation. |
+| `openclaw memory flush --session-key <sessionKey>` | Delete a namespace derived from a session key after confirmation. |
+| `openclaw memory journal --limit 50` | Inspect bounded lifecycle hints recorded by the sidecar. |
+| `openclaw memory dream-promote --user-id <userId> --dream-file <path>` | Promote vetted dream diary bullets. |
+
+Use `--yes` with `flush` only when you intentionally want to skip the
+confirmation prompt.

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,11 @@ LibraVDB Memory is a connect-only OpenClaw plugin. Install the plugin as a
 normal package, install `libravdbd` separately, and point the plugin at the
 daemon endpoint when you need a non-default location.
 
+OpenClaw compatibility note:
+
+- the plugin is currently only verified against OpenClaw `2026.4.23`
+- if you are running a different OpenClaw build, treat it as unverified until you test it locally
+
 For deeper operational detail, use the full
 [installation reference](./installation.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,10 @@ LibraVDB Memory is a connect-only OpenClaw plugin. Install the plugin as a
 normal package, install `libravdbd` separately, and point the plugin at the
 daemon endpoint when you need a non-default location.
 
+OpenClaw compatibility note:
+
+- the plugin is currently verified against OpenClaw `2026.4.23`
+
 For deeper operational detail, use the full
 [installation reference](./installation.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,11 +4,6 @@ LibraVDB Memory is a connect-only OpenClaw plugin. Install the plugin as a
 normal package, install `libravdbd` separately, and point the plugin at the
 daemon endpoint when you need a non-default location.
 
-OpenClaw compatibility note:
-
-- the plugin is currently only verified against OpenClaw `2026.4.23`
-- if you are running a different OpenClaw build, treat it as unverified until you test it locally
-
 For deeper operational detail, use the full
 [installation reference](./installation.md).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,10 @@ This is the full installation reference for
 Resource sizing and benchmark data live in
 [Performance and tuning](./performance-and-tuning.md).
 
+OpenClaw compatibility note:
+
+- the plugin is currently verified against OpenClaw `2026.4.23`
+
 ## Install Flow
 
 The published plugin package is connect-only. It installs TypeScript plugin code

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,11 @@ This is the full installation reference for
 Resource sizing and benchmark data live in
 [Performance and tuning](./performance-and-tuning.md).
 
+OpenClaw compatibility note:
+
+- the plugin is currently only verified against OpenClaw `2026.4.23`
+- if you are running a different OpenClaw build, treat it as unverified until you test it locally
+
 ## Install Flow
 
 The published plugin package is connect-only. It installs TypeScript plugin code

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,11 +18,6 @@ This is the full installation reference for
 Resource sizing and benchmark data live in
 [Performance and tuning](./performance-and-tuning.md).
 
-OpenClaw compatibility note:
-
-- the plugin is currently only verified against OpenClaw `2026.4.23`
-- if you are running a different OpenClaw build, treat it as unverified until you test it locally
-
 ## Install Flow
 
 The published plugin package is connect-only. It installs TypeScript plugin code

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,123 +1,30 @@
 # Installation Reference
 
-This document is the full installation reference for `@xdarkicex/openclaw-memory-libravdb`. For the short path, use the root [README.md](../README.md).
+This is the full installation reference for
+`@xdarkicex/openclaw-memory-libravdb`. For the shortest path, use
+[install.md](./install.md).
 
 ## System Requirements
 
-| Requirement | Minimum | Recommended | Notes |
-|---|---|---|---|
-| Node.js | `22.0.0` | Latest LTS | Enforced in [`package.json`](../package.json) `engines.node` |
-| OpenClaw | `2026.3.22` | Current stable | Pinned by [`package.json`](../package.json) `peerDependencies.openclaw`; this is the earliest local tag confirmed to expose `definePluginEntry`, `registerContextEngine`, `registerMemoryPromptSection`, and the base plugin API shape this repo uses. Newer hosts may also expose the optional `registerMemoryRuntime` seam, which this plugin now adopts when available |
-| Go | `1.22` | Latest stable | Required only for local daemon development, not for normal plugin install |
-| Disk | about `1 GB` free for default Nomic install | `2 GB+` if provisioning optional T5 and leaving room for DB growth | See Resource Requirements below |
-| RAM | about `512 MB` for embed-only runtime | `1 GB+` if optional T5 summarizer is provisioned | Based on local RSS measurements below |
-| OS | macOS, Linux, Windows | Current stable releases | Unix uses a local socket; Windows uses TCP loopback |
-| Architecture | `arm64`, `x64` | Match published daemon release assets | Current release matrix builds five daemon targets |
+| Requirement | Minimum | Notes |
+|---|---:|---|
+| Node.js | `22.0.0` | Enforced by `package.json` `engines.node`. |
+| OpenClaw | `2026.3.22` | Earliest supported host version for this plugin API shape. |
+| `libravdbd` | published daemon asset | Required for normal runtime. |
+| Go | `1.22` | Required only for local daemon development. |
+| OS | macOS, Linux, Windows | Unix uses a local socket; Windows uses TCP loopback. |
+| Architecture | `arm64`, `x64` | Must match the daemon release asset. |
 
-The published plugin install path is scanner-clean and connect-only. End users should not need Go to install the OpenClaw plugin itself.
+Resource sizing and benchmark data live in
+[Performance and tuning](./performance-and-tuning.md).
 
-## Resource Requirements
+## Install Flow
 
-The numbers in this section are either directly measured from the current local
-build on `2026-03-29` or explicitly labeled as estimates.
+The published plugin package is connect-only. It installs TypeScript plugin code
+and docs; it does not compile Go code, download model assets, or supervise the
+daemon.
 
-### Disk
-
-Measured locally from this checkout:
-
-- daemon binary: `7.7M`
-- bundled Nomic model directory: `523M`
-- bundled MiniLM fallback model directory: `87M`
-- optional T5 summarizer directory: `371M`
-- unpacked ONNX Runtime directory on macOS arm64: `44M`
-- ONNX Runtime archive download on macOS arm64: `9.5M`
-
-Practical footprints:
-
-- default quality-first install without optional T5:
-  about `575 MB` (`7.7M + 523M + 44M`)
-- install with optional T5 summarizer:
-  about `946 MB`
-
-Vector payload lower bounds for stored turns, derived from embedding dimension:
-
-- MiniLM `384d`: `384 * 4 = 1536 bytes` per vector
-- Nomic `768d`: `768 * 4 = 3072 bytes` per vector
-
-Estimated lower-bound vector payload for `10,000` stored turns:
-
-- MiniLM: about `15.4 MB`
-- Nomic: about `30.7 MB`
-
-These are lower bounds for vector payload only. Actual on-disk LibraVDB usage is
-higher because text, metadata, collection structure, and index state are stored
-as well.
-
-### Memory
-
-Measured locally on Apple M2, `2026-03-29`, by starting the daemon and reading
-RSS after startup:
-
-- idle RSS with Nomic embedding path loaded and no optional T5 summarizer:
-  about `271,872 KB` (`~266 MB`)
-- idle RSS with Nomic plus local ONNX T5 summarizer loaded:
-  about `515,312 KB` (`~503 MB`)
-
-Not yet bench-measured in the repo:
-
-- RSS during active inference
-- peak RSS during compaction of large clusters
-
-Current operational estimate:
-
-- embedding inference should remain close to the embed-only idle baseline plus
-  transient ONNX workspace allocation
-- optional T5 provisioning roughly doubles steady-state RSS
-
-### CPU
-
-Measured locally from the existing Go benchmark harness on Apple M2,
-`2026-03-29`:
-
-- MiniLM bundled query embedding: about `22.6 ms/op`
-- MiniLM onnx-local query embedding: about `16.3 ms/op`
-- Nomic onnx-local query embedding: about `43.7 ms/op`
-
-Measured locally from a one-off 40-query timing sample on Apple M2,
-`2026-03-29`:
-
-- Nomic query embedding `p50`: about `18.61 ms`
-- Nomic query embedding `p95`: about `24.19 ms`
-
-Measured locally from a one-off synthetic 50-turn compaction run using the
-current extractive summarizer and Nomic embeddings:
-
-- `50`-turn extractive compaction wall time: about `3175 ms`
-
-Not yet bench-measured in the repo:
-
-- equivalent Linux x64 embedding latency on a reference machine
-- `50`-turn compaction wall time through the optional ONNX T5 abstractive path
-
-### Network
-
-Setup downloads are front-loaded. After installation, the plugin is local-first.
-
-Current setup assets:
-
-- Nomic model: about `522 MB`
-- T5-small encoder: about `135 MB`
-- T5-small decoder: about `222 MB`
-- ONNX Runtime macOS arm64 archive: about `9.5 MB`
-
-After install, the plugin makes no required network calls for embedding or
-extractive compaction. The only optional runtime network path is:
-
-- `summarizerBackend = "ollama-local"` or another custom summarizer endpoint
-
-## Standard Install
-
-### Fastest Path on macOS
+Recommended macOS path:
 
 ```bash
 brew tap xDarkicex/homebrew-openclaw-libravdb-memory
@@ -126,85 +33,46 @@ brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-This is the preferred install flow for macOS users. It gives you a managed `libravdbd` service and a scanner-clean OpenClaw plugin package.
-
-### Plugin Package
-
-```bash
-openclaw plugins install @xdarkicex/openclaw-memory-libravdb
-```
-
-The plugin package installs as compiled OpenClaw runtime code without daemon bootstrap hooks.
-
-## Daemon Install
-
-Install and start `libravdbd` separately for the same user account that runs OpenClaw. The daemon owns the local DB engine and listens on a local endpoint.
-
-Default endpoints:
-
-- Homebrew on macOS: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
-- macOS/Linux user-local installs: `unix:$HOME/.clawdb/run/libravdb.sock`
-- Windows: `tcp:127.0.0.1:37421`
-
-If you run the daemon on a different endpoint, set `plugins.configs.libravdb-memory.sidecarPath` in `~/.openclaw/openclaw.json`.
-
-### Linux
-
-Recommended layout:
+Manual Linux sketch:
 
 ```bash
 mkdir -p ~/.local/bin ~/.config/systemd/user
 curl -L -o ~/.local/bin/libravdbd <published-libravdbd-binary-url>
 chmod +x ~/.local/bin/libravdbd
-cp <published-libravdbd-service-template> ~/.config/systemd/user/libravdbd.service
+curl -L -o ~/.config/systemd/user/libravdbd.service <published-libravdbd-service-template-url>
 systemctl --user enable --now libravdbd.service
+openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-Then verify:
-
-```bash
-systemctl --user status libravdbd.service
-openclaw memory status
-```
-
-### Homebrew / macOS
-
-Homebrew users should normally install from the published tap:
-
-```bash
-brew tap xDarkicex/homebrew-openclaw-libravdb-memory
-brew install libravdbd
-brew services start libravdbd
-```
-
-With `sidecarPath: "auto"`, Homebrew installs on Apple Silicon should resolve to:
+Windows uses a loopback TCP endpoint by default:
 
 ```text
-unix:/opt/homebrew/var/clawdb/run/libravdb.sock
+tcp:127.0.0.1:37421
 ```
 
-User-local installs still default to:
+This repository does not yet include a full Windows service-install walkthrough.
+Use the published Windows daemon asset under your preferred process supervisor
+or run `libravdbd serve` in a terminal for validation.
 
-```text
-unix:$HOME/.clawdb/run/libravdb.sock
+## Activation
+
+Assign `libravdb-memory` to both OpenClaw slots:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    }
+  }
+}
 ```
 
-The daemon release pipeline generates a publish-ready `libravdbd.rb` formula asset for release assets named:
+Treat partial assignment as a misconfiguration. This plugin is designed to own
+memory prompt injection and the context-engine lifecycle together.
 
-- `libravdbd-darwin-arm64`
-- `libravdbd-darwin-amd64`
-- `libravdbd-linux-amd64`
-- `libravdbd-linux-arm64`
-
-The generated Homebrew formula also stages the bundled ONNX Runtime archive, the shipped embedding profile assets, and the T5 summarizer bundle into the install prefix so the daemon can start without a separate manual asset unpack step.
-
-If your GitHub Actions configuration includes:
-
-- public tap repository `xDarkicex/homebrew-openclaw-libravdb-memory`
-
-then tagged releases also push the generated formula into `Formula/libravdbd.rb` in that tap repository automatically.
-
-Example plugin config:
+If the daemon uses a non-default endpoint, add `sidecarPath`:
 
 ```json
 {
@@ -222,42 +90,27 @@ Example plugin config:
 }
 ```
 
-## Expected Install Shape
+When `sidecarPath` is `"auto"`, macOS/Linux endpoint resolution checks:
 
-Expected successful plugin install shape:
+1. `LIBRAVDB_RPC_ENDPOINT`
+2. `$HOME/.clawdb/run/libravdb.sock`
+3. `/opt/homebrew/var/clawdb/run/libravdb.sock`
+4. `/usr/local/var/clawdb/run/libravdb.sock`
+5. fallback to `$HOME/.clawdb/run/libravdb.sock`
+
+## Default Paths
+
+| Platform | Default endpoint |
+|---|---|
+| macOS/Linux user-local | `unix:$HOME/.clawdb/run/libravdb.sock` |
+| macOS Homebrew Apple Silicon | `unix:/opt/homebrew/var/clawdb/run/libravdb.sock` |
+| Windows | `tcp:127.0.0.1:37421` |
+
+Default data path:
 
 ```text
-Installed plugin: libravdb-memory
+$HOME/.clawdb/data.libravdb
 ```
-
-## Activation
-
-The manifest declares `kind: "context-engine"` and the runtime registers the memory prompt and memory runtime surfaces in code. It is still intended to own both the `memory` and `contextEngine` slots together. Treat partial slot assignment as a misconfiguration.
-
-Add this to `~/.openclaw/openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
-    }
-  }
-}
-```
-
-Notes:
-
-- This plugin should own both `memory` and `contextEngine`. Do not assign only one of them.
-- The plugin id is `libravdb-memory`. The npm package name used at install time is `@xdarkicex/openclaw-memory-libravdb`.
-- On newer OpenClaw versions, the plugin also registers a memory runtime bridge so the built-in `memory_search` tool can query libraVDB through the same sidecar-backed retrieval path.
-- On newer OpenClaw versions, the plugin also listens for `before_reset` and `session_end` so it can send best-effort lifecycle hints into the sidecar.
-- Those hints are journaled internally by the sidecar and can be inspected with `openclaw memory journal` without exposing them to normal memory export or recall.
-- The journal keeps only a bounded number of newest entries. Override that cap with `plugins.configs.libravdb-memory.lifecycleJournalMaxEntries` if you need a different retention window.
-- The plugin does not currently register `registerMemoryFlushPlan`; transcript ingest and compaction remain owned by the context-engine lifecycle and the sidecar.
-
-Without a slot entry, OpenClaw's default memory can continue to run in parallel.
 
 ## Verification
 
@@ -274,6 +127,7 @@ Expected output shape:
 │ Sidecar            │ running                      │
 │ Turns stored       │ 0                            │
 │ Memories stored    │ 0                            │
+│ Lifecycle hints    │ 0                            │
 │ Gate threshold     │ 0.35                         │
 │ Abstractive model  │ ready | not provisioned      │
 │ Embedding profile  │ all-minilm-l6-v2             │
@@ -283,51 +137,10 @@ Expected output shape:
 
 Interpretation:
 
-- `Sidecar=running` means the local `libravdbd` daemon answered JSON-RPC `health`.
-- `Gate threshold=0.35` confirms the default gating scalar boundary is active.
-- `Abstractive model=not provisioned` is acceptable. The system degrades to extractive compaction.
-
-## Contributor Install
-
-For contributors working from a clone:
-
-```bash
-pnpm check
-bash scripts/build-daemon.sh
-```
-
-This prepares a local daemon binary in `.daemon-bin/libravdbd` (or `.exe` on Windows) and copies any locally available model/runtime assets there for testing.
-
-Contributor default:
-
-- install `libravdbd` separately with Homebrew or release assets, then run `bash scripts/build-daemon.sh`
-
-Private local daemon development:
-
-- set `LIBRAVDBD_SOURCE_DIR=/path/to/libravdbd` to build from your local daemon repo
-- or set `LIBRAVDBD_BINARY_PATH=/path/to/libravdbd` to use a prebuilt local daemon binary
-
-## User-Service Templates
-
-Published daemon installs include matching user-service templates:
-
-- Linux user service: `libravdbd.service`
-- macOS LaunchAgent: `com.xdarkicex.libravdbd.plist`
-
-Linux example:
-
-```bash
-mkdir -p ~/.config/systemd/user
-cp <published-libravdbd-service-template> ~/.config/systemd/user/libravdbd.service
-systemctl --user enable --now libravdbd.service
-```
-
-macOS example:
-
-1. Copy the published `com.xdarkicex.libravdbd.plist`
-2. Replace `__LIBRAVDBD_PATH__` and `__HOME__`
-3. Save it to `~/Library/LaunchAgents/com.xdarkicex.libravdbd.plist`
-4. Load it with `launchctl load ~/Library/LaunchAgents/com.xdarkicex.libravdbd.plist`
+- `Sidecar=running` means the daemon answered the health check.
+- `Gate threshold=0.35` confirms the default durable-memory gate.
+- `Abstractive model=not provisioned` is acceptable; compaction falls back to
+  the extractive path.
 
 ## Troubleshooting
 
@@ -335,47 +148,37 @@ macOS example:
 
 Common causes:
 
-- ONNX Runtime library missing or unpacked in the wrong place
-- downloaded model file hash mismatch
-- `libravdbd` not started for the current user
-- plugin pointed at the wrong endpoint
+- `libravdbd` is not running for the same user account as OpenClaw
+- `sidecarPath` points at the wrong endpoint
+- ONNX Runtime assets are missing or unpacked in the wrong place
+- a model asset failed checksum validation
 
-Check:
+Check the daemon first:
 
 ```bash
 openclaw memory status
+brew services restart libravdbd
 ```
 
-If the daemon is down, start it and verify the configured endpoint:
-
-```bash
-brew services start libravdbd
-```
-
-Or, without Homebrew:
+For foreground debugging:
 
 ```bash
 libravdbd serve
 ```
 
-On macOS/Linux, the default endpoint is `unix:$HOME/.clawdb/run/libravdb.sock`. On Windows, the default endpoint is `tcp:127.0.0.1:37421`.
-
 ### Hash mismatch
 
-Hash mismatch means one of:
+Do not bypass a checksum mismatch. Delete the corrupt or stale asset and rerun
+setup, or republish the release with corrected checksums.
 
-- the daemon asset is corrupt
-- the local cache is stale
-- the expected checksum is wrong
+### Default memory still appears active
 
-Do not bypass this. Delete the asset and rerun setup, or republish the release with corrected checksums.
+Confirm that `libravdb-memory` is assigned to both `memory` and
+`contextEngine`. Without both slot entries, OpenClaw's default memory path can
+continue to run in parallel.
 
-### Windows behavior
+### Lifecycle journal looks empty
 
-On Windows the daemon uses a loopback TCP endpoint instead of a Unix socket. This is expected. The plugin’s transport layer already handles the fallback.
-
-### Published daemon requirement
-
-The daemon must come from a published `libravdbd` binary for the current platform.
-If that download or checksum verification fails, setup stops instead of falling
-back to a local `go build`.
+The sidecar journal only records advisory lifecycle hints such as `before_reset`
+and `session_end`. It is bounded by `lifecycleJournalMaxEntries`, default `500`,
+and is not part of normal memory recall.

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,63 +1,54 @@
 # Model Strategy
 
-## Why ONNX Over Ollama
+The plugin uses local ONNX-first inference for embeddings and optional
+abstractive summarization. That keeps prompt assembly local, predictable, and
+available offline after assets are installed.
 
-The plugin uses ONNX-first local inference for embedding and optional abstractive summarization.
+## Why ONNX Over Ollama For The Critical Path
 
-### Latency
+`assemble` runs before each response build. An embedding request that crosses a
+process and HTTP server boundary adds avoidable tail latency. Local ONNX
+inference inside the sidecar keeps retrieval close to the database and avoids a
+runtime dependency on a separate model server.
 
-`assemble` is on the critical path before every response build. An embedding request that crosses process and HTTP boundaries adds avoidable tail latency. Local ONNX inference inside the sidecar keeps the retrieval path in the low-millisecond range on the target hardware profile.
-`assemble` is on the critical path before every response build. An embedding
-request that crosses process and HTTP boundaries adds avoidable tail latency.
-Local ONNX inference inside the sidecar keeps the retrieval path local and
-predictable. On the current Apple M2 development machine, the repository's own
-benchmark harness measures roughly `16-23 ms/op` for MiniLM query embeddings and
-about `44 ms/op` for Nomic in the steady-state Go benchmark path.
+ONNX assets can be provisioned once and reused without network access. Given
+fixed weights and input, embeddings are deterministic enough for stable
+similarity ordering and reproducible retrieval behavior.
 
-### Offline Operation
+The trade-off is artifact size. This project accepts that cost because local
+latency and offline operation are part of the product contract.
 
-The plugin is designed to be local-first. Requiring a running Ollama server would break that guarantee. ONNX assets can be provisioned once and reused without network or daemon availability.
+## Default And Optional Embedding Profiles
 
-### Determinism
+The current safe default profile is `all-minilm-l6-v2`.
 
-ONNX inference is deterministic given fixed weights and input. Deterministic embeddings give stable similarity ordering and reproducible retrieval behavior.
+MiniLM is the default because it keeps local retrieval within the target memory
+envelope on macOS and is less fragile with ONNX Runtime execution than larger
+profiles.
 
-### Binary Size Trade-Off
+`nomic-embed-text-v1.5` remains available as an explicit opt-in profile for
+long-context retrieval experiments. Nomic's Matryoshka training makes
+`64d -> 256d -> 768d` tiering principled rather than arbitrary truncation, but
+its larger footprint makes it a less conservative default.
 
-Local models increase the artifact footprint. That is an explicit trade-off accepted by the architecture because predictable latency and offline operation are more important for this plugin than minimal package size.
+For exact profile metadata, read [Embedding profiles](./embedding-profiles.md).
 
-## Why `nomic-embed-text-v1.5`
+## Summarization
 
-This is the default embedding profile because it earned the role on two axes:
+Compaction can run without an abstractive summarizer. When the optional T5-small
+assets are not provisioned, the daemon degrades to the extractive path.
 
-- long-context document support
-- Matryoshka structure for tiered retrieval
+T5-small is the optional local abstractive summarizer because it is small enough
+for CPU-local operation while still useful for session-cluster summaries. Larger
+generative models would increase latency and operational complexity.
 
-The model’s Matryoshka training is what makes the `64d -> 256d -> 768d` cascade principled rather than arbitrary truncation.
+## Model Roles
 
-## Why `all-minilm-l6-v2` Still Exists
+| Model/profile | Role |
+|---|---|
+| `all-minilm-l6-v2` | Default lightweight embedding profile. |
+| `nomic-embed-text-v1.5` | Opt-in long-context embedding profile. |
+| T5-small | Optional local abstractive compaction summarizer. |
 
-MiniLM remains the lightweight fallback profile. It is useful when:
-
-- the full Nomic profile is unavailable
-- a smaller bundled footprint matters more than long-context or Matryoshka behavior
-
-It is no longer the quality-first default.
-
-## Why T5-small for Summarization
-
-The abstractive summarization path is optional and must remain CPU-feasible on local machines. T5-small fits that constraint better than larger generative models:
-
-- small enough to run locally
-- expressive enough for session-cluster summarization
-- does not require a remote server
-
-The plugin still degrades gracefully to extractive compaction when the T5 assets are not provisioned.
-
-## Model Roles in the System
-
-- Nomic embedder: quality-first retrieval path, Matryoshka tiers
-- MiniLM: fallback embedder
-- T5-small: optional higher-quality compaction summarizer
-
-The model strategy is therefore not “use ONNX everywhere because ONNX is fashionable.” It is “use ONNX where local deterministic inference is part of the product contract.”
+External summarizer endpoints, such as Ollama, are optional. They are not part
+of the required retrieval path.

--- a/docs/performance-and-tuning.md
+++ b/docs/performance-and-tuning.md
@@ -1,0 +1,145 @@
+# Performance And Tuning
+
+This document keeps resource sizing, tuning knobs, and benchmark workflows out
+of the root README.
+
+## Resource Expectations
+
+The numbers below are local measurements from this repository as of
+`2026-03-29`, unless labeled as estimates.
+
+### Disk
+
+Measured local asset sizes:
+
+- daemon binary: `7.7M`
+- bundled Nomic model directory: `523M`
+- bundled MiniLM fallback model directory: `87M`
+- optional T5 summarizer directory: `371M`
+- unpacked ONNX Runtime directory on macOS arm64: `44M`
+- ONNX Runtime archive download on macOS arm64: `9.5M`
+
+Vector payload lower bounds:
+
+- MiniLM `384d`: `384 * 4 = 1536 bytes` per vector
+- Nomic `768d`: `768 * 4 = 3072 bytes` per vector
+
+Estimated lower-bound vector payload for `10,000` stored turns:
+
+- MiniLM: about `15.4 MB`
+- Nomic: about `30.7 MB`
+
+Actual on-disk LibraVDB usage is higher because text, metadata, collection
+structure, and index state are stored as well.
+
+### Memory
+
+Measured on Apple M2 by starting the daemon and reading RSS after startup:
+
+- Nomic embedding path loaded without optional T5 summarizer: about `266 MB`
+- Nomic plus local ONNX T5 summarizer loaded: about `503 MB`
+
+Not yet bench-measured in this repo:
+
+- RSS during active inference
+- peak RSS during compaction of large clusters
+
+### CPU
+
+Measured from the current Go benchmark harness on Apple M2:
+
+- MiniLM bundled query embedding: about `22.6 ms/op`
+- MiniLM onnx-local query embedding: about `16.3 ms/op`
+- Nomic onnx-local query embedding: about `43.7 ms/op`
+
+Measured from a one-off 40-query timing sample on Apple M2:
+
+- Nomic query embedding `p50`: about `18.61 ms`
+- Nomic query embedding `p95`: about `24.19 ms`
+
+Measured from a one-off synthetic 50-turn compaction run with the current
+extractive summarizer and Nomic embeddings:
+
+- `50`-turn extractive compaction wall time: about `3175 ms`
+
+Not yet bench-measured:
+
+- equivalent Linux x64 embedding latency on a reference machine
+- `50`-turn compaction wall time through the optional ONNX T5 abstractive path
+
+## Runtime Tuning Fields
+
+Prefer the defaults unless you are measuring a specific problem. These fields
+are advanced controls, not required install settings.
+
+| Field | Effect |
+|---|---|
+| `topK` | Search result budget before prompt fitting. |
+| `alpha`, `beta`, `gamma` | Hybrid scoring weights for similarity, scope, and recency-style signals. |
+| `ingestionGateThreshold` | Durable-memory promotion threshold, default `0.35`. |
+| `gatingWeights` | Domain-adaptive admission weights for conversational and technical memory. |
+| `gatingTechNorm` | Normalization control for the technical-content gate. |
+| `gatingCentroidK` | Number of centroid candidates used by the gate. |
+| `compactionQualityWeight` | How much summary confidence affects retrieval score, default `0.5`. |
+| `recencyLambdaSession` | Session-memory recency decay. |
+| `recencyLambdaUser` | Durable user-memory recency decay. |
+| `recencyLambdaGlobal` | Global-memory recency decay. |
+| `tokenBudgetFraction` | Fraction of host context budget available to memory assembly. |
+| `compactThreshold` | Explicit compaction trigger threshold. |
+| `compactionThresholdFraction` | Dynamic trigger ratio when `compactThreshold` is unset, default `0.8`. |
+| `compactSessionTokenBudget` | Auto-compaction budget since the last compaction, default `2000`; set `0` to disable. |
+| `rpcTimeoutMs` | Sidecar RPC timeout, default `30000`. |
+| `maxRetries` | Retry budget for sidecar RPC calls. |
+| `logLevel` | Plugin log level. |
+
+Model-related fields live in [Embedding profiles](./embedding-profiles.md) and
+[Models](./models.md).
+
+## LongMemEval Harness
+
+The repository includes a local LongMemEval harness that runs the dataset
+through the plugin layer and checks whether the assembled prompt still contains
+the evidence turns.
+
+The benchmark runner is committed, but the dataset and generated reports are
+not. Keep downloaded data and local outputs under `benchmarks/longmemeval/`,
+which is ignored by default.
+
+Run it with:
+
+```bash
+LONGMEMEVAL_DATA_FILE=/path/to/longmemeval_oracle.json pnpm run benchmark:longmemeval
+```
+
+If you already have a daemon running and do not want the benchmark to spawn
+another one, set:
+
+```bash
+LONGMEMEVAL_USE_EXISTING_DAEMON=1 \
+LONGMEMEVAL_SIDECAR_PATH=unix:/path/to/libravdb.sock \
+pnpm run benchmark:longmemeval
+```
+
+Optional controls:
+
+- `LONGMEMEVAL_LIMIT` caps the number of questions
+- `LONGMEMEVAL_TOPK` changes the search budget
+- `LONGMEMEVAL_OUT_FILE` writes JSONL records for analysis
+
+The harness writes JSONL incrementally, so partial results survive if a
+transient daemon failure interrupts a long run. If the local test daemon drops
+mid-run, the benchmark restarts it and retries the current instance once before
+recording an error result.
+
+To score a hypothesis JSONL file with the official LongMemEval evaluator:
+
+```bash
+LONGMEMEVAL_EVAL_REPO=/path/to/LongMemEval \
+LONGMEMEVAL_HYPOTHESIS_FILE=/path/to/hypotheses.jsonl \
+LONGMEMEVAL_DATA_FILE=/path/to/longmemeval_oracle.json \
+OPENAI_API_KEY=... \
+pnpm run benchmark:longmemeval:score
+```
+
+The scorer wrapper shells out to the official Python evaluation script and then
+prints aggregate metrics from the generated log when available.


### PR DESCRIPTION
## Summary
- Rework the root README into a shorter OpenClaw-style entry point with logo, dynamic release badge, install path, highlights, and docs-by-goal links
- Split specialized material into focused docs for features, performance/tuning, and development
- Tighten installation, model, contributing, and docs index pages around their specific purposes

## Verification
- Checked relative markdown links
- Ran `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`

Note: local rendered preview files under `docs/assets/readme-render*` were used for review only and are not included in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured main README into a docs-portal landing page with goal-based navigation.
  * Added development setup and validation guide and simplified contributor guidance.
  * Added feature docs for Markdown ingestion, dream promotion, and CLI commands.
  * Added performance and tuning guide with LongMemEval benchmarking.
  * Simplified installation guide and added a verified OpenClaw version note.
  * Streamlined models doc with clarified embedding and summarization profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->