### PR TITLE
chore: update plugin defaults, paths, and docs for daemon v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,44 @@
 </div>
 
 `@xdarkicex/openclaw-memory-libravdb` is a local-first OpenClaw memory plugin
-backed by the `libravdbd` daemon. It replaces the lightweight default memory
+backed by the `libravdbd` vector service. It replaces the lightweight default memory
 path with scoped session, user, and global memory; continuity-aware prompt
 assembly; durable recall; and sidecar-owned compaction.
 
 [Install](./docs/install.md) · [Full installation reference](./docs/installation.md) · [Architecture](./docs/architecture.md) · [Security](./docs/security.md) · [Performance and tuning](./docs/performance-and-tuning.md) · [Contributing](./docs/contributing.md)
 
-New install? Start here: [Install guide](./docs/install.md). Preferred setup on
-macOS: install `libravdbd` with Homebrew, install the OpenClaw plugin, then
-assign the plugin to the OpenClaw memory slot.
+New install? Start here: [Install guide](./docs/install.md).
 
 ## Install
+
+Install `libravdbd` with your system package manager, then install
+the OpenClaw plugin.
+
+**macOS (Homebrew)**
 
 ```bash
 brew tap xDarkicex/homebrew-openclaw-libravdb-memory
 brew install libravdbd
 brew services start libravdbd
+```
+
+**Linux (APT)**
+
+```bash
+sudo apt install libravdbd
+systemctl --user enable --now libravdbd
+```
+
+**Linux (AUR)**
+
+```bash
+yay -S libravdbd-bin
+systemctl --user enable --now libravdbd
+```
+
+**Plugin (all platforms)**
+
+```bash
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
@@ -51,8 +73,11 @@ Then activate the plugin in `~/.openclaw/openclaw.json`:
 }
 ```
 
-Verify the daemon and plugin:
+Verify the service and plugin:
 
+```bash
+openclaw memory status
+```
 
 Healthy output should show `Sidecar=running`, stored memory counts, the active
 gate threshold, and the loaded embedding profile.
@@ -63,7 +88,7 @@ Runtime requirements:
 
 - OpenClaw `>= 2026.3.22`
 - Node.js `>= 22`
-- a separately installed `libravdbd` daemon
+- a separately installed `libravdbd` service
 
 Compatibility note:
 
@@ -71,11 +96,11 @@ Compatibility note:
 
 Default endpoints:
 
-- macOS/Linux user-local daemon: `unix:$HOME/.clawdb/run/libravdb.sock`
-- Homebrew daemon on Apple Silicon: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
-- Windows daemon: `tcp:127.0.0.1:37421`
+- macOS/Linux user-local service: `unix:$HOME/.libravdbd/run/libravdb.sock`
+- Homebrew service on Apple Silicon: `unix:/opt/homebrew/var/libravdbd/run/libravdb.sock`
+- Windows service: `tcp:127.0.0.1:37421`
 
-If your daemon runs elsewhere, set `sidecarPath`:
+If your service runs elsewhere, set `sidecarPath`:
 
 ```json
 {
@@ -108,14 +133,14 @@ If your daemon runs elsewhere, set `sidecarPath`:
   newest working context.
 - **Local-first inference** - uses local embedding and compaction paths by
   default, with optional external summarizer configuration.
-- **Explicit daemon lifecycle** - the npm/OpenClaw package stays connect-only;
+- **Explicit service lifecycle** - the npm/OpenClaw package stays connect-only;
   `libravdbd` is installed and supervised separately.
 
 ## Security Defaults
 
 Stored memory is treated as untrusted historical context. Retrieved memory is
 framed before it reaches the downstream model, memory collections are scoped by
-session/user/global namespace, and daemon installation is outside the npm plugin
+session/user/global namespace, and service installation is outside the npm plugin
 package.
 
 Before exposing OpenClaw over remote channels, read [Security](./docs/security.md).
@@ -123,7 +148,7 @@ Before exposing OpenClaw over remote channels, read [Security](./docs/security.m
 ## Operator Quick Refs
 
 ```bash
-openclaw memory status
+openclaw memory status [--deep] [--json]
 openclaw memory index --force
 openclaw memory search "prior context"
 openclaw memory export --user-id <userId>
