### PR TITLE
fix: gate dream query path behind crossSessionRecall config

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -183,6 +183,9 @@ async function searchResolvedCollections(
   k: number,
 ): Promise<{ results: SearchResult[] }> {
   const collections = resolveSearchCollections(cfg, userId, sessionId);
+  if (collections.length === 0) {
+    return { results: [] };
+  }
   return collections.length === 1
     ? await rpc.call<{ results: SearchResult[] }>("search_text", {
         collection: collections[0],
@@ -198,21 +201,27 @@ async function searchResolvedCollections(
 }
 
 function resolveSearchCollections(cfg: PluginConfig, userId: string, sessionId?: string): string[] {
+  if (cfg.crossSessionRecall === false) {
+    return sessionId ? [resolveSessionSearchCollection(cfg, sessionId)] : [];
+  }
+
   const collections = [`user:${userId}`, "global"];
   if (!sessionId) {
     return collections;
   }
 
+  collections.unshift(resolveSessionSearchCollection(cfg, sessionId));
+  return collections;
+}
+
+function resolveSessionSearchCollection(cfg: PluginConfig, sessionId: string): string {
   if (cfg.useSessionSummarySearchExperiment) {
-    collections.unshift(`session_summary:${sessionId}`);
-    return collections;
+    return `session_summary:${sessionId}`;
   }
   if (cfg.useSessionRecallProjection) {
-    collections.unshift(`session_recall:${sessionId}`);
-    return collections;
+    return `session_recall:${sessionId}`;
   }
-  collections.unshift(`session:${sessionId}`);
-  return collections;
+  return `session:${sessionId}`;
 }
 
 function firstString(...values: Array<string | undefined>): string | undefined {

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -114,7 +114,7 @@ function createMemorySearchManager(
       const minScore = normalizeNumber(params.minScore);
       const rpc = await getRpc();
 
-      const result = dreamQuery.active
+      const result = dreamQuery.active && cfg.crossSessionRecall !== false
         ? await rpc.call<{ results: SearchResult[] }>("search_text", {
             collection: resolveDreamCollection(userId),
             text: queryText,

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -132,6 +132,34 @@ test("memory runtime bridge keeps the legacy string search shape", async () => {
   assert.equal(result.results[0]?.content, "remembered item");
 });
 
+test("memory runtime bridge respects disabled cross-session recall", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {
+    crossSessionRecall: false,
+    useSessionRecallProjection: true,
+  });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find session context", sessionId: "s1", userId: "u1" });
+
+  assert.ok(Array.isArray(result));
+  assert.equal(rpc.calls[1]?.method, "search_text");
+  assert.equal(rpc.calls[1]?.params.collection, "session_recall:s1");
+  assert.equal(rpc.calls.some((call) => call.method === "search_text_collections"), false);
+  assert.equal(result.length, 1);
+});
+
+test("memory runtime bridge returns no results without a session when cross-session recall is disabled", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find prior context", userId: "u1" });
+
+  assert.deepEqual(result, []);
+  assert.equal(rpc.calls.length, 1, "only the initial status check should run");
+});
+
 test("memory runtime bridge round-trips encoded collection names in result paths", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -87,19 +87,51 @@ test("memory runtime bridge searches the resolved durable namespace under the la
   assert.equal(result[0]?.source, "memory");
 });
 
-test("memory runtime bridge routes dream queries to the dream collection only", async () => {
+test("memory runtime bridge routes dream queries to the dream collection when cross-session recall is enabled", async () => {
+  for (const cfg of [{}, { crossSessionRecall: true }] satisfies PluginConfig[]) {
+    const rpc = new FakeRpc();
+    const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
+    const { manager } = await runtime.getMemorySearchManager();
+
+    const result = await manager.search({ query: "tell me about your dreams from last week", userId: "u1" });
+
+    assert.ok(Array.isArray(result));
+    assert.equal(rpc.calls[1]?.method, "search_text");
+    assert.deepEqual(rpc.calls[1]?.params.collection, "dream:u1");
+    assert.equal(rpc.calls.some((call) => call.method === "search_text_collections"), false);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]?.snippet, "dream recall item");
+  }
+});
+
+test("memory runtime bridge treats dream queries as session-scoped searches when cross-session recall is disabled", async () => {
   const rpc = new FakeRpc();
-  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
   const { manager } = await runtime.getMemorySearchManager();
 
-  const result = await manager.search({ query: "tell me about your dreams from last week", userId: "u1" });
+  const result = await manager.search({
+    query: "tell me about your dreams from last week",
+    userId: "u1",
+    sessionId: "s1",
+  });
 
   assert.ok(Array.isArray(result));
   assert.equal(rpc.calls[1]?.method, "search_text");
-  assert.deepEqual(rpc.calls[1]?.params.collection, "dream:u1");
-  assert.equal(rpc.calls.some((call) => call.method === "search_text_collections"), false);
+  assert.equal(rpc.calls[1]?.params.collection, "session:s1");
+  assert.equal(rpc.calls.some((call) => call.params.collection === "dream:u1"), false);
+  assert.equal(rpc.calls.some((call) => Array.isArray(call.params.collections)), false);
   assert.equal(result.length, 1);
-  assert.equal(result[0]?.snippet, "dream recall item");
+});
+
+test("memory runtime bridge returns no results for dream queries without a session when cross-session recall is disabled", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "tell me about your dreams", userId: "u1" });
+
+  assert.deepEqual(result, []);
+  assert.equal(rpc.calls.some((call) => call.params.collection === "dream:u1"), false);
 });
 
 test("memory runtime bridge falls back to session-scoped namespace when no other identity is present", async () => {


### PR DESCRIPTION
Addresses the gap identified by @fuller-stack-dev on PR #57.

## Problem

When `crossSessionRecall === false`, the dream query branch in `search()` still routes to `dream:${userId}`, which is inherently cross-session (no session scoping). This bypasses the config gate that PR #57 added for the normal search path.

## Fix

- Changed the dream query condition from `dreamQuery.active` to `dreamQuery.active && cfg.crossSessionRecall !== false`. When cross-session recall is disabled, dream queries fall through to `searchResolvedCollections`, which already handles the `crossSessionRecall === false` case correctly.

- Tests cover enabled, disabled, and no-session-id cases for dream queries under crossSessionRecall.

All 10 tests pass.

## Notes

This targets `main` since cross-repo PRs cannot target a non-default branch. If #57 merges first, this can be rebased. The dream gate change is a single line and applies cleanly on top of #57.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search and recall routing to properly respect the cross-session recall configuration setting.
  * Improved session-scoped search functionality: when cross-session recall is disabled, search is now correctly limited to the current session.
  * Enhanced safe handling of empty collection results.

* **Tests**
  * Extended test coverage for conditional search routing based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->