### PR TITLE
fix: remove unused markdown collection option

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -51,7 +51,6 @@ Relevant config fields:
 | `markdownIngestionRoots` | Generic markdown roots to watch. |
 | `markdownIngestionInclude` | Optional include globs for generic roots. |
 | `markdownIngestionExclude` | Optional exclude globs for generic roots. |
-| `markdownIngestionCollection` | Target collection for generic markdown, default `global`. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -150,10 +150,6 @@
           "type": "string"
         }
       },
-      "markdownIngestionCollection": {
-        "type": "string",
-        "default": "global"
-      },
       "markdownIngestionDebounceMs": {
         "type": "number",
         "default": 150

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,6 @@ export interface PluginConfig {
   markdownIngestionObsidianDebounceMs?: number;
   markdownIngestionInclude?: string[];
   markdownIngestionExclude?: string[];
-  markdownIngestionCollection?: string;
   markdownIngestionDebounceMs?: number;
   dreamPromotionEnabled?: boolean;
   dreamPromotionDiaryPath?: string;


### PR DESCRIPTION
## Summary

Removes the documented/schema `markdownIngestionCollection` option because it is not actually wired to the daemon markdown ingestion RPC.

## Why

The option appears in:

- `openclaw.plugin.json`
- `PluginConfig`
- `docs/features.md`

…but no runtime code reads it. More importantly, `IngestMarkdownDocumentRequest` has no `collection` field, and `MarkdownSourceMeta` has no target collection field either. So users can set `markdownIngestionCollection`, but it cannot affect where markdown is stored.

Leaving it documented is misleading. Until the daemon/proto supports target collections for authored markdown, the honest fix is to remove the dead config surface.

## Evidence

```text
grep -R "markdownIngestionCollection" src test docs openclaw.plugin.json
```

Only type/schema/docs references exist; no ingest path uses it.

Generated IPC shape:

- `IngestMarkdownDocumentRequest`: `sourceDoc`, `text`, `tokenizerId`, `coreDoc`, `sourceMeta`
- `MarkdownSourceMeta`: source/provenance/hash fields only

## Tests

```text
npx tsc --noEmit
corepack pnpm run test:ts -- --test-name-pattern="markdown ingestion|manifest"
```

Unit suite passes. Full integration on main is currently blocked by the brittle checklist assertion fixed separately in #48.