### PR TITLE
fix: expose core config schema fields

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -22,6 +22,35 @@
       "sidecarPath": {
         "type": "string"
       },
+      "userId": {
+        "type": "string",
+        "description": "Stable identity for cross-session durable memory. When set, sessions share memories under user:{userId}."
+      },
+      "identityPath": {
+        "type": "string",
+        "description": "Custom path for the auto-derived identity JSON file."
+      },
+      "crossSessionRecall": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, only session-scoped memories are retrieved; durable user recall is skipped."
+      },
+      "useSessionRecallProjection": {
+        "type": "boolean"
+      },
+      "grpcEndpoint": {
+        "type": "string",
+        "description": "Optional gRPC kernel endpoint for hosts using the daemon kernel transport."
+      },
+      "authoredHardBudgetFraction": {
+        "type": "number"
+      },
+      "authoredSoftBudgetFraction": {
+        "type": "number"
+      },
+      "elevatedGuidanceBudgetFraction": {
+        "type": "number"
+      },
       "useSessionSummarySearchExperiment": {
         "type": "boolean"
       },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -43,13 +43,19 @@
         "description": "Optional gRPC kernel endpoint for hosts using the daemon kernel transport."
       },
       "authoredHardBudgetFraction": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
       },
       "authoredSoftBudgetFraction": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
       },
       "elevatedGuidanceBudgetFraction": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
       },
       "useSessionSummarySearchExperiment": {
         "type": "boolean"


### PR DESCRIPTION
## Summary

Adds missing `openclaw.plugin.json` schema entries for core config fields already consumed by the plugin code:

- `userId`
- `identityPath`
- `crossSessionRecall`
- `useSessionRecallProjection`
- `grpcEndpoint`
- authored/elevated guidance budget fractions

## Why

The manifest has `additionalProperties: false`, but several supported config fields exist only in `PluginConfig` and runtime code, not in the schema. That means schema-driven configuration UIs/validators cannot discover or may reject these supported settings.

Examples from code:

- `src/index.ts` logs `cfg.userId` / `cfg.crossSessionRecall`
- `src/context-engine.ts` and `src/memory-runtime.ts` resolve durable identity from `cfg.userId` / `cfg.identityPath`
- `src/plugin-runtime.ts` initializes the gRPC kernel client from `cfg.grpcEndpoint`
- `src/context-engine.ts` forwards authored/elevated budget fractions to the daemon

## Tests

```text
node -e "JSON.parse(require('fs').readFileSync('openclaw.plugin.json','utf8')); console.log('json ok')"
npx tsc --noEmit
```

`npm run test:integration` is currently blocked on main by the brittle checklist regex fixed separately in #48.