@@ -132,8 +157,131 @@ openclaw memory journal --limit 50
 openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
 ```
 
-Use [Install](./docs/install.md) for daemon lifecycle commands and
+Use [Install](./docs/install.md) for service lifecycle commands and
 [Uninstall](./docs/uninstall.md) for safe shutdown and removal.
+
+## Configuration Reference
+
+All configuration keys are optional.
+
+If you do not have a GPU available, setting `onnxDevice` to `"cpu"` is
+recommended to avoid startup failures from missing GPU/NPU providers,
+but this is also optional — the service auto-detects and falls back to
+CPU when a provider is unavailable.
+
+### Connection
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `sidecarPath` | string | `auto` | `"auto"` probes standard socket paths; set `unix:/path` or `tcp:host:port` to override |
+| `grpcEndpoint` | string | — | Optional gRPC kernel endpoint for hosts using the gRPC kernel transport |
+| `rpcTimeoutMs` | number | `30000` | Per-call timeout for service RPC (ms) |
+| `dbPath` | string | auto-named | Explicit DB path; when set bypasses model-specific naming |
+
+### Embedding
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `embeddingProfile` | string | `nomic-embed-text-v1.5` | Primary embedding model |
+| `fallbackProfile` | string | `bge-small-en-v1.5` | Fallback when primary model fails dimension checks |
+| `embeddingBackend` | string | — | `bundled`, `onnx-local`, or `custom-local` |
+| `onnxDevice` | string | `auto` | ONNX execution provider: `auto`, `cpu`, `coreml` (macOS), `cuda` (Linux/Windows), `directml` (Windows), `openvino` (Linux) |
+| `embeddingRuntimePath` | string | — | Path to ONNX runtime library (maps to `LIBRAVDB_ONNX_RUNTIME`) |
+| `embeddingModelPath` | string | — | Path to custom embedding model `.onnx` file |
+| `embeddingTokenizerPath` | string | — | Path to custom tokenizer file |
+| `embeddingDimensions` | number | — | Embedding dimension override |
+| `embeddingNormalize` | boolean | — | Enable embedding normalization |
+
+### Retrieval
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `topK` | number | — | Max results per search |
+| `alpha` | number | — | Semantic similarity weight |
+| `beta` | number | — | Recency weight |
+| `gamma` | number | — | Summary quality weight |
+| `crossSessionRecall` | boolean | `true` | When `false`, only session-scoped memories are retrieved |
+| `useSessionRecallProjection` | boolean | — | Use `session_recall` collection instead of `session` |
+| `useSessionSummarySearchExperiment` | boolean | — | Use `session_summary` collection for search |
+
+### Ingestion gating
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `ingestionGateThreshold` | number | `0.35` | Minimum semantic relevance score to store a memory |
+| `gatingWeights` | object | `{w1c:0.35, w2c:0.4, w3c:0.25, w1t:0.4, w2t:0.35, w3t:0.25}` | Hybrid scoring weights |
+| `gatingTechNorm` | number | `1.5` | Technical content normalization factor |
+| `gatingCentroidK` | number | `10` | K for centroid-based similarity gating |
+
+### Compaction
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `compactThreshold` | number | — | Absolute token threshold for forced compaction |
+| `compactionThresholdFraction` | number | `0.8` | Dynamic trigger as fraction of active token budget |
+| `compactSessionTokenBudget` | number | `2000` | Auto-compact when session exceeds this many tokens since last compaction; `0` disables |
+| `compactionQualityWeight` | number | `0.5` | How much summary confidence affects retrieval score (0 = ignore, 1 = full suppression) |
+
+### Summarizer
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `summarizerBackend` | string | — | `bundled`, `onnx-local`, `ollama-local`, or `custom-local` |
+| `summarizerProfile` | string | — | Summarizer model profile |
+| `summarizerModel` | string | — | Model name for summarization |
+| `summarizerModelPath` | string | — | Path to summarizer model file |
+| `summarizerTokenizerPath` | string | — | Path to summarizer tokenizer file |
+| `summarizerRuntimePath` | string | — | Path to summarizer ONNX runtime |
+| `summarizerEndpoint` | string | — | External summarizer endpoint URL |
+| `ollamaUrl` | string | — | Ollama base URL (populates `summarizerEndpoint` when unset) |
+| `compactModel` | string | — | Model to use for compaction summaries (populates `summarizerModel` when unset) |
+
+### Identity
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `userId` | string | auto-derived | Stable user identity for cross-session durable memory |
+| `identityPath` | string | `$OPENCLAW_STATE_DIR/libravdb-identity.json` | Custom path for the auto-derived identity file |
+
+### Markdown ingestion
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `markdownIngestionEnabled` | boolean | `false` | Watch markdown roots for changes |
+| `markdownIngestionRoots` | string[] | — | Directories to watch |
+| `markdownIngestionInclude` | string[] | — | Glob patterns to include |
+| `markdownIngestionExclude` | string[] | — | Glob patterns to exclude |
+| `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
+| `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
+| `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |
+| `markdownIngestionObsidianInclude` | string[] | — | Obsidian glob include patterns |
+| `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
+| `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
+
+### Dream promotion
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `dreamPromotionEnabled` | boolean | `false` | Enable dream diary promotion |
+| `dreamPromotionDiaryPath` | string | — | Path to dream diary markdown file |
+| `dreamPromotionUserId` | string | — | User ID for dream collection scoping |
+| `dreamPromotionDebounceMs` | number | `150` | Debounce window for dream diary changes |
+
+### Misc
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `sessionTTL` | number | — | Session TTL in seconds |
+| `recencyLambdaSession` | number | — | Session recency decay factor |
+| `recencyLambdaUser` | number | — | User recency decay factor |
+| `recencyLambdaGlobal` | number | — | Global recency decay factor |
+| `tokenBudgetFraction` | number | — | Fraction of host token budget to use for memory context |
+| `maxRetries` | number | — | Max RPC retries |
+| `logLevel` | string | — | Log level override |
+| `lifecycleJournalMaxEntries` | number | `500` | Max lifecycle journal entries |
+| `authoredHardBudgetFraction` | number | — | Token budget fraction for hard-authored recall (0–1) |
+| `authoredSoftBudgetFraction` | number | — | Token budget fraction for soft-authored recall (0–1) |
+| `elevatedGuidanceBudgetFraction` | number | — | Token budget fraction for elevated guidance recall (0–1) |
 
 ## Optional Features
 
