### PR TITLE
fix: validate configured sidecar endpoints

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -585,7 +585,21 @@ function describeEndpoint(endpoint: string): string {
 }
 
 function isConfiguredEndpoint(value?: string): boolean {
-  return value?.startsWith("tcp:") === true || value?.startsWith("unix:") === true;
+  if (!value) return false;
+  if (value.startsWith("unix:")) {
+    return value.slice("unix:".length).trim().length > 0;
+  }
+  if (!value.startsWith("tcp:")) {
+    return false;
+  }
+  const address = value.slice("tcp:".length);
+  const separator = address.lastIndexOf(":");
+  if (separator <= 0 || separator === address.length - 1) {
+    return false;
+  }
+  const host = address.slice(0, separator).trim();
+  const port = Number(address.slice(separator + 1));
+  return host.length > 0 && Number.isInteger(port) && port > 0 && port <= 65535;
 }
 
 export { PlaceholderSocket };

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -27,6 +27,16 @@ test("resolveConfiguredEndpoint rejects executable paths", () => {
   );
 });
 
+test("resolveConfiguredEndpoint rejects malformed daemon endpoints", () => {
+  for (const sidecarPath of ["unix:", "tcp:", "tcp::123", "tcp:127.0.0.1", "tcp:127.0.0.1:notaport", "tcp:127.0.0.1:70000"]) {
+    assert.throws(
+      () => resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath }),
+      /must be a daemon endpoint/,
+      sidecarPath,
+    );
+  }
+});
+
 test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", () => {
   // On machines where /opt/homebrew/var/clawdb/run/libravdb.sock exists (Homebrew install),
   // defaultEndpoint probes the filesystem and returns the Homebrew path. On machines without


### PR DESCRIPTION
## Summary
- tighten `sidecarPath` endpoint validation for configured daemon endpoints
- reject empty Unix socket endpoints and malformed TCP endpoints before socket creation
- add unit coverage for invalid endpoint shapes

## Why
`resolveConfiguredEndpoint()` only checked whether `sidecarPath` started with `unix:` or `tcp:`. Values like `unix:`, `tcp:`, `tcp:127.0.0.1`, `tcp:127.0.0.1:notaport`, or out-of-range TCP ports passed validation and failed later with lower-level socket/runtime errors.

This keeps the existing user-facing config error at the boundary where the invalid `sidecarPath` is parsed.

## Testing
- [x] `git diff --check`
- [x] `npm run test:ts` — 83/83 pass
- [x] `npm run test:integration` — 30/30 pass

Note: `pnpm check` could not be run on this host because `pnpm` is not installed. The substantive TypeScript/unit gate was run directly with `npm run test:ts`, and integration tests were run with `npm run test:integration`.
