### PR TITLE
fix: register embedding adapter IDs for config resolution discoverability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,27 @@ export function register(api: OpenClawPluginApi) {
     runtime: buildMemoryRuntimeBridge(runtime.getRpc, cfg),
   });
 
+  // Register embedding adapter IDs so OpenClaw can discover available
+  // embedding backends for config resolution. Actual embeddings run inside
+  // the vector service — these are declarative discovery entries only.
+  const embeddingAdapters = [
+    { id: "libravdb-bundled", transport: "local" as const, profile: cfg.embeddingProfile ?? "nomic-embed-text-v1.5" },
+    { id: "libravdb-onnx", transport: "local" as const, profile: cfg.fallbackProfile ?? "bge-small-en-v1.5" },
+  ];
+  for (const entry of embeddingAdapters) {
+    api.registerMemoryEmbeddingProvider?.({
+      id: entry.id,
+      defaultModel: entry.profile,
+      transport: entry.transport,
+      async create(_options: Record<string, unknown>) {
+        return {
+          ok: false,
+          error: `LibraVDB embedding is managed by the vector service. Use config embeddingBackend="${entry.id}" to select this backend.`,
+        };
+      },
+    });
+  }
+
   api.registerContextEngine(
     MEMORY_ID,
     () => buildContextEngineFactory(runtime, cfg, api.logger ?? console),


### PR DESCRIPTION
## Summary
- Registers `libravdb-bundled` and `libravdb-onnx` embedding adapter IDs via `api.registerMemoryEmbeddingProvider()`
- These are declarative discovery entries — actual embeddings run inside the vector service, not through OpenClaw's embedding framework
- Lets OpenClaw discover available embedding backends without loading the plugin runtime

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Adapters are registered only in full mode (guarded behind existing runtime check)
- [x] `api.registerMemoryEmbeddingProvider` uses optional chaining for older SDK compatibility