@@ -141,8 +289,8 @@ Use [Install](./docs/install.md) for daemon lifecycle commands and
   and syncs eligible notes into memory. See [Features](./docs/features.md).
 - **Dream promotion** promotes vetted dream diary bullets into an isolated
   `dream:{userId}` collection. See [Features](./docs/features.md).
-- **Embedding profiles** expose local model metadata defaults for MiniLM and
-  Nomic. See [Embedding profiles](./docs/embedding-profiles.md).
+- **Embedding profiles** default to `nomic-embed-text-v1.5` with `bge-small-en-v1.5`
+  fallback. See [Embedding profiles](./docs/embedding-profiles.md).
 
 ## Docs By Goal
 
@@ -162,8 +310,8 @@ bash scripts/build-daemon.sh
 ```
 
 `scripts/build-daemon.sh` prepares `.daemon-bin/libravdbd` for local plugin
-testing when you have a published daemon binary, a Homebrew daemon, or a local
-daemon checkout. For the full source workflow, read [Development](./docs/development.md).
+testing when you have a published service binary, a Homebrew service, or a local
+service checkout. For the full source workflow, read [Development](./docs/development.md).
 
 ## Runtime Facts
 
@@ -171,6 +319,6 @@ daemon checkout. For the full source workflow, read [Development](./docs/develop
 - OpenClaw plugin id: `libravdb-memory`
 - plugin kind: `memory`, `context-engine`
 - minimum OpenClaw host version: `>= 2026.3.22`
-- default data path: `$HOME/.clawdb/data.libravdb`
-- default macOS/Linux endpoint: `unix:$HOME/.clawdb/run/libravdb.sock`
+- default data path: `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
+- default macOS/Linux endpoint: `unix:$HOME/.libravdbd/run/libravdb.sock`
 - default Windows endpoint: `tcp:127.0.0.1:37421`

--- a/docs/embedding-profiles.md
+++ b/docs/embedding-profiles.md
@@ -1,32 +1,31 @@
 # Embedding Profiles
 
-The plugin now supports a lightweight `embeddingProfile` setting for named local model metadata defaults.
+The plugin uses `embeddingProfile` for named local model metadata defaults.
 
-Default selection baseline as of `2026-03-28`:
+Default selection baseline:
 
 - default embedding profile: `nomic-embed-text-v1.5`
-- bundled fallback profile: `nomic-embed-text-v1.5`
+- bundled fallback profile: `bge-small-en-v1.5`
 
 Why:
 
-- MiniLM keeps the local LongMemEval retrieval slice inside the target memory envelope on macOS.
-- Nomic remains available as an explicit opt-in profile for long-context experiments.
-- Nomic ONNX on macOS is fragile with CoreML execution and can trigger multi-GB RSS, so it is no longer the safe bundled default.
+- Nomic is the default because its Matryoshka-trained embeddings deliver significantly higher retrieval accuracy than MiniLM, with principled dimensionality tiering (`64d → 256d → 768d`) that lets the daemon trade memory for precision without re-embedding.
+- bge-small-en-v1.5 is the fallback for resource-constrained systems and is automatically selected when the primary model's dimensions do not match the active collection.
 - Intel Macs without reliable Metal/MPS support should set `onnxDevice: "cpu"` to force CPU ONNX execution and bypass CoreML.
 
 Current shipped profile names:
 
 - `nomic-embed-text-v1.5`
   - family: `nomic-embed-text-v1.5`
