### PR TITLE
fix: truncate mtimeMs to integer before BigInt conversion

### DIFF
--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -434,7 +434,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       this.fileStates.delete(sourceDoc);
       return;
     }
-    await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, Math.trunc(stat.mtimeMs));
+    await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, stat.mtimeMs);
     this.fileStates.set(sourceDoc, {
       root: rootState.root,
       sourceDoc,

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -434,7 +434,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       this.fileStates.delete(sourceDoc);
       return;
     }
-    await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, stat.mtimeMs);
+    await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, Math.trunc(stat.mtimeMs));
     this.fileStates.set(sourceDoc, {
       root: rootState.root,
       sourceDoc,
@@ -466,7 +466,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         sourceKind: this.kind,
         fileHash,
         sourceSize,
-        sourceMtimeMs,
+        sourceMtimeMs: Math.trunc(sourceMtimeMs),
         ingestVersion: MARKDOWN_INGEST_VERSION,
         hashBackend: HASH_BACKEND,
       },


### PR DESCRIPTION
## Problem

Node.js `fs.stat().mtimeMs` returns a float (e.g. `1777104808165.547`). The daemon RPC protobuf layer converts `sourceMtimeMs` to `BigInt`, which rejects non-integer values:

```
The number 1777104808165.547 cannot be converted to a BigInt because it is not an integer
```

This breaks **all** markdown ingestion on Linux/WSL2 where filesystem mtimes commonly have sub-millisecond precision. Every workspace `.md` file fails to ingest at startup.

## Fix

`Math.trunc()` both the call site (`stat.mtimeMs`) and the RPC params field (`sourceMtimeMs`) to produce integer milliseconds before BigInt conversion.

## Testing

- TypeScript compiles clean (`tsc --noEmit` passes)
- Patched plugin running on WSL2 with daemon v1.4.25 — all 7 workspace files ingested successfully, database grew from 12KB to 119KB
- No unit test changes needed (no behavioral change beyond the type coercion)

## Reproduction

On any Linux filesystem with sub-millisecond mtime precision, start the gateway with `markdownIngestionRoots` configured and watch the daemon logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp precision handling in the markdown ingestion pipeline to ensure consistent integer-based formatting of file modification times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->