### PR TITLE
fix: stop markdown ingestion before CLI runtime shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,10 @@ export function register(api: OpenClawPluginApi) {
   const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getRpc, api.logger ?? console);
 
   runtime.onShutdown(async () => {
-    await dreamPromotion.stop();
     await markdownIngestion.stop();
+  });
+  runtime.onShutdown(async () => {
+    await dreamPromotion.stop();
   });
 
   void markdownIngestion.start().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,11 @@ export function register(api: OpenClawPluginApi) {
   const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getRpc, api.logger ?? console);
   const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getRpc, api.logger ?? console);
 
+  runtime.onShutdown(async () => {
+    await dreamPromotion.stop();
+    await markdownIngestion.stop();
+  });
+
   void markdownIngestion.start().catch((error) => {
     api.logger?.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
   });
@@ -104,8 +109,6 @@ export function register(api: OpenClawPluginApi) {
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
   api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
   api.on("gateway_stop", async () => {
-    await dreamPromotion.stop();
-    await markdownIngestion.stop();
     await runtime.shutdown();
   });
 }

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -193,9 +193,11 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly logger: LoggerLike;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
+  private readonly activeScans = new Set<Promise<void>>();
   private readonly tokenizerId: string;
   private readonly coreDoc: boolean;
   private started = false;
+  private stopping = false;
 
   constructor(kind: string, config: GenericMarkdownSourceConfig, getRpc: RpcGetterLike, logger: LoggerLike, fsApi: FsApi) {
     this.kind = kind;
@@ -215,11 +217,12 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       return;
     }
     this.started = true;
