### PR TITLE
fix(cli): make memory index a compatibility no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ openclaw memory journal --limit 50
 openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
 ```
 
+`openclaw memory index --force` is kept as a compatibility command. LibraVDB
+maintains its own index state inside the sidecar, so the command exits without
+starting an explicit reindex pass.
+
 Use [Install](./docs/install.md) for daemon lifecycle commands and
 [Uninstall](./docs/uninstall.md) for safe shutdown and removal.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -114,7 +114,7 @@ CLI API.
 | Command | Purpose |
 |---|---|
 | `openclaw memory status` | Show sidecar health, counts, active thresholds, and model readiness. |
-| `openclaw memory index --force` | Refresh delegated sidecar index state for OpenClaw memory CLI compatibility. |
+| `openclaw memory index --force` | Compatibility no-op for OpenClaw memory CLI flows; LibraVDB keeps index state inside the sidecar. |
 | `openclaw memory search "query"` | Search LibraVDB memory through the active memory runtime bridge. |
 | `openclaw memory export --user-id <userId>` | Stream stored memories as newline-delimited JSON for one durable namespace. |
 | `openclaw memory export --session-key <sessionKey>` | Export a namespace derived from a session key. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ export function registerMemoryCli(
         // Non-full modes register structure only so `openclaw memory --help` works.
         // No runtime available — do not attach action handlers.
         ensureCommand(root, "status").description("Show sidecar health, record counts, and active thresholds");
-        ensureCommand(root, "index").description("Refresh delegated LibraVDB memory index state");
+        ensureCommand(root, "index").description("Compatibility no-op for sidecar-managed LibraVDB indexing");
         ensureCommand(root, "search").description("Search LibraVDB memory");
         ensureCommand(root, "flush").description("Wipe a durable memory namespace after confirmation");
         ensureCommand(root, "export").description("Stream stored memories as newline-delimited JSON");
@@ -115,7 +115,7 @@ export function registerMemoryCli(
         });
 
       ensureCommand(root, "index")
-        .description("Refresh delegated LibraVDB memory index state")
+        .description("Compatibility no-op for sidecar-managed LibraVDB indexing")
         .option("--agent <id>", "Agent id")
         .option("--force", "Force refresh where supported")
         .option("--verbose", "Verbose logging")
@@ -291,44 +291,21 @@ async function runStatus(
 }
 
 async function runIndex(
-  runtime: PluginRuntime,
-  cfg: PluginConfig,
+  _runtime: PluginRuntime,
+  _cfg: PluginConfig,
   opts: CliOptionBag | undefined,
-  logger: LoggerLike,
+  _logger: LoggerLike,
   params: { quiet?: boolean } = {},
 ): Promise<void> {
-  try {
-    const bridge = buildMemoryRuntimeBridge(runtime.getRpc, cfg);
-    const { manager } = await bridge.getMemorySearchManager({
-      agentId: opts?.agent,
-      purpose: "status",
-    });
-    await manager.sync?.({
-      reason: "cli",
-      force: Boolean(opts?.force),
-    });
-    const status = manager.status();
-    if (status.ok === false) {
-      logger.error(`LibraVDB index refresh unavailable: ${status.message ?? "sidecar unavailable"}`);
-      process.exitCode = 1;
-      return;
-    }
-    if (opts?.verbose && !params.quiet) {
-      console.table({
-        Provider: status.provider ?? "libravdb",
-        Model: status.model ?? status.embeddingProfile ?? "unknown",
-        "Turns stored": status.turnCount ?? 0,
-        "Memories stored": status.memoryCount ?? 0,
-        Message: status.message ?? "ok",
-      });
-    }
-    if (!params.quiet) {
-      console.log("LibraVDB memory index refresh delegated to the sidecar.");
-    }
-  } catch (error) {
-    logger.error(`LibraVDB index refresh failed: ${formatError(error)}`);
-    process.exitCode = 1;
+  if (params.quiet) {
+    return;
   }
+  const scope = opts?.agent ? ` for agent ${opts.agent}` : "";
+  const forceNote = opts?.force ? " `--force` is accepted for compatibility." : "";
+  const verboseNote = opts?.verbose ? " Use `openclaw memory status` for live sidecar health and counts." : "";
+  console.log(
+    `LibraVDB memory index is a compatibility no-op${scope}; the sidecar maintains its own index state.${forceNote}${verboseNote}`,
+  );
 }
 
 async function runSearch(

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -212,6 +212,61 @@ test("status command shuts the plugin runtime down after printing status", async
   assert.equal(shutdownCalls, 1);
 });
 
+test("index command is a compatibility no-op and shuts the plugin runtime down", async () => {
+  let registered: RegisteredCli | null = null;
+  let getRpcCalls = 0;
+  let shutdownCalls = 0;
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        getRpcCalls += 1;
+        throw new Error("index compatibility no-op should not start the runtime");
+      },
+      getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  assert.ok(memory);
+  const index = memory.commands.find((command) => command.name() === "index");
+  assert.ok(index?.handler);
+
+  const originalLog = console.log;
+  const printed: string[] = [];
+  console.log = ((message?: unknown) => {
+    printed.push(String(message ?? ""));
+  }) as typeof console.log;
+  try {
+    await index.handler?.({ agent: "main", force: true });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(getRpcCalls, 0);
+  assert.equal(shutdownCalls, 1);
+  assert.match(printed[0] ?? "", /compatibility no-op/i);
+});
+
 test("non-full CLI registration exposes command structure without action handlers", () => {
   let registered: RegisteredCli | null = null;
   const api = {


### PR DESCRIPTION
## Summary
- make `openclaw memory index` a true compatibility no-op for LibraVDB instead of spinning up the runtime and doing redundant status RPCs
- update the CLI help and docs to clarify that LibraVDB keeps index state inside the sidecar
- add a unit test that locks in the no-runtime-start behavior for the index command

## Why
- operators and retry loops still invoke `openclaw memory index --force` for generic OpenClaw compatibility, but LibraVDB does not have a host-side reindex pass to run
- the previous implementation still started the plugin runtime and hit the sidecar just to print a delegated message, which adds avoidable churn and log noise under repeated retries

## Testing
- `pnpm run test:ts`
- `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that `openclaw memory index --force` is retained for backward compatibility but no longer performs a reindex operation.

* **Refactor**
  * The memory index command now executes as a compatibility no-op, with index state managed internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->