-  - dimensions: `384`
-  - normalize: `true`
-  - max context tokens: `128`
-
-- `nomic-embed-text-v1.5`
-  - family: `nomic-embed-text-v1.5`
   - dimensions: `768`
   - normalize: `true`
   - max context tokens: `8192`
+
+- `bge-small-en-v1.5`
+  - family: `bge-small-en-v1.5`
+  - dimensions: `384`
+  - normalize: `true`
+  - max context tokens: `512`
 
 How it works:
 
@@ -38,6 +37,6 @@ How it works:
 
 Recommended usage:
 
-- `bundled` for the shipped default path, which now prefers MiniLM for local stability.
-- `onnx-local` plus `embeddingProfile` when a power user wants a known model family like Nomic with local assets.
+- `bundled` for the shipped default path, which uses `nomic-embed-text-v1.5`.
+- `onnx-local` plus `embeddingProfile` when a power user wants a known model family with local assets.
 - treat remote/Ollama providers as future separate backend types, not as overloads of `custom-local`.

--- a/docs/embedding-profiles.md
+++ b/docs/embedding-profiles.md
@@ -4,8 +4,8 @@ The plugin now supports a lightweight `embeddingProfile` setting for named local
 
 Default selection baseline as of `2026-03-28`:
 
-- default embedding profile: `all-minilm-l6-v2`
-- bundled fallback profile: `all-minilm-l6-v2`
+- default embedding profile: `nomic-embed-text-v1.5`
+- bundled fallback profile: `nomic-embed-text-v1.5`
 
 Why:
 
@@ -16,8 +16,8 @@ Why:
 
 Current shipped profile names:
 
-- `all-minilm-l6-v2`
-  - family: `all-minilm-l6-v2`
+- `nomic-embed-text-v1.5`
+  - family: `nomic-embed-text-v1.5`
   - dimensions: `384`
   - normalize: `true`
   - max context tokens: `128`

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,13 +85,15 @@ The daemon owns the local database, embeddings, and JSON-RPC endpoint.
 
 Default endpoints:
 
-- Homebrew on macOS: `unix:/opt/homebrew/var/libravdbd/run/libravdb.sock`
+- Homebrew on macOS (Apple Silicon): `unix:/opt/homebrew/var/libravdbd/run/libravdb.sock`
+- Homebrew on macOS (Intel): `unix:/usr/local/var/libravdbd/run/libravdb.sock`
 - macOS/Linux user-local installs: `unix:$HOME/.libravdbd/run/libravdb.sock`
 - Windows: `tcp:127.0.0.1:37421`
 
 Default data path:
 
-- macOS/Linux/Windows user installs: `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
+- macOS/Linux user installs: `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
+- Windows user installs: `%USERPROFILE%\.libravdbd\data_nomic-embed-text-v1_5.libravdb`
 
 ### Homebrew
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -63,7 +63,7 @@ If you run the daemon on a non-default endpoint, add a plugin config:
       "libravdb-memory": {
         "enabled": true,
         "config": {
-          "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+          "sidecarPath": "unix:/Users/<you>/.libravdbd/run/libravdb.sock"
         }
       }
     }
@@ -74,10 +74,10 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 When `sidecarPath` is set to `"auto"`, the plugin resolves endpoints in this order on macOS/Linux:
 
 1. `LIBRAVDB_RPC_ENDPOINT` if it is set to a valid daemon endpoint
-2. `$HOME/.clawdb/run/libravdb.sock` if it exists
-3. `/opt/homebrew/var/clawdb/run/libravdb.sock` if it exists
-4. `/usr/local/var/clawdb/run/libravdb.sock` if it exists
-5. fallback to `$HOME/.clawdb/run/libravdb.sock`
+2. `$HOME/.libravdbd/run/libravdb.sock` if it exists
+3. `/opt/homebrew/var/libravdbd/run/libravdb.sock` if it exists
+4. `/usr/local/var/libravdbd/run/libravdb.sock` if it exists
+5. fallback to `$HOME/.libravdbd/run/libravdb.sock`
 
 ## Sidecar Daemon Install
 
@@ -85,13 +85,13 @@ The daemon owns the local database, embeddings, and JSON-RPC endpoint.
 
 Default endpoints:
 
