### PR TITLE
docs: update OpenClaw config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ assembly; durable recall; and sidecar-owned compaction.
 
 New install? Start here: [Install guide](./docs/install.md). Preferred setup on
 macOS: install `libravdbd` with Homebrew, install the OpenClaw plugin, then
-assign the plugin to both required slots.
+assign the plugin to the OpenClaw memory slot.
 
 ## Install
 
@@ -31,18 +31,20 @@ brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-Then activate both plugin slots in `~/.openclaw/openclaw.json`:
+Then activate the plugin in `~/.openclaw/openclaw.json`:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
+      "memory": "libravdb-memory"
     },
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "auto"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "auto"
+        }
       }
     }
   }
@@ -78,9 +80,12 @@ If your daemon runs elsewhere, set `sidecarPath`:
 ```json
 {
   "plugins": {
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "tcp:127.0.0.1:37421"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "tcp:127.0.0.1:37421"
+        }
       }
     }
   }
@@ -89,7 +94,8 @@ If your daemon runs elsewhere, set `sidecarPath`:
 
 ## Highlights
 
-- **Dual slot ownership** - owns both OpenClaw `memory` and `contextEngine`.
+- **Memory capability ownership** - owns the OpenClaw `memory` slot and
+  registers the context engine capability at runtime.
 - **Memory runtime bridge** - routes built-in `memory_search` calls to the same
   libraVDB-backed sidecar on hosts that expose the runtime API.
 - **Three memory scopes** - keeps active session, durable user, and global memory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,8 @@ internal sequencing.
 
 LibraVDB Memory is split into two cooperating pieces:
 
-- a TypeScript OpenClaw plugin that owns the `memory` and `contextEngine`
-  slots
+- a TypeScript OpenClaw plugin that owns the `memory` slot and registers
+  context-engine capability at runtime
 - a Go sidecar daemon that owns storage, retrieval, and compaction
 
 The plugin keeps the host integration light and stable. The daemon keeps the

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,16 +27,19 @@ Example:
 ```json
 {
   "plugins": {
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "markdownIngestionEnabled": true,
-        "markdownIngestionRoots": [
-          "/Users/<you>/.openclaw/memory"
-        ],
-        "markdownIngestionObsidianEnabled": true,
-        "markdownIngestionObsidianRoots": [
-          "/Users/<you>/Documents/Obsidian/Main"
-        ]
+        "enabled": true,
+        "config": {
+          "markdownIngestionEnabled": true,
+          "markdownIngestionRoots": [
+            "/Users/<you>/.openclaw/memory"
+          ],
+          "markdownIngestionObsidianEnabled": true,
+          "markdownIngestionObsidianRoots": [
+            "/Users/<you>/Documents/Obsidian/Main"
+          ]
+        }
       }
     }
   }
@@ -85,12 +88,15 @@ Automatic diary watching:
 ```json
 {
   "plugins": {
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "dreamPromotionEnabled": true,
-        "dreamPromotionDiaryPath": "/Users/<you>/DREAMS.md",
-        "dreamPromotionUserId": "<userId>",
-        "dreamPromotionDebounceMs": 150
+        "enabled": true,
+        "config": {
+          "dreamPromotionEnabled": true,
+          "dreamPromotionDiaryPath": "/Users/<you>/DREAMS.md",
+          "dreamPromotionUserId": "<userId>",
+          "dreamPromotionDebounceMs": 150
+        }
       }
     }
   }

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,8 +37,7 @@ openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
 If you use the OpenClaw.ai plugin UI instead of the CLI, install the same
-package and then assign the plugin id `libravdb-memory` to both the `memory`
-and `contextEngine` slots.
+package and then assign the plugin id `libravdb-memory` to the `memory` slot.
 
 Activate the plugin in `~/.openclaw/openclaw.json`:
 
@@ -46,8 +45,7 @@ Activate the plugin in `~/.openclaw/openclaw.json`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
+      "memory": "libravdb-memory"
     }
   }
 }
@@ -59,12 +57,14 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
+      "memory": "libravdb-memory"
     },
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        }
       }
     }
   }
@@ -158,7 +158,7 @@ you wrap it in `brew services`, `systemd`, or `launchd`.
 ### Plugin Lifecycle
 
 - Install the package with `openclaw plugins install`.
-- Activate it by assigning `libravdb-memory` to both `memory` and `contextEngine`.
+- Activate it by assigning `libravdb-memory` to the `memory` slot.
 - Update it with your normal OpenClaw plugin update flow.
 - Disable it by removing the slot assignment from `~/.openclaw/openclaw.json`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,21 +60,20 @@ or run `libravdbd serve` in a terminal for validation.
 
 ## Activation
 
-Assign `libravdb-memory` to both OpenClaw slots:
+Assign `libravdb-memory` to the OpenClaw memory slot:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
+      "memory": "libravdb-memory"
     }
   }
 }
 ```
 
-Treat partial assignment as a misconfiguration. This plugin is designed to own
-memory prompt injection and the context-engine lifecycle together.
+The plugin registers both memory and context-engine capabilities at runtime;
+current OpenClaw config only needs the `memory` slot assignment.
 
 If the daemon uses a non-default endpoint, add `sidecarPath`:
 
@@ -82,12 +81,14 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory",
-      "contextEngine": "libravdb-memory"
+      "memory": "libravdb-memory"
     },
-    "configs": {
+    "entries": {
       "libravdb-memory": {
-        "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        "enabled": true,
+        "config": {
+          "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+        }
       }
     }
   }
@@ -177,9 +178,9 @@ setup, or republish the release with corrected checksums.
 
 ### Default memory still appears active
 
-Confirm that `libravdb-memory` is assigned to both `memory` and
-`contextEngine`. Without both slot entries, OpenClaw's default memory path can
-continue to run in parallel.
+Confirm that `libravdb-memory` is assigned to `plugins.slots.memory`.
+Without that slot entry, OpenClaw's default memory path can continue to run in
+parallel.
 
 ### Lifecycle journal looks empty
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -18,9 +18,9 @@ Remove the plugin from the active OpenClaw slot in `~/.openclaw/openclaw.json`:
 }
 ```
 
-Treat that JSON as a minimal example only. If you assigned `libravdb-memory`
-under both `memory` and `contextEngine`, remove those two slot entries and
-leave any other plugin slots intact.
+Treat that JSON as a minimal example only. If you assigned
+`libravdb-memory` under `memory`, remove that slot entry and leave any other
+plugin slots intact.
 
 If you installed the package through the OpenClaw.ai plugin UI, remove or
 disable the same package there as well. If you use the CLI, remove it through


### PR DESCRIPTION
## Summary
- update install/config examples from legacy `plugins.configs` to current `plugins.entries.<id>.config`
- remove stale `contextEngine` slot assignment guidance; the plugin checks `plugins.slots.memory` and registers context-engine capability at runtime
- refresh related README, install, feature, uninstall, and architecture wording

## Verification
- verified live OpenClaw/Libra configs use `plugins.slots.memory` plus `plugins.entries.<id>.config`
- verified source comments/checks only treat `plugins.slots.memory` as configurable
- parsed all changed fenced JSON examples successfully
- `npm run test:ts` ✅ 82/82
- `npm run test:integration` ✅ 30/30

Note: `pnpm run check` could not be run in this checkout because `pnpm` is not installed on this host; the underlying test scripts were run directly with npm.