### PR TITLE
fix: stop leaking prePromptMessageCount to daemon in afterTurn

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -978,7 +978,6 @@ export function buildContextEngineFactory(
             sessionKey: args.sessionKey,
             userId,
             messages,
-            prePromptMessageCount: args.prePromptMessageCount,
             isHeartbeat: args.isHeartbeat,
           });
           await performAfterTurnPredictiveCompaction({
@@ -990,9 +989,11 @@ export function buildContextEngineFactory(
         }
         const rpc = await runtime.getRpc();
         const result = await rpc.call("after_turn_kernel", {
-          ...args,
+          sessionId: args.sessionId,
+          sessionKey: args.sessionKey,
           userId,
           messages,
+          isHeartbeat: args.isHeartbeat,
         });
         await performAfterTurnPredictiveCompaction({
           sessionId: args.sessionId,

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -449,7 +449,7 @@ test("compact omits invalid currentTokenCount values from the wire request", asy
   assert.equal("currentTokenCount" in params, false);
 });
 
-test("afterTurn forwards message arrays and pre-prompt counts correctly", async () => {
+test("afterTurn forwards only daemon-relevant fields, strips prePromptMessageCount", async () => {
   const rpc = new StaticContractRpc();
   const recallCache = createRecallCache<SearchResult>();
   const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
@@ -473,7 +473,7 @@ test("afterTurn forwards message arrays and pre-prompt counts correctly", async 
   assert.ok(params, "Expected after_turn_kernel to be called");
   assert.equal(params.sessionId, "test-session");
   assert.equal(params.userId, "test-user");
-  assert.equal(params.prePromptMessageCount, 1);
+  assert.equal("prePromptMessageCount" in params, false, "prePromptMessageCount must not leak to daemon — daemon defaults to 0 and uses content-hash dedup");
   assert.equal(params.isHeartbeat, false);
   assert.deepEqual(params.messages, mockMessages);
 });


### PR DESCRIPTION
## Summary
- `afterTurn` was spreading `...args` into the RPC call, leaking `prePromptMessageCount`, `tokenBudget`, and `runtimeContext` to the daemon
- The daemon uses `prePromptMessageCount` to skip messages by array position — if the framework passes a stale value, messages are silently dropped before persistence
- The daemon already has content-hash dedup (`afterTurnIngestedKeys`), so the positional skip is redundant for correctness

## Fix
- Kernel path: removed `prePromptMessageCount` forwarding
- RPC path: replaced `...args` spread with explicit `{ sessionId, sessionKey, userId, messages, isHeartbeat }`
- Both paths now let the daemon default `prePromptMessageCount` to 0, processing all messages; content-hash dedup catches any already-ingested

## Test plan
- [x] `npm run test:integration` — all 30 pass
- [x] `npm run test:ts` — 72 pass, 10 pre-existing failures (unrelated, present on clean main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Optimized internal messaging to reduce unnecessary data transmission in RPC communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->