### PR TITLE
fix: add cli-metadata entry to openclaw.extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "./dist/index.js",
+      "./dist/cli-metadata.js"
     ],
     "compat": {
       "pluginApi": ">=2026.3.22"


### PR DESCRIPTION
## Summary
- Adds `./dist/cli-metadata.js` to the `openclaw.extensions` array in `package.json`
- The lightweight CLI metadata entry point was already built and shipped in the `files` array but not declared in `extensions`
- This lets OpenClaw discover the metadata-only entry for lightweight CLI registration without loading the full runtime

## Test plan
- [x] `package.json` parses as valid JSON
- [x] `openclaw.extensions` now includes both `./dist/index.js` and `./dist/cli-metadata.js`
- [x] `./dist/cli-metadata.js` exists after `npm run build`