### PR TITLE
feat: implement status --deep to probe authored collection health

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -113,7 +113,7 @@ CLI API.
 
 | Command | Purpose |
 |---|---|
-| `openclaw memory status` | Show sidecar health, counts, active thresholds, and model readiness. |
+| `openclaw memory status` | Show sidecar health, counts, active thresholds, and model readiness. Use `--deep` to probe authored collection search health. |
 | `openclaw memory index --force` | Refresh delegated sidecar index state for OpenClaw memory CLI compatibility. |
 | `openclaw memory search "query"` | Search LibraVDB memory through the active memory runtime bridge. |
 | `openclaw memory export --user-id <userId>` | Stream stored memories as newline-delimited JSON for one durable namespace. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,18 @@ type StatusResult = {
   embeddingProfile?: string;
 };
 
+type DeepStatusProbe = {
+  ok: boolean;
+  collection: string;
+  resultCount?: number;
+  error?: string;
+};
+
+type DeepStatusResult = {
+  ok: boolean;
+  probes: DeepStatusProbe[];
+};
+
 type ExportResult = {
   records?: Array<{
     collection: string;
@@ -243,8 +255,12 @@ async function runStatus(
   try {
     const rpc = await runtime.getRpc();
     const status = await rpc.call<StatusResult>("status", {});
+    const deep = opts.deep ? await runDeepStatusProbe(rpc) : undefined;
     if (opts.json) {
-      console.log(JSON.stringify({ status }, null, 2));
+      console.log(JSON.stringify({ status, ...(deep ? { deep } : {}) }, null, 2));
+      if (deep && !deep.ok) {
+        process.exitCode = 1;
+      }
       return;
     }
     console.table({
@@ -255,8 +271,12 @@ async function runStatus(
       "Gate threshold": status.gatingThreshold ?? cfg.ingestionGateThreshold ?? 0.35,
       "Abstractive model": status.abstractiveReady ? "ready" : "not provisioned",
       "Embedding profile": status.embeddingProfile ?? "unknown",
+      ...(deep ? formatDeepStatusTableRows(deep) : {}),
       Message: status.message ?? (status.ok ? "ok" : "unavailable"),
     });
+    if (deep && !deep.ok) {
+      process.exitCode = 1;
+    }
   } catch (error) {
     logger.error(`LibraVDB status unavailable: ${formatError(error)}`);
     if (opts.json) {
@@ -288,6 +308,48 @@ async function runStatus(
     });
     process.exitCode = 1;
   }
+}
+
+const DEEP_STATUS_COLLECTIONS = ["authored:hard", "authored:soft", "authored:variant"] as const;
+
+async function runDeepStatusProbe(rpc: { call<T>(method: string, params: unknown): Promise<T> }): Promise<DeepStatusResult> {
+  const probes: DeepStatusProbe[] = [];
+  for (const collection of DEEP_STATUS_COLLECTIONS) {
+    try {
+      const result = await rpc.call<{ results?: unknown[] }>("search_text", {
+        collection,
+        text: "memory",
+        k: 1,
+      });
+      probes.push({
+        ok: true,
+        collection,
+        resultCount: Array.isArray(result.results) ? result.results.length : 0,
+      });
+    } catch (error) {
+      probes.push({
+        ok: false,
+        collection,
+        error: formatError(error),
+      });
+    }
+  }
+  return {
+    ok: probes.every((probe) => probe.ok),
+    probes,
+  };
+}
+
+function formatDeepStatusTableRows(deep: DeepStatusResult): Record<string, string> {
+  const rows: Record<string, string> = {
+    "Deep probe": deep.ok ? "ok" : "failed",
+  };
+  for (const probe of deep.probes) {
+    rows[`Probe ${probe.collection}`] = probe.ok
+      ? `ok (${probe.resultCount ?? 0} hits)`
+      : `failed: ${probe.error ?? "unknown error"}`;
+  }
+  return rows;
 }
 
 async function runIndex(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,7 +116,7 @@ export function registerMemoryCli(
         .description("Show sidecar health, record counts, and active thresholds")
         .option("--agent <id>", "Agent id")
         .option("--json", "Print JSON")
-        .option("--deep", "Probe daemon readiness")
+        .option("--deep", "Probe authored collection search health")
         .option("--index", "Refresh delegated index state before printing status")
         .option("--fix", "Accepted for OpenClaw memory CLI compatibility")
         .option("--verbose", "Verbose logging")

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -212,6 +212,83 @@ test("status command shuts the plugin runtime down after printing status", async
   assert.equal(shutdownCalls, 1);
 });
 
+test("status --deep probes authored collection search health", async () => {
+  let registered: RegisteredCli | null = null;
+  let shutdownCalls = 0;
+  const rpcCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>) {
+            rpcCalls.push({ method, params });
+            if (method === "status") {
+              return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
+            }
+            if (method === "search_text") {
+              if (params.collection === "authored:soft") {
+                throw new Error("query vector dimension 384 does not match collection dimension 1");
+              }
+              return { results: [] };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const status = memory?.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const originalLog = console.log;
+  const previousExitCode = process.exitCode;
+  const logs: string[] = [];
+  let observedExitCode: string | number | undefined;
+  console.log = ((message?: unknown) => { logs.push(String(message)); }) as typeof console.log;
+  process.exitCode = undefined;
+  try {
+    await status.handler?.({ deep: true, json: true });
+    observedExitCode = process.exitCode;
+  } finally {
+    console.log = originalLog;
+    process.exitCode = previousExitCode;
+  }
+
+  const payload = JSON.parse(logs[0] ?? "{}");
+  assert.equal(payload.status.ok, true);
+  assert.equal(payload.deep.ok, false);
+  assert.deepEqual(
+    rpcCalls.filter((call) => call.method === "search_text").map((call) => call.params.collection),
+    ["authored:hard", "authored:soft", "authored:variant"],
+  );
+  assert.match(payload.deep.probes[1]?.error ?? "", /dimension 384/);
+  assert.equal(observedExitCode, 1);
+  assert.equal(shutdownCalls, 1);
+});
+
 test("non-full CLI registration exposes command structure without action handlers", () => {
   let registered: RegisteredCli | null = null;
   const api = {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -289,6 +289,70 @@ test("status --deep probes authored collection search health", async () => {
   assert.equal(shutdownCalls, 1);
 });
 
+test("status --deep includes authored probe rows in table output", async () => {
+  let registered: RegisteredCli | null = null;
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>) {
+            if (method === "status") {
+              return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
+            }
+            if (method === "search_text") {
+              return { results: params.collection === "authored:variant" ? [{ id: "v1" }] : [] };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      async shutdown() {},
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const status = memory?.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const originalTable = console.table;
+  const previousExitCode = process.exitCode;
+  const tables: Array<Record<string, unknown>> = [];
+  console.table = ((value?: unknown) => {
+    tables.push(value as Record<string, unknown>);
+  }) as typeof console.table;
+  process.exitCode = undefined;
+  try {
+    await status.handler?.({ deep: true });
+  } finally {
+    console.table = originalTable;
+    process.exitCode = previousExitCode;
+  }
+
+  assert.equal(tables.length, 1);
+  assert.equal(tables[0]?.["Deep probe"], "ok");
+  assert.equal(tables[0]?.["Probe authored:hard"], "ok (0 hits)");
+  assert.equal(tables[0]?.["Probe authored:soft"], "ok (0 hits)");
+  assert.equal(tables[0]?.["Probe authored:variant"], "ok (1 hits)");
+});
+
 test("non-full CLI registration exposes command structure without action handlers", () => {
   let registered: RegisteredCli | null = null;
   const api = {


### PR DESCRIPTION
## Summary
- implement `openclaw memory status --deep` to probe authored collection search health
- probe `authored:hard`, `authored:soft`, and `authored:variant` with a trivial search_text call
- surface per-collection ok/failure with error details; set exit code 1 on any probe failure
- update features doc to describe `--deep` flag

## Why
`--deep` was registered as a CLI option but did nothing. Operators (especially beta testers with isolated profiles) need to verify that authored collections are searchable, not just that the sidecar is "running". This catches problems like dimension mismatches (#42) early instead of silently degrading.

## Testing
- [x] `git diff --check`
- [x] `npm run test:ts` — 83/83 pass
- [x] `npm run test:integration` — 30/30 pass

Note: `pnpm check` could not be run on this host because `pnpm` is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--deep` flag to `openclaw memory status` command for deeper search health diagnostics
  * Reports per-collection search probe results in both JSON and table output formats
  * Sets appropriate exit codes based on search health status

* **Documentation**
  * Updated `openclaw memory status` documentation with `--deep` flag usage instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->