### PR TITLE
fix: add contracts block to plugin manifest for capability discovery

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,6 +7,10 @@
     "memory",
     "context-engine"
   ],
+  "contracts": {
+    "memory": true,
+    "contextEngine": true
+  },
   "activation": {
     "onCommands": [
       "memory"


### PR DESCRIPTION
## Summary
- Adds `contracts` block to `openclaw.plugin.json` declaring `memory` and `contextEngine` capabilities
- Required for OpenClaw to discover plugin capabilities without loading the runtime
- Complements the existing `kind` field with the formal discovery contract

## Test plan
- [x] `openclaw.plugin.json` parses as valid JSON
- [x] `contracts` block contains `memory: true` and `contextEngine: true`