### PR TITLE
fix: allow memory flush by session key

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,11 +147,7 @@ export function registerMemoryCli(
 
       const flush = ensureCommand(root, "flush")
         .description("Wipe a durable memory namespace after confirmation");
-      if (flush.requiredOption) {
-        flush.requiredOption("--user-id <userId>", "User id whose durable memory should be deleted");
-      } else {
-        flush.option("--user-id <userId>", "User id whose durable memory should be deleted");
-      }
+      flush.option("--user-id <userId>", "User id whose durable memory should be deleted");
       flush.option("--session-key <sessionKey>", "Session key whose derived durable namespace should be deleted");
       flush
         .option("--yes", "Skip the confirmation prompt")

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -21,6 +21,7 @@ class FakeCommand {
   public commands: FakeCommand[] = [];
   public descriptions: string[] = [];
   public options: string[] = [];
+  public requiredOptions: string[] = [];
   public arguments: string[] = [];
   public handler: ((...args: unknown[]) => unknown) | null = null;
 
@@ -49,6 +50,7 @@ class FakeCommand {
 
   requiredOption(flags: string): FakeCommand {
     this.options.push(flags);
+    this.requiredOptions.push(flags);
     return this;
   }
 
@@ -148,6 +150,17 @@ test("full CLI registration exposes standard memory commands and LibraVDB operat
   assert.ok(search.options.includes("--query <text>"));
   assert.ok(search.options.includes("--max-results <n>"));
   assert.ok(search.options.includes("--json"));
+
+  const flush = memory.commands.find((command) => command.name() === "flush");
+  assert.ok(flush);
+  assert.ok(flush.options.includes("--user-id <userId>"));
+  assert.ok(flush.options.includes("--session-key <sessionKey>"));
+  assert.equal(flush.requiredOptions.includes("--user-id <userId>"), false);
+
+  const dreamPromote = memory.commands.find((command) => command.name() === "dream-promote");
+  assert.ok(dreamPromote);
+  assert.ok(dreamPromote.requiredOptions.includes("--user-id <userId>"));
+  assert.ok(dreamPromote.requiredOptions.includes("--dream-file <path>"));
 });
 
 test("status command shuts the plugin runtime down after printing status", async () => {


### PR DESCRIPTION
## Summary
- stop registering `memory flush --user-id` as a Commander required option
- keep runtime validation requiring either `--user-id` or `--session-key`
- add CLI registration coverage so `--session-key` remains usable while `dream-promote` keeps its truly required options

## Why
The docs advertise both:

```bash
openclaw memory flush --user-id <userId>
openclaw memory flush --session-key <sessionKey>
```

But when Commander supports `requiredOption`, the CLI registered `--user-id` as required. That means `memory flush --session-key <sessionKey>` would be rejected by the CLI parser before `runFlush()` could apply its intended “user id or session key” validation.

## Testing
- [x] `git diff --check`
- [x] `npm run test:ts` — 82/82 pass
- [x] `npm run test:integration` — 30/30 pass

Note: `pnpm check` could not be run on this host because `pnpm` is not installed. The substantive TypeScript/unit gate was run directly with `npm run test:ts`, and integration tests were run with `npm run test:integration`.
