### PR TITLE
fix: expose ONNX device override

### DIFF
--- a/docs/embedding-profiles.md
+++ b/docs/embedding-profiles.md
@@ -12,6 +12,7 @@ Why:
 - MiniLM keeps the local LongMemEval retrieval slice inside the target memory envelope on macOS.
 - Nomic remains available as an explicit opt-in profile for long-context experiments.
 - Nomic ONNX on macOS is fragile with CoreML execution and can trigger multi-GB RSS, so it is no longer the safe bundled default.
+- Intel Macs without reliable Metal/MPS support should set `onnxDevice: "cpu"` to force CPU ONNX execution and bypass CoreML.
 
 Current shipped profile names:
 
@@ -33,6 +34,7 @@ How it works:
 - `onnx-local` still requires local model assets through `embeddingModelPath`, typically a directory containing `embedding.json`.
 - The manifest may override or refine the profile, but explicit dimension mismatches fail closed.
 - The sidecar store persists an embedding fingerprint, so reopening an existing store with a different effective model profile will fail instead of silently mixing vector spaces.
+- `onnxDevice` is passed through as `LIBRAVDB_ONNX_DEVICE` for daemon versions that support execution-provider selection (`auto`, `cpu`, `cuda`, `coreml`, `directml`, `openvino`).
 
 Recommended usage:
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -28,6 +28,18 @@
       "embeddingRuntimePath": {
         "type": "string"
       },
+      "onnxDevice": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "cpu",
+          "cuda",
+          "coreml",
+          "directml",
+          "openvino"
+        ],
+        "description": "Optional ONNX execution provider override passed to libravdbd. Use cpu to bypass CoreML/MPS on Intel Macs."
+      },
       "embeddingBackend": {
         "type": "string",
         "enum": [

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -442,6 +442,9 @@ export function buildSidecarEnv(cfg: PluginConfig): Record<string, string> {
   if (cfg.embeddingRuntimePath) {
     env.LIBRAVDB_ONNX_RUNTIME = cfg.embeddingRuntimePath;
   }
+  if (cfg.onnxDevice) {
+    env.LIBRAVDB_ONNX_DEVICE = cfg.onnxDevice;
+  }
   if (cfg.embeddingBackend) {
     env.LIBRAVDB_EMBEDDING_BACKEND = cfg.embeddingBackend;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,9 @@ export interface PluginConfig {
   useSessionRecallProjection?: boolean;
   useSessionSummarySearchExperiment?: boolean;
   embeddingRuntimePath?: string;
+  /** Optional ONNX execution provider override passed through to libravdbd.
+   *  Use "cpu" to bypass CoreML/MPS on Intel Macs or fragile GPU/NPU providers. */
+  onnxDevice?: "auto" | "cpu" | "cuda" | "coreml" | "directml" | "openvino";
   embeddingBackend?: "bundled" | "onnx-local" | "custom-local";
   embeddingProfile?: string;
   fallbackProfile?: string;

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -78,6 +78,7 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
     rpcTimeoutMs: 1,
     dbPath: "/tmp/libravdb",
     embeddingRuntimePath: "/opt/onnx/libonnxruntime.so",
+    onnxDevice: "cpu",
     embeddingBackend: "custom-local",
     embeddingProfile: "nomic-embed-text-v1.5",
     fallbackProfile: "all-minilm-l6-v2",
@@ -95,6 +96,7 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
   assert.deepEqual(env, {
     LIBRAVDB_DB_PATH: "/tmp/libravdb",
     LIBRAVDB_ONNX_RUNTIME: "/opt/onnx/libonnxruntime.so",
+    LIBRAVDB_ONNX_DEVICE: "cpu",
     LIBRAVDB_EMBEDDING_BACKEND: "custom-local",
     LIBRAVDB_EMBEDDING_PROFILE: "nomic-embed-text-v1.5",
     LIBRAVDB_FALLBACK_PROFILE: "all-minilm-l6-v2",


### PR DESCRIPTION
## Summary

Adds a plugin config passthrough for the daemon-supported `LIBRAVDB_ONNX_DEVICE` environment variable.

This lets users force CPU execution with:

```json
{
  "plugins": {
    "configs": {
      "libravdb-memory": {
        "onnxDevice": "cpu"
      }
    }
  }
}
```

That gives Intel Mac users a clean way to bypass CoreML/MPS when the CoreML execution provider aborts during ONNX session creation.

Refs #36.

## Evidence

- Confirmed current `libravdbd v1.4.26` contains `LIBRAVDB_ONNX_DEVICE` and accepts `cpu`.
- Local daemon probe with `LIBRAVDB_ONNX_DEVICE=cpu` starts successfully and logs CPU fallback:

```text
epconfig: no GPU/NPU providers registered, using CPU
```

## Tests

```text
npx tsc --noEmit
corepack pnpm run test:ts
```

All 82 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ONNX execution provider selection with options including cpu, cuda, coreml, directml, openvino, and auto. Allows optimization for different hardware and resolution of compatibility issues.

* **Documentation**
  * Added guidance for Intel Mac users regarding ONNX device configuration recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->