### PR TITLE
fix: remove plugin-side gating config dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,14 @@ CPU when a provider is unavailable.
 
 ### Ingestion gating
 
+Gating thresholds and scoring weights are owned by the vector service and configured via
+service environment variables. See the service documentation for tuning details.
+
+The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
+
 | Key | Type | Default | Notes |
 |---|---|---|---|
-| `ingestionGateThreshold` | number | `0.35` | Minimum semantic relevance score to store a memory |
-| `gatingWeights` | object | `{w1c:0.35, w2c:0.4, w3c:0.25, w1t:0.4, w2t:0.35, w3t:0.25}` | Hybrid scoring weights |
-| `gatingTechNorm` | number | `1.5` | Technical content normalization factor |
-| `gatingCentroidK` | number | `10` | K for centroid-based similarity gating |
+| `ingestionGateThreshold` | number | `0.35` | Minimum semantic relevance score used by the plugin host for ingestion gating |
 
 ### Compaction
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -215,52 +215,6 @@
         "type": "number",
         "default": 150
       },
-      "gatingWeights": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {
-          "w1c": 0.35,
-          "w2c": 0.4,
-          "w3c": 0.25,
-          "w1t": 0.4,
-          "w2t": 0.35,
-          "w3t": 0.25
-        },
-        "properties": {
-          "w1c": {
-            "type": "number",
-            "default": 0.35
-          },
-          "w2c": {
-            "type": "number",
-            "default": 0.4
-          },
-          "w3c": {
-            "type": "number",
-            "default": 0.25
-          },
-          "w1t": {
-            "type": "number",
-            "default": 0.4
-          },
-          "w2t": {
-            "type": "number",
-            "default": 0.35
-          },
-          "w3t": {
-            "type": "number",
-            "default": 0.25
-          }
-        }
-      },
-      "gatingTechNorm": {
-        "type": "number",
-        "default": 1.5
-      },
-      "gatingCentroidK": {
-        "type": "number",
-        "default": 10
-      },
       "lifecycleJournalMaxEntries": {
         "type": "number",
         "default": 500

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -493,33 +493,6 @@ export function buildSidecarEnv(cfg: PluginConfig): Record<string, string> {
   if (cfg.compactModel && !env.LIBRAVDB_SUMMARIZER_MODEL) {
     env.LIBRAVDB_SUMMARIZER_MODEL = cfg.compactModel;
   }
-  if (cfg.gatingWeights?.w1c != null) {
-    env.LIBRAVDB_GATING_W1C = String(cfg.gatingWeights.w1c);
-  }
-  if (cfg.gatingWeights?.w2c != null) {
-    env.LIBRAVDB_GATING_W2C = String(cfg.gatingWeights.w2c);
-  }
-  if (cfg.gatingWeights?.w3c != null) {
-    env.LIBRAVDB_GATING_W3C = String(cfg.gatingWeights.w3c);
-  }
-  if (cfg.gatingWeights?.w1t != null) {
-    env.LIBRAVDB_GATING_W1T = String(cfg.gatingWeights.w1t);
-  }
-  if (cfg.gatingWeights?.w2t != null) {
-    env.LIBRAVDB_GATING_W2T = String(cfg.gatingWeights.w2t);
-  }
-  if (cfg.gatingWeights?.w3t != null) {
-    env.LIBRAVDB_GATING_W3T = String(cfg.gatingWeights.w3t);
-  }
-  if (typeof cfg.gatingTechNorm === "number" && cfg.gatingTechNorm > 0) {
-    env.LIBRAVDB_GATING_TECH_NORM = String(cfg.gatingTechNorm);
-  }
-  if (typeof cfg.ingestionGateThreshold === "number" && cfg.ingestionGateThreshold >= 0) {
-    env.LIBRAVDB_GATING_THRESHOLD = String(cfg.ingestionGateThreshold);
-  }
-  if (typeof cfg.gatingCentroidK === "number" && cfg.gatingCentroidK > 0) {
-    env.LIBRAVDB_GATING_CENTROID_K = String(cfg.gatingCentroidK);
-  }
   if (typeof cfg.lifecycleJournalMaxEntries === "number" && cfg.lifecycleJournalMaxEntries > 0) {
     env.LIBRAVDB_LIFECYCLE_JOURNAL_MAX_ENTRIES = String(cfg.lifecycleJournalMaxEntries);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,16 +53,6 @@ export interface PluginConfig {
   dreamPromotionDiaryPath?: string;
   dreamPromotionUserId?: string;
   dreamPromotionDebounceMs?: number;
-  gatingWeights?: {
-    w1c?: number;
-    w2c?: number;
-    w3c?: number;
-    w1t?: number;
-    w2t?: number;
-    w3t?: number;
-  };
-  gatingTechNorm?: number;
-  gatingCentroidK?: number;
   lifecycleJournalMaxEntries?: number;
   compactionQualityWeight?: number;
   recencyLambdaSession?: number;

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -96,10 +96,6 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
     embeddingTokenizerPath: "/models/tokenizer.json",
     embeddingDimensions: 768,
     embeddingNormalize: false,
-    gatingWeights: { w1c: 0.35, w2c: 0.4, w3c: 0.25, w1t: 0.4, w2t: 0.35, w3t: 0.25 },
-    gatingTechNorm: 1.5,
-    ingestionGateThreshold: 0.35,
-    gatingCentroidK: 10,
     lifecycleJournalMaxEntries: 250,
   });
 
@@ -114,15 +110,6 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
     LIBRAVDB_EMBEDDING_TOKENIZER: "/models/tokenizer.json",
     LIBRAVDB_EMBEDDING_DIMENSIONS: "768",
     LIBRAVDB_EMBEDDING_NORMALIZE: "false",
-    LIBRAVDB_GATING_W1C: "0.35",
-    LIBRAVDB_GATING_W2C: "0.4",
-    LIBRAVDB_GATING_W3C: "0.25",
-    LIBRAVDB_GATING_W1T: "0.4",
-    LIBRAVDB_GATING_W2T: "0.35",
-    LIBRAVDB_GATING_W3T: "0.25",
-    LIBRAVDB_GATING_TECH_NORM: "1.5",
-    LIBRAVDB_GATING_THRESHOLD: "0.35",
-    LIBRAVDB_GATING_CENTROID_K: "10",
     LIBRAVDB_LIFECYCLE_JOURNAL_MAX_ENTRIES: "250",
   });
 });


### PR DESCRIPTION
## Summary

The daemon owns gating configuration end-to-end with built-in defaults. The plugin's `buildSidecarEnv()` was mapping gating config to env vars (LIBRAVDB_GATING_*) but that function was never called in production — the plugin is connect-only and doesn't spawn the daemon process.

## Changes

- Removed `gatingWeights`, `gatingTechNorm`, `gatingCentroidK` from `openclaw.plugin.json` schema
- Removed those fields from PluginConfig type in `src/types.ts`
- Removed gating env var mappings from `buildSidecarEnv()` in `src/sidecar.ts`
- Updated README ingestion gating section to clarify these are service-owned
- Updated unit test to match

`ingestionGateThreshold` is kept since it has legitimate plugin-side usage in `context-engine.ts`.

## Test plan

- [x] `npm run check` passes (type check + 99 unit tests)