### PR TITLE
fix: add agent_end hook for per-turn observability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export function register(api: OpenClawPluginApi) {
   api.on("agent_end", async (event: unknown) => {
     const e = asRecord(event) ?? {};
     logger.info?.(
-      `LibraVDB agent_end success=${e.success ?? false} ` +
+      `LibraVDB agent_end success=${e.success ?? 'unknown'} ` +
       `durationMs=${e.durationMs ?? "?"} ` +
       `error=${typeof e.error === "string" ? e.error : "none"}`,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,9 +128,21 @@ export function register(api: OpenClawPluginApi) {
 
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
   api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
+  api.on("agent_end", async (event: unknown) => {
+    const e = asRecord(event) ?? {};
+    logger.info?.(
+      `LibraVDB agent_end success=${e.success ?? false} ` +
+      `durationMs=${e.durationMs ?? "?"} ` +
+      `error=${typeof e.error === "string" ? e.error : "none"}`,
+    );
+  });
   api.on("gateway_stop", async () => {
     await runtime.shutdown();
   });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
 }
 
 export default definePluginEntry({


### PR DESCRIPTION
## Summary
- Registers an `agent_end` lifecycle hook that logs turn completion with success state, duration, and error details
- Observation-only — no blocking calls, no RPC, lightweight logging
- Fires per-turn (not per-session), complementing the existing `session_end` hook

## Configuration required
Non-bundled plugins must set in their OpenClaw config:
```json
{
  "plugins": {
    "entries": {
      "libravdb-memory": {
        "hooks": {
          "allowConversationAccess": true
        }
      }
    }
  }
}
```

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Handler is fire-and-forget (no async RPC, just logger.info)
- [x] Uses structural typing on the event to avoid strict SDK type coupling