### PR TITLE
fix: enable LibraVDB CLI in discovery mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,14 @@ export function register(api: OpenClawPluginApi) {
     return;
   }
 
-  const isFullMode = (api.registrationMode as string) === "full";
+  const mode = api.registrationMode as string;
+  const isFullMode = mode === "full";
   const cfg = api.pluginConfig as PluginConfig;
 
-  // Null in non-full mode: cli.ts skips action handlers when runtime is null.
-  const runtimeOrNull = isFullMode
+  // OpenClaw lazy-loads plugin-owned CLI commands through discovery mode.
+  // Provide a runtime there so subcommands attach real handlers, but keep the
+  // long-lived memory/context-engine registrations gated to full mode only.
+  const runtimeOrNull = (isFullMode || mode === "discovery")
     ? createPluginRuntime(cfg, api.logger ?? console)
     : null;
   registerMemoryCli(api, runtimeOrNull, cfg, api.logger ?? console);

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { registerMemoryCli } from "../../src/cli.js";
 import { registerMemoryCliMetadata } from "../../src/cli-descriptors.js";
+import { register } from "../../src/index.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
 
 type RegisteredCli = {
@@ -234,4 +235,55 @@ test("non-full CLI registration exposes command structure without action handler
     ["status", "index", "search", "flush", "export", "journal", "dream-promote"],
   );
   assert.ok(memory.commands.every((command) => command.handler === null));
+});
+
+test("discovery registration exposes runtime-backed memory commands for lazy CLI loading", () => {
+  let registered: RegisteredCli | null = null;
+  let memoryCapabilityRegistrations = 0;
+  let contextEngineRegistrations = 0;
+
+  register({
+    id: "libravdb-memory",
+    name: "LibraVDB Memory",
+    description: "Persistent vector memory with three-tier hybrid scoring",
+    source: "test",
+    registrationMode: "discovery",
+    config: selectedConfig,
+    pluginConfig: {},
+    logger: {
+      error(_msg: string) {},
+      warn(_msg: string) {},
+      info(_msg: string) {},
+    },
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+    registerMemoryCapability() {
+      memoryCapabilityRegistrations += 1;
+    },
+    registerContextEngine() {
+      contextEngineRegistrations += 1;
+    },
+    on() {
+      assert.fail("discovery mode should not register full runtime hooks");
+    },
+  } as never);
+
+  assert.ok(registered);
+  assert.equal(memoryCapabilityRegistrations, 0);
+  assert.equal(contextEngineRegistrations, 0);
+
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  assert.ok(memory);
+
+  const status = memory.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const journal = memory.commands.find((command) => command.name() === "journal");
+  assert.ok(journal);
+  assert.ok(journal.options.includes("--limit <limit>"));
 });


### PR DESCRIPTION
## Summary
- create the LibraVDB plugin runtime in `discovery` mode so lazy-loaded `openclaw memory` subcommands register real handlers on newer OpenClaw builds
- keep memory and context-engine activation gated to `full` mode only, so discovery stays non-activating outside CLI command registration
- add a regression test covering discovery-mode CLI registration

## Testing
- pnpm run test:ts
- npm run build
- openclaw memory status
- openclaw memory journal --limit 1
- openclaw memory search --query foo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI plugin registration to support discovery mode, enabling more efficient lazy initialization of CLI subcommands.

* **Tests**
  * Added unit tests validating discovery-mode behavior for CLI plugin registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->