### PR TITLE
fix: honor disabled cross-session recall in memory runtime

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -183,6 +183,9 @@ async function searchResolvedCollections(
   k: number,
 ): Promise<{ results: SearchResult[] }> {
   const collections = resolveSearchCollections(cfg, userId, sessionId);
+  if (collections.length === 0) {
+    return { results: [] };
+  }
   return collections.length === 1
     ? await rpc.call<{ results: SearchResult[] }>("search_text", {
         collection: collections[0],
@@ -198,21 +201,27 @@ async function searchResolvedCollections(
 }
 
 function resolveSearchCollections(cfg: PluginConfig, userId: string, sessionId?: string): string[] {
+  if (cfg.crossSessionRecall === false) {
+    return sessionId ? [resolveSessionSearchCollection(cfg, sessionId)] : [];
+  }
+
   const collections = [`user:${userId}`, "global"];
   if (!sessionId) {
     return collections;
   }
 
+  collections.unshift(resolveSessionSearchCollection(cfg, sessionId));
+  return collections;
+}
+
+function resolveSessionSearchCollection(cfg: PluginConfig, sessionId: string): string {
   if (cfg.useSessionSummarySearchExperiment) {
-    collections.unshift(`session_summary:${sessionId}`);
-    return collections;
+    return `session_summary:${sessionId}`;
   }
   if (cfg.useSessionRecallProjection) {
-    collections.unshift(`session_recall:${sessionId}`);
-    return collections;
+    return `session_recall:${sessionId}`;
   }
-  collections.unshift(`session:${sessionId}`);
-  return collections;
+  return `session:${sessionId}`;
 }
 
 function firstString(...values: Array<string | undefined>): string | undefined {

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -132,6 +132,34 @@ test("memory runtime bridge keeps the legacy string search shape", async () => {
   assert.equal(result.results[0]?.content, "remembered item");
 });
 
+test("memory runtime bridge respects disabled cross-session recall", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {
+    crossSessionRecall: false,
+    useSessionRecallProjection: true,
+  });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find session context", sessionId: "s1", userId: "u1" });
+
+  assert.ok(Array.isArray(result));
+  assert.equal(rpc.calls[1]?.method, "search_text");
+  assert.equal(rpc.calls[1]?.params.collection, "session_recall:s1");
+  assert.equal(rpc.calls.some((call) => call.method === "search_text_collections"), false);
+  assert.equal(result.length, 1);
+});
+
+test("memory runtime bridge returns no results without a session when cross-session recall is disabled", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find prior context", userId: "u1" });
+
+  assert.deepEqual(result, []);
+  assert.equal(rpc.calls.length, 1, "only the initial status check should run");
+});
+
 test("memory runtime bridge round-trips encoded collection names in result paths", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});


### PR DESCRIPTION
## Summary
- make the memory runtime search bridge respect `crossSessionRecall: false`
- limit searches to the active session collection when a session id is available
- return no runtime-search results instead of querying durable user/global collections when no session id is available
- add unit coverage for both paths

## Why
`crossSessionRecall` was already documented as disabling durable user recall and exact recall already honors it, but the memory runtime bridge ignored it. Calls through the memory search manager could still query `user:*` and `global` collections even when config requested session-only recall.

## Testing
- [x] `git diff --check`
- [x] `npm run test:ts` — 84/84 pass
- [x] `npm run test:integration` — 30/30 pass

Note: `pnpm check` could not be run on this host because `pnpm` is not installed. The substantive TypeScript/unit gate was run directly with `npm run test:ts`, and integration tests were run with `npm run test:integration`.