-- Homebrew on macOS: `unix:/opt/homebrew/var/clawdb/run/libravdb.sock`
-- macOS/Linux user-local installs: `unix:$HOME/.clawdb/run/libravdb.sock`
+- Homebrew on macOS: `unix:/opt/homebrew/var/libravdbd/run/libravdb.sock`
+- macOS/Linux user-local installs: `unix:$HOME/.libravdbd/run/libravdb.sock`
 - Windows: `tcp:127.0.0.1:37421`
 
 Default data path:
 
-- macOS/Linux/Windows user installs: `$HOME/.clawdb/data.libravdb`
+- macOS/Linux/Windows user installs: `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
 
 ### Homebrew
 
@@ -188,5 +188,5 @@ Healthy output should show that:
 
 If OpenClaw cannot reach the daemon, verify the endpoint first:
 
-- macOS/Linux default: `unix:$HOME/.clawdb/run/libravdb.sock`
+- macOS/Linux default: `unix:$HOME/.libravdbd/run/libravdb.sock`
 - Windows default: `tcp:127.0.0.1:37421`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
       "libravdb-memory": {
         "enabled": true,
         "config": {
-          "sidecarPath": "unix:/Users/<you>/.clawdb/run/libravdb.sock"
+          "sidecarPath": "unix:/Users/<you>/.libravdbd/run/libravdb.sock"
         }
       }
     }
@@ -98,23 +98,23 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
 When `sidecarPath` is `"auto"`, macOS/Linux endpoint resolution checks:
 
 1. `LIBRAVDB_RPC_ENDPOINT`
-2. `$HOME/.clawdb/run/libravdb.sock`
-3. `/opt/homebrew/var/clawdb/run/libravdb.sock`
-4. `/usr/local/var/clawdb/run/libravdb.sock`
-5. fallback to `$HOME/.clawdb/run/libravdb.sock`
+2. `$HOME/.libravdbd/run/libravdb.sock`
+3. `/opt/homebrew/var/libravdbd/run/libravdb.sock`
+4. `/usr/local/var/libravdbd/run/libravdb.sock`
+5. fallback to `$HOME/.libravdbd/run/libravdb.sock`
 
 ## Default Paths
 
 | Platform | Default endpoint |
 |---|---|
-| macOS/Linux user-local | `unix:$HOME/.clawdb/run/libravdb.sock` |
-| macOS Homebrew Apple Silicon | `unix:/opt/homebrew/var/clawdb/run/libravdb.sock` |
+| macOS/Linux user-local | `unix:$HOME/.libravdbd/run/libravdb.sock` |
+| macOS Homebrew Apple Silicon | `unix:/opt/homebrew/var/libravdbd/run/libravdb.sock` |
 | Windows | `tcp:127.0.0.1:37421` |
 
 Default data path:
 
 ```text
