### PR TITLE
fix: register background services via registerService API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,18 +112,24 @@ export function register(api: OpenClawPluginApi) {
   const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getRpc, api.logger ?? console);
   const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getRpc, api.logger ?? console);
 
-  runtime.onShutdown(async () => {
-    await markdownIngestion.stop();
-  });
-  runtime.onShutdown(async () => {
-    await dreamPromotion.stop();
+  api.registerService?.({
+    id: "libravdb-markdown-ingestion",
+    async start(_ctx: unknown) {
+      await markdownIngestion.start();
+    },
+    async stop(_ctx: unknown) {
+      await markdownIngestion.stop();
+    },
   });
 
-  void markdownIngestion.start().catch((error) => {
-    api.logger?.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
-  });
-  void dreamPromotion.start().catch((error) => {
-    api.logger?.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+  api.registerService?.({
+    id: "libravdb-dream-promotion",
+    async start(_ctx: unknown) {
+      await dreamPromotion.start();
+    },
+    async stop(_ctx: unknown) {
+      await dreamPromotion.stop();
+    },
   });
 
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -66,6 +66,11 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
         }>;
       },
     ): void;
+    registerService?(service: {
+      id: string;
+      start(ctx: unknown): void | Promise<void>;
+      stop?(ctx: unknown): void | Promise<void>;
+    }): void;
     on(event: string, handler: (...args: unknown[]) => void | Promise<void>, opts?: { priority?: number }): void;
   }
 


### PR DESCRIPTION
## Summary
- Wraps markdown ingestion and dream promotion as `OpenClawPluginService` registrations via `api.registerService()`
- Removes manual fire-and-forget `start()` calls and `onShutdown` tasks — the framework now manages start/stop lifecycle
- Adds `registerService` to local SDK type declarations in `src/openclaw-plugin-sdk.d.ts`
- Uses optional chaining (`api.registerService?.()`) for graceful degradation on older SDKs

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Both services registered with `id`, `start`, and `stop` callbacks
- [x] No more manual start/shutdown wiring for these services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin lifecycle management by transitioning from direct cleanup and startup handling to a service registration system, enhancing overall reliability and consistency.

* **New Features**
  * Extended the plugin SDK with service registration capabilities, enabling better lifecycle control for plugin components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->