### PR TITLE
feat: add memory slot check and migrate to registerMemoryCapability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ type CliProgram = CliCommand;
 
 export function registerMemoryCli(
   api: OpenClawPluginApi,
-  runtime: PluginRuntime,
+  runtime: PluginRuntime | null,
   cfg: PluginConfig,
   logger: LoggerLike = console,
 ): void {
@@ -64,10 +64,23 @@ export function registerMemoryCli(
     return;
   }
 
+  const isFullMode = runtime !== null;
+
   api.registerCli(
     ({ program }) => {
       const root = ensureCommand(program, "memory")
         .description("Manage LibraVDB memory");
+
+      if (!isFullMode) {
+        // cli-metadata mode: register structure only so `openclaw memory --help` works.
+        // No runtime available — do not attach action handlers.
+        ensureCommand(root, "status").description("Show sidecar health, record counts, and active thresholds");
+        ensureCommand(root, "flush").description("Wipe a durable memory namespace after confirmation");
+        ensureCommand(root, "export").description("Stream stored memories as newline-delimited JSON");
+        ensureCommand(root, "journal").description("Inspect internal lifecycle journal hints");
+        ensureCommand(root, "dream-promote").description("Promote vetted dream diary entries into the dedicated dream collection");
+        return;
+      }
 
       ensureCommand(root, "status")
         .description("Show sidecar health, record counts, and active thresholds")

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,15 +10,9 @@ import { createRecallCache } from "./recall-cache.js";
 import { createPluginRuntime } from "./plugin-runtime.js";
 import type { PluginConfig, SearchResult } from "./types.js";
 
-const MEMORY_ID = "libravdb-memory";
+export const MEMORY_ID = "libravdb-memory";
 
-export default definePluginEntry({
-  id: "libravdb-memory",
-  name: "LibraVDB Memory",
-  description: "Persistent vector memory with three-tier hybrid scoring",
-  kind: ["memory", "context-engine"],
-
-  register(api: OpenClawPluginApi) {
+export function register(api: OpenClawPluginApi) {
     const isFullMode = (api.registrationMode as string) === "full";
     const cfg = api.pluginConfig as PluginConfig;
 
@@ -49,13 +43,13 @@ export default definePluginEntry({
     }
 
     // Migrated from three legacy calls to a single registerMemoryCapability.
-    api.registerMemoryCapability("libravdb-memory", {
+    api.registerMemoryCapability(MEMORY_ID, {
       promptBuilder: buildMemoryPromptSection(runtime.getRpc, cfg, recallCache),
       runtime: buildMemoryRuntimeBridge(runtime.getRpc, cfg),
     });
 
     api.registerContextEngine(
-      "libravdb-memory",
+      MEMORY_ID,
       () => buildContextEngineFactory(runtime, cfg, recallCache, api.logger ?? console),
     );
 
@@ -76,5 +70,13 @@ export default definePluginEntry({
       await markdownIngestion.stop();
       await runtime.shutdown();
     });
-  },
+  }
+
+export default definePluginEntry({
+  id: MEMORY_ID,
+  name: "LibraVDB Memory",
+  description: "Persistent vector memory with three-tier hybrid scoring",
+  kind: ["memory", "context-engine"],
+
+  register,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { createRecallCache } from "./recall-cache.js";
 import { createPluginRuntime } from "./plugin-runtime.js";
 import type { PluginConfig, SearchResult } from "./types.js";
 
+const MEMORY_ID = "libravdb-memory";
+
 export default definePluginEntry({
   id: "libravdb-memory",
   name: "LibraVDB Memory",
@@ -17,38 +19,36 @@ export default definePluginEntry({
   kind: ["memory", "context-engine"],
 
   register(api: OpenClawPluginApi) {
-    // Gate all heavy runtime work on "full" mode.
-    // This prevents sidecar startup, RPC calls, and exclusive API registration
-    // from firing during lightweight modes like `openclaw --help` (cli-metadata).
     const isFullMode = (api.registrationMode as string) === "full";
+    const cfg = api.pluginConfig as PluginConfig;
+
+    // Null in non-full mode — cli.ts skips action handlers when runtime is null.
+    const runtimeOrNull = isFullMode
+      ? createPluginRuntime(cfg, api.logger ?? console)
+      : null;
+    registerMemoryCli(api, runtimeOrNull, cfg, api.logger ?? console);
+
     if (!isFullMode) return;
 
-    const cfg = api.pluginConfig as PluginConfig;
+    // TypeScript can't narrow through the ternary, so re-bind and guard.
+    const runtime = runtimeOrNull;
+    if (!runtime) return; // unreachable but satisfies the type checker
+
+    const recallCache = createRecallCache<SearchResult>();
 
     // Exclusive slot check: refuse to register if another plugin owns the memory slot.
     // plugins.slots.memory is the only configurable slot; context engine exclusivity
     // is enforced by the registry at runtime (no config surface for it).
+    // "none" means memory is disabled — not a conflict, allow registration.
     const memSlot = api.config?.plugins?.slots?.memory;
-    if (memSlot && memSlot !== "libravdb-memory") {
+    if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {
       throw new Error(
         `[libravdb-memory] plugins.slots.memory is "${memSlot}". ` +
         `Set it to "libravdb-memory" before enabling this plugin.`,
       );
     }
 
-    const recallCache = createRecallCache<SearchResult>();
-    const runtime = createPluginRuntime(cfg, api.logger ?? console);
-
-    // CLI commands are registered below via registerMemoryCli (calls api.registerCli
-    // internally). That call happens here in full mode too, which is fine — CLI
-    // registration is cheap and safe to repeat.
-
-    registerMemoryCli(api, runtime, cfg, api.logger ?? console);
-
     // Migrated from three legacy calls to a single registerMemoryCapability.
-    // The underlying builders (buildMemoryPromptSection, buildMemoryRuntimeBridge)
-    // return types that structurally match MemoryPluginCapability fields exactly,
-    // so zero behavior change — just grouping.
     api.registerMemoryCapability("libravdb-memory", {
       promptBuilder: buildMemoryPromptSection(runtime.getRpc, cfg, recallCache),
       runtime: buildMemoryRuntimeBridge(runtime.getRpc, cfg),
@@ -59,8 +59,6 @@ export default definePluginEntry({
       () => buildContextEngineFactory(runtime, cfg, recallCache, api.logger ?? console),
     );
 
-    // Start background services (markdown ingestion + dream promotion).
-    // Failures are non-fatal — log and continue so the plugin remains usable.
     const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getRpc, api.logger ?? console);
     const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getRpc, api.logger ?? console);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,50 @@ export default definePluginEntry({
   kind: ["memory", "context-engine"],
 
   register(api: OpenClawPluginApi) {
+    // Gate all heavy runtime work on "full" mode.
+    // This prevents sidecar startup, RPC calls, and exclusive API registration
+    // from firing during lightweight modes like `openclaw --help` (cli-metadata).
+    const isFullMode = (api.registrationMode as string) === "full";
+    if (!isFullMode) return;
+
     const cfg = api.pluginConfig as PluginConfig;
+
+    // Exclusive slot check: refuse to register if another plugin owns the memory slot.
+    // plugins.slots.memory is the only configurable slot; context engine exclusivity
+    // is enforced by the registry at runtime (no config surface for it).
+    const memSlot = api.config?.plugins?.slots?.memory;
+    if (memSlot && memSlot !== "libravdb-memory") {
+      throw new Error(
+        `[libravdb-memory] plugins.slots.memory is "${memSlot}". ` +
+        `Set it to "libravdb-memory" before enabling this plugin.`,
+      );
+    }
+
     const recallCache = createRecallCache<SearchResult>();
     const runtime = createPluginRuntime(cfg, api.logger ?? console);
+
+    // CLI commands are registered below via registerMemoryCli (calls api.registerCli
+    // internally). That call happens here in full mode too, which is fine — CLI
+    // registration is cheap and safe to repeat.
+
+    registerMemoryCli(api, runtime, cfg, api.logger ?? console);
+
+    // Migrated from three legacy calls to a single registerMemoryCapability.
+    // The underlying builders (buildMemoryPromptSection, buildMemoryRuntimeBridge)
+    // return types that structurally match MemoryPluginCapability fields exactly,
+    // so zero behavior change — just grouping.
+    api.registerMemoryCapability("libravdb-memory", {
+      promptBuilder: buildMemoryPromptSection(runtime.getRpc, cfg, recallCache),
+      runtime: buildMemoryRuntimeBridge(runtime.getRpc, cfg),
+    });
+
+    api.registerContextEngine(
+      "libravdb-memory",
+      () => buildContextEngineFactory(runtime, cfg, recallCache, api.logger ?? console),
+    );
+
+    // Start background services (markdown ingestion + dream promotion).
+    // Failures are non-fatal — log and continue so the plugin remains usable.
     const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getRpc, api.logger ?? console);
     const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getRpc, api.logger ?? console);
 
@@ -30,12 +71,6 @@ export default definePluginEntry({
       api.logger?.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
     });
 
-    registerMemoryCli(api, runtime, cfg, api.logger ?? console);
-    api.registerContextEngine("libravdb-memory", () =>
-      buildContextEngineFactory(runtime, cfg, recallCache, api.logger ?? console),
-    );
-    api.registerMemoryPromptSection(buildMemoryPromptSection(runtime.getRpc, cfg, recallCache));
-    api.registerMemoryRuntime?.(buildMemoryRuntimeBridge(runtime.getRpc, cfg));
     api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
     api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
     api.on("gateway_stop", async () => {

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -50,7 +50,7 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       promptBuilder?: MemoryPromptSectionBuilder;
       runtime?: unknown;
     }): void;
-    registerMemoryPromptSection(builder: MemoryPromptSectionBuilder): void;
+    registerMemoryPromptSection?(builder: MemoryPromptSectionBuilder): void;
     registerMemoryFlushPlan?(resolver: unknown): void;
     registerMemoryRuntime?(runtime: unknown): void;
     registerMemoryEmbeddingProvider?(provider: unknown): void;

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -14,8 +14,31 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
     name?(): string;
   }
 
+  // Minimal structural types for the fields we use
+  interface PluginsSlots {
+    memory?: string;
+  }
+
+  interface PluginsConfig {
+    slots?: PluginsSlots;
+  }
+
+  interface OpenClawConfig {
+    plugins?: PluginsConfig;
+  }
+
+  type PluginRegistrationMode = string;
+
   export interface OpenClawPluginApi {
-    pluginConfig: unknown;
+    id: string;
+    name: string;
+    version?: string;
+    description?: string;
+    source: string;
+    rootDir?: string;
+    registrationMode: PluginRegistrationMode;
+    config: OpenClawConfig;
+    pluginConfig: Record<string, unknown>;
     logger?: {
       debug?(message: string): void;
       error(message: string): void;
@@ -23,6 +46,10 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       warn?(message: string): void;
     };
     registerContextEngine(id: string, factory: () => unknown): void;
+    registerMemoryCapability(id: string, capability: {
+      promptBuilder?: MemoryPromptSectionBuilder;
+      runtime?: unknown;
+    }): void;
     registerMemoryPromptSection(builder: MemoryPromptSectionBuilder): void;
     registerMemoryFlushPlan?(resolver: unknown): void;
     registerMemoryRuntime?(runtime: unknown): void;

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Test the slot check behavior in src/index.ts register() logic.
+// We isolate the exact checks to verify they behave correctly.
+
+const MEMORY_ID = "libravdb-memory";
+
+function makeSlotCheck(cfg: {
+  registrationMode?: string;
+  slotsMemory?: string;
+}): { memSlot: string | undefined; isFullMode: boolean } {
+  const api = {
+    registrationMode: cfg.registrationMode ?? "full",
+    config: {
+      plugins: {
+        slots: {
+          memory: cfg.slotsMemory,
+        },
+      },
+    },
+  };
+  const memSlot = api.config?.plugins?.slots?.memory;
+  const isFullMode = (api.registrationMode as string) === "full";
+  return { memSlot, isFullMode };
+}
+
+test("slot check — ours: passes (does not throw)", () => {
+  const { memSlot } = makeSlotCheck({ slotsMemory: "libravdb-memory" });
+  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
+  assert.ok(!wouldThrow, "should not throw when slot is libravdb-memory");
+});
+
+test("slot check — other plugin: throws", () => {
+  const { memSlot } = makeSlotCheck({ slotsMemory: "memory-lancedb" });
+  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
+  assert.ok(wouldThrow, "should throw when slot is taken by memory-lancedb");
+});
+
+test("slot check — unset: passes (no conflict)", () => {
+  const { memSlot } = makeSlotCheck({ slotsMemory: undefined });
+  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
+  assert.ok(!wouldThrow, "should not throw when slot is unset");
+});
+
+test("slot check — 'none': passes (memory disabled)", () => {
+  const { memSlot } = makeSlotCheck({ slotsMemory: "none" });
+  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
+  assert.ok(!wouldThrow, "should not throw when slot is 'none' (memory disabled)");
+});
+
+test("registrationMode gate — 'full' allows registration", () => {
+  const { isFullMode } = makeSlotCheck({ registrationMode: "full" });
+  assert.ok(isFullMode, "full mode should allow registration");
+});
+
+test("registrationMode gate — 'cli-metadata' blocks registration", () => {
+  const { isFullMode } = makeSlotCheck({ registrationMode: "cli-metadata" });
+  assert.ok(!isFullMode, "cli-metadata mode should block registration");
+});
+
+test("registrationMode gate — 'setup-only' blocks registration", () => {
+  const { isFullMode } = makeSlotCheck({ registrationMode: "setup-only" });
+  assert.ok(!isFullMode, "setup-only mode should block registration");
+});
+
+test("combined — cli-metadata with other slot: still blocked by mode gate first", () => {
+  // In register(), the mode check happens before the slot check.
+  // When mode is not "full", we return early — slot check never runs.
+  const { isFullMode, memSlot } = makeSlotCheck({
+    registrationMode: "cli-metadata",
+    slotsMemory: "memory-lancedb",
+  });
+  assert.ok(!isFullMode, "mode gate blocks first");
+  // If mode gate passes (full), slot check would run:
+  const slotWouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
+  assert.ok(slotWouldThrow, "slot is correctly detected as conflicting");
+});

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -1,78 +1,104 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-// Test the slot check behavior in src/index.ts register() logic.
-// We isolate the exact checks to verify they behave correctly.
+// Import the real register function from src/index.ts so tests actually
+// exercise the production code path.
+import { register, MEMORY_ID } from "../../src/index.js";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
-const MEMORY_ID = "libravdb-memory";
-
-function makeSlotCheck(cfg: {
+/** Builds a fake OpenClawPluginApi for register(). */
+function makeFakeApi(overrides: {
   registrationMode?: string;
   slotsMemory?: string;
-}): { memSlot: string | undefined; isFullMode: boolean } {
-  const api = {
-    registrationMode: cfg.registrationMode ?? "full",
+} = {}): OpenClawPluginApi {
+  return {
+    id: "test-plugin",
+    name: "Test",
+    description: "",
+    source: "test",
+    registrationMode: overrides.registrationMode ?? "full",
     config: {
       plugins: {
         slots: {
-          memory: cfg.slotsMemory,
+          memory: overrides.slotsMemory,
         },
       },
     },
-  };
-  const memSlot = api.config?.plugins?.slots?.memory;
-  const isFullMode = (api.registrationMode as string) === "full";
-  return { memSlot, isFullMode };
+    pluginConfig: {},
+    logger: {
+      error(_msg: string) {},
+      warn(_msg: string) {},
+      info(_msg: string) {},
+    },
+    registerMemoryCapability(_id: string, _cap: unknown) {},
+    registerContextEngine(_id: string, _factory: () => unknown) {},
+    on(_event: string, _handler: unknown) {},
+  } as unknown as OpenClawPluginApi;
 }
 
-test("slot check — ours: passes (does not throw)", () => {
-  const { memSlot } = makeSlotCheck({ slotsMemory: "libravdb-memory" });
-  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
-  assert.ok(!wouldThrow, "should not throw when slot is libravdb-memory");
+// slot: "libravdb-memory" — no conflict, should not throw
+test("slot check — ours: register succeeds", () => {
+  const api = makeFakeApi({ slotsMemory: "libravdb-memory" });
+  assert.doesNotThrow(() => register(api), "should not throw when slot is libravdb-memory");
 });
 
-test("slot check — other plugin: throws", () => {
-  const { memSlot } = makeSlotCheck({ slotsMemory: "memory-lancedb" });
-  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
-  assert.ok(wouldThrow, "should throw when slot is taken by memory-lancedb");
+// slot: another plugin — should throw with slot name in message
+test("slot check — other plugin: register throws", () => {
+  const api = makeFakeApi({ slotsMemory: "memory-lancedb" });
+  assert.throws(
+    () => register(api),
+    /memory-lancedb/,
+    "error message should name the conflicting plugin",
+  );
+  assert.throws(
+    () => register(api),
+    /libravdb-memory/,
+    "error message should name this plugin",
+  );
 });
 
-test("slot check — unset: passes (no conflict)", () => {
-  const { memSlot } = makeSlotCheck({ slotsMemory: undefined });
-  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
-  assert.ok(!wouldThrow, "should not throw when slot is unset");
+// slot: undefined — nobody owns it, should not throw
+test("slot check — unset: register succeeds", () => {
+  const api = makeFakeApi({ slotsMemory: undefined });
+  assert.doesNotThrow(() => register(api), "should not throw when slot is unset");
 });
 
-test("slot check — 'none': passes (memory disabled)", () => {
-  const { memSlot } = makeSlotCheck({ slotsMemory: "none" });
-  const wouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
-  assert.ok(!wouldThrow, "should not throw when slot is 'none' (memory disabled)");
+// slot: "none" — memory disabled, should not throw
+test("slot check — 'none': register succeeds", () => {
+  const api = makeFakeApi({ slotsMemory: "none" });
+  assert.doesNotThrow(() => register(api), "should not throw when slot is 'none'");
 });
 
+// registrationMode: "full" — registration proceeds
 test("registrationMode gate — 'full' allows registration", () => {
-  const { isFullMode } = makeSlotCheck({ registrationMode: "full" });
-  assert.ok(isFullMode, "full mode should allow registration");
+  const api = makeFakeApi({ registrationMode: "full", slotsMemory: "libravdb-memory" });
+  assert.doesNotThrow(() => register(api), "full mode should allow registration");
 });
 
-test("registrationMode gate — 'cli-metadata' blocks registration", () => {
-  const { isFullMode } = makeSlotCheck({ registrationMode: "cli-metadata" });
-  assert.ok(!isFullMode, "cli-metadata mode should block registration");
+// registrationMode: "cli-metadata" — returns early, no throws
+test("registrationMode gate — 'cli-metadata' returns early without throwing", () => {
+  const api = makeFakeApi({ registrationMode: "cli-metadata", slotsMemory: "memory-lancedb" });
+  // In cli-metadata mode, register() returns before the slot check runs.
+  // No error should be thrown — mode guard is first.
+  assert.doesNotThrow(() => register(api), "cli-metadata mode should return early, slot check never fires");
 });
 
-test("registrationMode gate — 'setup-only' blocks registration", () => {
-  const { isFullMode } = makeSlotCheck({ registrationMode: "setup-only" });
-  assert.ok(!isFullMode, "setup-only mode should block registration");
+// registrationMode: "setup-only" — returns early, no throws
+test("registrationMode gate — 'setup-only' returns early without throwing", () => {
+  const api = makeFakeApi({ registrationMode: "setup-only", slotsMemory: "memory-lancedb" });
+  assert.doesNotThrow(() => register(api), "setup-only mode should return early");
 });
 
-test("combined — cli-metadata with other slot: still blocked by mode gate first", () => {
-  // In register(), the mode check happens before the slot check.
-  // When mode is not "full", we return early — slot check never runs.
-  const { isFullMode, memSlot } = makeSlotCheck({
-    registrationMode: "cli-metadata",
-    slotsMemory: "memory-lancedb",
-  });
-  assert.ok(!isFullMode, "mode gate blocks first");
-  // If mode gate passes (full), slot check would run:
-  const slotWouldThrow = !!(memSlot && memSlot !== MEMORY_ID && memSlot !== "none");
-  assert.ok(slotWouldThrow, "slot is correctly detected as conflicting");
+// cli-metadata mode: slot check skipped because mode gate runs first
+// This is the key test that validates ordering — in cli-metadata, even a
+// conflicting slot does NOT throw because register() exits before the slot check.
+test("combined — cli-metadata with conflicting slot: mode gate blocks before slot check", () => {
+  const api = makeFakeApi({ registrationMode: "cli-metadata", slotsMemory: "memory-lancedb" });
+  let threw = false;
+  try {
+    register(api);
+  } catch {
+    threw = true;
+  }
+  assert.ok(!threw, "no error in cli-metadata even with conflicting slot — mode guard exits first");
 });


### PR DESCRIPTION
## Summary

- **Slot detection at registration time**: `register()` now checks `api.config.plugins.slots.memory` and throws with a clear message if another plugin already owns the slot. Context engine has no config surface — the registry enforces exclusivity at runtime.
- **`registrationMode` gating**: All heavy initialization (sidecar startup, RPC calls, exclusive API registration) is gated on `registrationMode === "full"`, preventing side effects during lightweight CLI modes like `openclaw --help`.
- **Migrated to `registerMemoryCapability`**: Consolidated three legacy memory calls into a single `registerMemoryCapability("libravdb-memory", { promptBuilder, runtime })`. Zero behavioral change — the underlying builders structurally match `MemoryPluginCapability` fields exactly.
- **Updated SDK stub**: `openclaw-plugin-sdk.d.ts` now includes `config.plugins.slots.memory`, `registrationMode`, and `registerMemoryCapability`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:ts` — 49/49 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode-aware registration: lighter behavior for non-full modes while preserving full-mode capabilities.
  * Explicit memory capability registration and consolidated memory wiring.

* **Chores**
  * Stronger plugin API types and configuration validation.

* **Tests**
  * Added unit tests covering registration modes and memory slot conflict handling.

* **UX**
  * CLI now shows memory subcommands help even when runtime features are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->