### PR TITLE
test: relax registration mode checklist

### DIFF
--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -42,7 +42,7 @@ test("source checklist invariants are present in host code", async () => {
   assert.match(indexTs, /api\.on\("before_reset"/);
   assert.match(indexTs, /api\.on\("session_end"/);
   assert.match(indexTs, /api\.on\("gateway_stop"/);
-  assert.match(indexTs, /registrationMode === "cli-metadata"/);
+  assert.match(indexTs, /(?:registrationMode|mode) === "cli-metadata"/);
   assert.doesNotMatch(indexTs, /registerMemoryPromptSection/);
   assert.doesNotMatch(indexTs, /registerMemoryRuntime\?\.\(/);
   assert.doesNotMatch(indexTs, /api\.on\("shutdown"/);


### PR DESCRIPTION
## Summary

Fixes a brittle integration checklist assertion that currently fails on `main`.

The checklist looked for the literal source text:

```ts
registrationMode === "cli-metadata"
```

but `src/index.ts` aliases the value first:

```ts
const mode = api.registrationMode as string;
if (mode === "cli-metadata") { ... }
```

The behavior is correct; the test was too literal. This updates the regex to accept either direct or local-variable forms.

## Repro

On current `main`:

```text
npm run test:integration
```

fails `source checklist invariants are present in host code` with:

```text
expected: /registrationMode === "cli-metadata"/
actual: if (mode === "cli-metadata")
```

## Tests

```text
npm run test:integration
corepack pnpm run test:ts
npx tsc --noEmit
```

All pass after this change.