+    this.stopping = false;
     await this.refresh();
   }
 
   async refresh(): Promise<void> {
-    if (!this.started) {
+    if (!this.started || this.stopping) {
       return;
     }
     for (const root of this.roots) {
@@ -228,6 +231,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   async stop(): Promise<void> {
+    this.stopping = true;
     for (const state of this.states.values()) {
       if (state.scanState.timer) {
         clearTimeout(state.scanState.timer);
@@ -238,9 +242,13 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       state.directoryWatchers.clear();
     }
+    if (this.activeScans.size > 0) {
+      await Promise.allSettled([...this.activeScans]);
+    }
     this.states.clear();
     this.fileStates.clear();
     this.started = false;
+    this.stopping = false;
   }
 
   private getRootState(root: string): RootState {
@@ -264,6 +272,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   private async scanRoot(root: string): Promise<void> {
+    if (this.stopping) {
+      return;
+    }
     const rootState = this.getRootState(root);
     if (rootState.scanState.scanning) {
       rootState.scanState.dirty = true;
@@ -271,21 +282,37 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
 
     rootState.scanState.scanning = true;
-    try {
-      const currentFiles = new Set<string>();
-      await this.walkDirectory(rootState, rootState.root, currentFiles);
-      await this.pruneDeletedFiles(rootState, currentFiles);
-      rootState.knownFiles = currentFiles;
-    } finally {
-      rootState.scanState.scanning = false;
-      if (rootState.scanState.dirty) {
-        rootState.scanState.dirty = false;
-        this.scheduleRootScan(rootState);
+    const scan = (async () => {
+      try {
+        const currentFiles = new Set<string>();
+        await this.walkDirectory(rootState, rootState.root, currentFiles);
+        if (!this.stopping) {
+          await this.pruneDeletedFiles(rootState, currentFiles);
+          rootState.knownFiles = currentFiles;
+        }
+      } finally {
+        rootState.scanState.scanning = false;
+        if (rootState.scanState.dirty) {
+          rootState.scanState.dirty = false;
+          if (!this.stopping) {
+            this.scheduleRootScan(rootState);
+          }
+        }
       }
+    })();
+
+    this.activeScans.add(scan);
+    try {
+      await scan;
+    } finally {
+      this.activeScans.delete(scan);
     }
   }
 
   private scheduleRootScan(rootState: RootState): void {
+    if (this.stopping) {
+      return;
+    }
     if (rootState.scanState.scanning) {
       rootState.scanState.dirty = true;
       return;
@@ -316,6 +343,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
 
     for (const entry of entries) {
+      if (this.stopping) {
+        return;
+      }
       const child = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         await this.walkDirectory(rootState, child, currentFiles);
@@ -331,7 +361,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       try {
         await this.syncMarkdownFile(rootState, child);
       } catch (error) {
-        this.logger.warn?.(`[markdown-ingest] sync failed for ${child}: ${formatError(error)}`);
+        if (!this.stopping) {
+          this.logger.warn?.(`[markdown-ingest] sync failed for ${child}: ${formatError(error)}`);
+        }
       }
     }
   }
@@ -343,7 +375,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
 
     try {
       const watcher = this.fsApi.watch(dir, () => {
-        this.scheduleRootScan(rootState);
+        if (!this.stopping) {
+          this.scheduleRootScan(rootState);
+        }
       });
       watcher.on("error", (error) => {
         this.logger.warn?.(`[markdown-ingest] watch error for ${dir}: ${formatError(error)}`);

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -248,7 +248,6 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.states.clear();
     this.fileStates.clear();
     this.started = false;
-    this.stopping = false;
   }
 
   private getRootState(root: string): RootState {
@@ -272,7 +271,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   private async scanRoot(root: string): Promise<void> {
-    if (this.stopping) {
+    if (!this.started || this.stopping) {
       return;
     }
     const rootState = this.getRootState(root);
@@ -310,7 +309,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   private scheduleRootScan(rootState: RootState): void {
-    if (this.stopping) {
+    if (!this.started || this.stopping) {
       return;
     }
     if (rootState.scanState.scanning) {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -27,10 +27,13 @@ export interface LifecycleHint {
   nextSessionKey?: string;
 }
 
+export type RuntimeShutdownTask = () => Promise<void> | void;
+
 export interface PluginRuntime {
   getRpc: RpcGetter;
   getKernel(): GrpcKernelClient | null;
   emitLifecycleHint(hint: LifecycleHint): Promise<void>;
+  onShutdown(task: RuntimeShutdownTask): void;
   shutdown(): Promise<void>;
 }
 
@@ -40,7 +43,9 @@ export function createPluginRuntime(
 ): PluginRuntime {
   let started: Promise<{ rpc: RpcClient; sidecar: SidecarHandle; kernel: GrpcKernelClient | null }> | null = null;
   let stopped = false;
+  let shuttingDown = false;
   let resolvedKernel: GrpcKernelClient | null = null;
+  const shutdownTasks: RuntimeShutdownTask[] = [];
 
   const ensureStarted = async () => {
     if (stopped) {
@@ -103,7 +108,26 @@ export function createPluginRuntime(
         logger.warn?.(`LibraVDB lifecycle hint dropped: ${formatError(error)}`);
       }
     },
+    onShutdown(task: RuntimeShutdownTask) {
+      if (stopped || shuttingDown) {
+        return;
+      }
+      shutdownTasks.push(task);
+    },
     async shutdown() {
+      if (stopped || shuttingDown) {
+        return;
+      }
+      shuttingDown = true;
+
+      for (const task of shutdownTasks.splice(0).reverse()) {
+        try {
+          await task();
+        } catch (error) {
+          logger.warn?.(`LibraVDB shutdown task failed: ${formatError(error)}`);
+        }
+      }
+
       stopped = true;
       if (!started) {
         return;

--- a/test/integration/cross-session-smoke.test.ts
+++ b/test/integration/cross-session-smoke.test.ts
@@ -84,6 +84,7 @@ function buildRuntime(rpc: RpcClient): PluginRuntime {
     getRpc: async () => rpc,
     getKernel: () => null,
     emitLifecycleHint: async () => {},
+    onShutdown: () => {},
     shutdown: async () => {},
   };
 }

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -72,6 +72,7 @@ function buildContextEngineFactory(
     getRpc,
     getKernel: () => null,
     emitLifecycleHint: async () => {},
+    onShutdown: () => {},
     shutdown: async () => {},
   } as unknown as import("../../src/plugin-runtime.js").PluginRuntime;
   return createContextEngineFactory(runtime, cfg, recallCache, logger);

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -300,3 +300,56 @@ test("obsidian markdown ingestion accepts inline tags like #project", async () =
 
   await handle.stop();
 });
+
+test("markdown ingestion stop waits for an in-flight startup scan", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-stop-"));
+  const notePath = path.join(tempRoot, "slow.md");
+  await fsp.writeFile(notePath, "# Slow note\n\nThis scan is intentionally held open.");
+
+  let callStarted!: () => void;
+  const callStartedPromise = new Promise<void>((resolve) => {
+    callStarted = resolve;
+  });
+  let releaseCall!: () => void;
+  const releaseCallPromise = new Promise<void>((resolve) => {
+    releaseCall = resolve;
+  });
+  let rpcCompleted = false;
+
+  const rpc = {
+    async call<T>(method: string): Promise<T> {
+      assert.equal(method, "ingest_markdown_document");
+      callStarted();
+      await releaseCallPromise;
+      rpcCompleted = true;
+      return { ok: true } as T;
+    },
+  };
+
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+    },
+    async () => rpc,
+    { error() {}, warn() {} },
+  );
+
+  const startPromise = handle.start();
+  await callStartedPromise;
+
+  let stopResolved = false;
+  const stopPromise = handle.stop().then(() => {
+    stopResolved = true;
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(stopResolved, false, "stop must wait for the in-flight scan before resolving");
+  assert.equal(rpcCompleted, false, "the held RPC should still be in flight");
+
+  releaseCall();
+  await stopPromise;
+  await startPromise;
+  assert.equal(rpcCompleted, true);
+});

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -80,6 +80,7 @@ function createRuntime(): PluginRuntime {
       return null;
     },
     async emitLifecycleHint() {},
+    onShutdown() {},
     async shutdown() {},
   };
 }
@@ -184,6 +185,7 @@ test("status command shuts the plugin runtime down after printing status", async
         return null;
       },
       async emitLifecycleHint() {},
+      onShutdown() {},
       async shutdown() {
         shutdownCalls += 1;
       },

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -60,6 +60,7 @@ function fakeRuntime(rpc: FakeRpc): PluginRuntime {
     getRpc: async () => rpc as unknown as RpcClient,
     getKernel: () => null,
     emitLifecycleHint: async () => {},
+    onShutdown: () => {},
     shutdown: async () => {},
   };
 }
@@ -281,6 +282,7 @@ test("context engine assemble keeps daemon result when exact recall RPC acquisit
     },
     getKernel: () => null,
     emitLifecycleHint: async () => {},
+    onShutdown: () => {},
     shutdown: async () => {},
   };
   const warnings: string[] = [];

--- a/test/unit/lifecycle-hooks.test.ts
+++ b/test/unit/lifecycle-hooks.test.ts
@@ -14,6 +14,7 @@ function createRuntimeRecorder() {
     async emitLifecycleHint(hint: LifecycleHint) {
       hints.push(hint);
     },
+    onShutdown() {},
     async shutdown() {},
   };
   return { runtime, hints };


### PR DESCRIPTION
## Summary

Fixes #53 by making plugin-owned background tasks participate in runtime shutdown.

The CLI commands call `runtime.shutdown()` after the command action. Before this change, markdown ingestion and dream promotion were only stopped from the `gateway_stop` hook, so one-shot CLI invocations could start markdown ingestion and then close the runtime/socket while the startup scan was still in flight. That produced misleading shutdown errors such as `Socket closed` and `LibraVDB plugin runtime has been shut down` even when the daemon was healthy and the CLI command succeeded.

## Changes

- Add `PluginRuntime.onShutdown()` for plugin-owned background cleanup.
- Register markdown ingestion and dream promotion cleanup with the runtime shutdown path.
- Keep `gateway_stop` cleanup routed through `runtime.shutdown()` so gateway and CLI share one shutdown path.
- Make markdown ingestion `stop()` wait for active scans before resolving, canceling timers/watchers first so no new scans are scheduled.
- Suppress per-file sync warnings during intentional markdown ingestion shutdown.
- Add coverage proving markdown ingestion stop waits for an in-flight startup scan.

## Tests

```text
PATH=/tmp/corepack-bin:$PATH pnpm run check
npm run test:integration
```

Results:

```text
pnpm run check: 82/82 unit tests passed
npm run test:integration: 31/31 integration tests passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shutdown hook mechanism for coordinated component lifecycle management.

* **Bug Fixes**
  * Improved shutdown process to reliably wait for in-flight markdown scans to complete before stopping, preventing interrupted operations.
  * Enhanced shutdown coordination to prevent new work from being scheduled during the shutdown phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->