### PR TITLE
fix: defer background services to gateway_start hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,11 +119,13 @@ export function register(api: OpenClawPluginApi) {
     await dreamPromotion.stop();
   });
 
-  void markdownIngestion.start().catch((error) => {
-    api.logger?.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
-  });
-  void dreamPromotion.start().catch((error) => {
-    api.logger?.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+  api.on("gateway_start", async () => {
+    await markdownIngestion.start().catch((error) => {
+      api.logger?.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    await dreamPromotion.start().catch((error) => {
+      api.logger?.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+    });
   });
 
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));


### PR DESCRIPTION
## Summary
- Moves markdown ingestion and dream promotion `start()` calls from fire-and-forget during `register()` into a `gateway_start` hook
- Ensures background services start after the gateway is fully initialized, matching the documented plugin lifecycle
- The existing `gateway_stop` hook already handles graceful shutdown of both services

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `gateway_stop` hook still calls `runtime.shutdown()` which drains `onShutdown` tasks (markdown/dream stop)