### PR TITLE
fix: add compat.minGatewayVersion and build metadata for ClawHub compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
       "minGatewayVersion": ">=2026.3.22"
     },
     "build": {
-      "openclawVersion": ">=2026.3.22",
-      "pluginSdkVersion": ">=2026.3.22"
+      "openclawVersion": "2026.4.11",
+      "pluginSdkVersion": "2026.4.11"
     },
     "install": {
       "minHostVersion": ">=2026.3.22"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,12 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.22"
+      "pluginApi": ">=2026.3.22",
+      "minGatewayVersion": ">=2026.3.22"
+    },
+    "build": {
+      "openclawVersion": ">=2026.3.22",
+      "pluginSdkVersion": ">=2026.3.22"
     },
     "install": {
       "minHostVersion": ">=2026.3.22"


### PR DESCRIPTION
## Summary
- Adds `compat.minGatewayVersion` to the `openclaw` block in `package.json`
- Adds `build` block with `openclawVersion` and `pluginSdkVersion` version pins
- These fields are required for ClawHub publishing per the Building Plugins docs

## Test plan
- [x] `package.json` parses as valid JSON
- [x] `openclaw` block now contains: `extensions`, `compat` (pluginApi + minGatewayVersion), `build` (openclawVersion + pluginSdkVersion), `install`
- [x] Existing `compat.pluginApi` value preserved unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded plugin compatibility metadata to include build and SDK targets (updated to 2026.4.11) while retaining existing API and gateway minimum constraints (>=2026.3.22). This clarifies supported build/SDK combinations for plugins.
  * No changes to public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->