-$HOME/.clawdb/data.libravdb
+$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb
 ```
 
 ## Verification
@@ -135,7 +135,7 @@ Expected output shape:
 │ Lifecycle hints    │ 0                            │
 │ Gate threshold     │ 0.35                         │
 │ Abstractive model  │ ready | not provisioned      │
-│ Embedding profile  │ all-minilm-l6-v2             │
+│ Embedding profile  │ nomic-embed-text-v1.5             │
 │ Message            │ ok                           │
 └────────────────────┴──────────────────────────────┘
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -20,7 +20,7 @@ latency and offline operation are part of the product contract.
 
 ## Default And Optional Embedding Profiles
 
-The current safe default profile is `all-minilm-l6-v2`.
+The current safe default profile is `nomic-embed-text-v1.5`.
 
 MiniLM is the default because it keeps local retrieval within the target memory
 envelope on macOS and is less fragile with ONNX Runtime execution than larger
@@ -46,7 +46,7 @@ generative models would increase latency and operational complexity.
 
 | Model/profile | Role |
 |---|---|
-| `all-minilm-l6-v2` | Default lightweight embedding profile. |
+| `nomic-embed-text-v1.5` | Default lightweight embedding profile. |
 | `nomic-embed-text-v1.5` | Opt-in long-context embedding profile. |
 | T5-small | Optional local abstractive compaction summarizer. |
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -20,16 +20,15 @@ latency and offline operation are part of the product contract.
 
 ## Default And Optional Embedding Profiles
 
-The current safe default profile is `nomic-embed-text-v1.5`.
+The default profile is `nomic-embed-text-v1.5`. Nomic was chosen as the default
+because its Matryoshka-trained embeddings deliver significantly higher retrieval
+accuracy than MiniLM, with principled dimensionality tiering (`64d → 256d →
+768d`) that lets the daemon trade memory for precision without re-embedding.
 
-MiniLM is the default because it keeps local retrieval within the target memory
-envelope on macOS and is less fragile with ONNX Runtime execution than larger
-profiles.
-
-`nomic-embed-text-v1.5` remains available as an explicit opt-in profile for
-long-context retrieval experiments. Nomic's Matryoshka training makes
-`64d -> 256d -> 768d` tiering principled rather than arbitrary truncation, but
-its larger footprint makes it a less conservative default.
+`bge-small-en-v1.5` is the fallback profile. It has a smaller disk and memory
+footprint than Nomic and is automatically selected when the primary model's
+dimensions do not match the active collection. Operators on resource-constrained
+systems can also set it as the primary profile for lighter local inference.
 
 For exact profile metadata, read [Embedding profiles](./embedding-profiles.md).
 
@@ -46,8 +45,8 @@ generative models would increase latency and operational complexity.
 
 | Model/profile | Role |
 |---|---|
-| `nomic-embed-text-v1.5` | Default lightweight embedding profile. |
-| `nomic-embed-text-v1.5` | Opt-in long-context embedding profile. |
+| `nomic-embed-text-v1.5` | Default embedding profile — high-accuracy Matryoshka embeddings. |
+| `bge-small-en-v1.5` | Fallback embedding profile — lighter footprint for constrained systems. |
 | T5-small | Optional local abstractive compaction summarizer. |
 
 External summarizer endpoints, such as Ollama, are optional. They are not part

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,7 +27,7 @@ Current implementation facts:
 - the published plugin manifest does not register `openclaw.setup`
 - the published plugin source contains no direct `child_process` usage
 - the plugin connects only to a configured local endpoint such as
-  `unix:/Users/<you>/.clawdb/run/libravdb.sock` or `tcp:127.0.0.1:37421`
+  `unix:/Users/<you>/.libravdbd/run/libravdb.sock` or `tcp:127.0.0.1:37421`
 - daemon installation and lifecycle are explicit user or operator actions
 
 The daemon distribution surface should be evaluated separately from the plugin

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -84,8 +84,8 @@ Only do this if you want to permanently remove stored LibraVDB memory.
 
 Common local state:
 
-- socket directory: `~/.clawdb/run/`
-- database file: `~/.clawdb/data.libravdb`
+- socket directory: `~/.libravdbd/run/`
+- database file: `~/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
 
 If you configured a custom Unix socket endpoint in `sidecarPath`, remove that
 socket path or containing directory if applicable. If you configured `dbPath`,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -85,11 +85,11 @@
       },
       "embeddingProfile": {
         "type": "string",
-        "default": "all-minilm-l6-v2"
+        "default": "nomic-embed-text-v1.5"
       },
       "fallbackProfile": {
         "type": "string",
-        "default": "all-minilm-l6-v2"
+        "default": "bge-small-en-v1.5"
       },
       "embeddingModelPath": {
         "type": "string"

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -430,7 +430,7 @@ start_manual_daemon() {
     return 0
   fi
 
-  mkdir -p "$HOME/.libravdbd"
+  mkdir -p "$HOME/.libravdbd" "$HOME/.libravdbd/run"
   nohup "$HOME/.local/bin/libravdbd" serve > "$HOME/.libravdbd/libravdbd.log" 2>&1 &
   echo $! > "$HOME/.libravdbd/libravdbd.pid"
   warn "Started manual background daemon (no system service)."

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -305,7 +305,7 @@ write_launchd_plist() {
   local escaped_home escaped_daemon_bin escaped_runtime_lib
   local runtime_block=""
 
-  mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs" "$HOME/.clawdb/run"
+  mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs" "$HOME/.libravdbd/run"
   escaped_home="$(xml_escape "$HOME")"
   escaped_daemon_bin="$(xml_escape "$daemon_bin")"
   escaped_runtime_lib="$(xml_escape "$runtime_lib")"
@@ -333,9 +333,9 @@ EOF
     <key>EnvironmentVariables</key>
     <dict>
       <key>LIBRAVDB_RPC_ENDPOINT</key>
-      <string>unix:${escaped_home}/.clawdb/run/libravdb.sock</string>
+      <string>unix:${escaped_home}/.libravdbd/run/libravdb.sock</string>
       <key>LIBRAVDB_DB_PATH</key>
-      <string>${escaped_home}/.clawdb/data.libravdb</string>
+      <string>${escaped_home}/.libravdbd/data_nomic-embed-text-v1_5.libravdb</string>
 ${runtime_block}
       <key>LIBRAVDB_SUMMARIZER_BACKEND</key>
       <string>bundled</string>
@@ -379,7 +379,7 @@ setup_systemd_manual() {
     info "[dry-run] systemctl --user enable --now libravdbd.service"
     return 0
   fi
-  mkdir -p "$HOME/.config/systemd/user" "$HOME/.clawdb/run"
+  mkdir -p "$HOME/.config/systemd/user" "$HOME/.libravdbd/run"
   cat > "$service" <<'EOF'
 [Unit]
 Description=LibraVDB daemon (user)
@@ -389,8 +389,8 @@ After=network.target
 ExecStart=%h/.local/bin/libravdbd serve
 Restart=on-failure
 RestartSec=5
-Environment=LIBRAVDB_RPC_ENDPOINT=unix:%h/.clawdb/run/libravdb.sock
-Environment=LIBRAVDB_DB_PATH=%h/.clawdb/data.libravdb
+Environment=LIBRAVDB_RPC_ENDPOINT=unix:%h/.libravdbd/run/libravdb.sock
+Environment=LIBRAVDB_DB_PATH=%h/.libravdbd/data_nomic-embed-text-v1_5.libravdb
 
 [Install]
 WantedBy=default.target
@@ -416,9 +416,9 @@ start_manual_daemon() {
     return 0
   fi
 
-  if [[ -f "$HOME/.clawdb/libravdbd.pid" ]]; then
+  if [[ -f "$HOME/.libravdbd/libravdbd.pid" ]]; then
     local pid
-    pid="$(cat "$HOME/.clawdb/libravdbd.pid" 2>/dev/null || true)"
+    pid="$(cat "$HOME/.libravdbd/libravdbd.pid" 2>/dev/null || true)"
     if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
       info "Manual daemon already running with pid ${pid}; skipping duplicate start."
       return 0
@@ -430,9 +430,9 @@ start_manual_daemon() {
     return 0
   fi
 
-  mkdir -p "$HOME/.clawdb"
-  nohup "$HOME/.local/bin/libravdbd" serve > "$HOME/.clawdb/libravdbd.log" 2>&1 &
-  echo $! > "$HOME/.clawdb/libravdbd.pid"
+  mkdir -p "$HOME/.libravdbd"
+  nohup "$HOME/.local/bin/libravdbd" serve > "$HOME/.libravdbd/libravdbd.log" 2>&1 &
+  echo $! > "$HOME/.libravdbd/libravdbd.pid"
   warn "Started manual background daemon (no system service)."
 }
 
@@ -447,7 +447,7 @@ xml_escape() {
 }
 
 verify_manual_daemon_ready() {
-  local socket_path="$HOME/.clawdb/run/libravdb.sock"
+  local socket_path="$HOME/.libravdbd/run/libravdb.sock"
   local i
   for i in {1..20}; do
     if [[ -S "$socket_path" ]]; then
@@ -458,7 +458,7 @@ verify_manual_daemon_ready() {
     sleep 0.5
   done
   warn "Manual daemon socket was not detected at ${socket_path} after waiting."
-  warn "If startup failed, inspect logs under ~/.clawdb or ~/Library/Logs/libravdbd.log."
+  warn "If startup failed, inspect logs under ~/.libravdbd or ~/Library/Logs/libravdbd.log."
   return 1
 }
 
@@ -669,8 +669,8 @@ stop_daemon_services() {
     fi
   fi
 
-  if [[ -f "$HOME/.clawdb/libravdbd.pid" ]]; then
-    pid="$(cat "$HOME/.clawdb/libravdbd.pid" 2>/dev/null || true)"
+  if [[ -f "$HOME/.libravdbd/libravdbd.pid" ]]; then
+    pid="$(cat "$HOME/.libravdbd/libravdbd.pid" 2>/dev/null || true)"
     if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
       if [[ "$DRY_RUN" -eq 1 ]]; then
         info "[dry-run] kill ${pid}"
@@ -679,9 +679,9 @@ stop_daemon_services() {
       fi
     fi
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      info "[dry-run] rm -f $HOME/.clawdb/libravdbd.pid"
+      info "[dry-run] rm -f $HOME/.libravdbd/libravdbd.pid"
     else
-      rm -f "$HOME/.clawdb/libravdbd.pid"
+      rm -f "$HOME/.libravdbd/libravdbd.pid"
     fi
   fi
 }
@@ -705,7 +705,7 @@ run_uninstall_mode() {
 
   echo -e "${BOLD}LibraVDB Memory Uninstall (Safe Mode)${RESET}"
   echo "This will stop/remove user-level daemon wiring and remove plugin assignments."
-  echo "Data under ~/.clawdb is not deleted."
+  echo "Data under ~/.libravdbd is not deleted."
   echo
 
   if ! confirm "Proceed with uninstall actions?"; then

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -408,11 +408,11 @@ export function defaultEndpoint(
   const sockName = "libravdb.sock";
   const candidateDirs = [
     // User-local (npm plugin convention)
-    homeDir?.trim() ? path.join(homeDir, ".clawdb", "run") : null,
+    homeDir?.trim() ? path.join(homeDir, ".libravdbd", "run") : null,
     // Homebrew (Apple Silicon) — matches the Homebrew formula LaunchAgent
-    "/opt/homebrew/var/clawdb/run",
+    "/opt/homebrew/var/libravdbd/run",
     // Homebrew (Intel Mac) / manual Linux installs
-    "/usr/local/var/clawdb/run",
+    "/usr/local/var/libravdbd/run",
   ].filter((d): d is string => d !== null);
 
   for (const dir of candidateDirs) {
@@ -428,8 +428,8 @@ export function defaultEndpoint(
 
   // Fallback to the original user-local path so error messages stay familiar.
   const baseDir = homeDir?.trim()
-    ? path.join(homeDir, ".clawdb", "run")
-    : path.join(".", ".clawdb", "run");
+    ? path.join(homeDir, ".libravdbd", "run")
+    : path.join(".", ".libravdbd", "run");
   return `unix:${path.join(baseDir, sockName)}`;
 }
 

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -38,9 +38,9 @@ test("resolveConfiguredEndpoint rejects malformed daemon endpoints", () => {
 });
 
 test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", () => {
-  // On machines where /opt/homebrew/var/clawdb/run/libravdb.sock exists (Homebrew install),
+  // On machines where /opt/homebrew/var/libravdbd/run/libravdb.sock exists (Homebrew install),
   // defaultEndpoint probes the filesystem and returns the Homebrew path. On machines without
-  // it, the user-local fallback (~/.clawdb/run/libravdb.sock) is used. Both are valid unix
+  // it, the user-local fallback (~/.libravdbd/run/libravdb.sock) is used. Both are valid unix
   // endpoints — the test verifies the platform dispatch (unix vs win32) and env-var override.
   const darwinResult = defaultEndpoint("darwin", "/Users/demo");
   assert.match(darwinResult, /^unix:.*libravdb\.sock$/);
@@ -66,10 +66,10 @@ test("defaultEndpoint prefers the Homebrew socket when the user-local socket is 
   const endpoint = defaultEndpoint(
     "darwin",
     "/Users/demo",
-    (candidate) => candidate === "/opt/homebrew/var/clawdb/run/libravdb.sock",
+    (candidate) => candidate === "/opt/homebrew/var/libravdbd/run/libravdb.sock",
   );
 
-  assert.equal(endpoint, "unix:/opt/homebrew/var/clawdb/run/libravdb.sock");
+  assert.equal(endpoint, "unix:/opt/homebrew/var/libravdbd/run/libravdb.sock");
 });
 
 test("computeBackoffMs applies capped exponential backoff", () => {


### PR DESCRIPTION
## Summary

Updates the plugin to match the latest daemon (libravdbd) changes:

- **Default embedding model**: `nomic-embed-text-v1.5` (was `all-minilm-l6-v2`)
- **Default fallback model**: `bge-small-en-v1.5` (was `all-minilm-l6-v2`)
- **Path prefix**: `~/.clawdb/` → `~/.libravdbd/` (socket, DB, logs, pid files)
- **DB path**: `data.libravdb` → `data_nomic-embed-text-v1_5.libravdb`

Docs and README:

- Added comprehensive **Configuration Reference** to README covering all 50+ config keys
- Added **APT** and **AUR** install instructions alongside Homebrew
- Replaced "daemon" terminology with "service" throughout README
- Documented `onnxDevice` values and GPU/CPU guidance
- Updated all doc paths and model references

The `onnxDevice` config field and `LIBRAVDB_ONNX_DEVICE` env var pass-through were already wired — this PR updates the defaults, paths, and documentation only.

## Testing

- [x] `npm run test:ts` — all pass
- [x] `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides and configuration reference with revised daemon paths and socket locations.
  * Updated embedding profile documentation with new default model.
  * Clarified setup instructions for plugin verification and lifecycle management.

* **Chores**
  * Changed default embedding profile to `nomic-embed-text-v1.5` with updated fallback model.
  * Updated installer script and default endpoint resolution to reflect new configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->