### PR TITLE
fix: add registerRuntimeLifecycle for cleanup on plugin disable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,13 @@ export function register(api: OpenClawPluginApi) {
     },
   });
 
+  api.registerRuntimeLifecycle?.({
+    async onDisable() {
+      logger.info?.("LibraVDB disable — shutting down runtime");
+      await runtime.shutdown();
+    },
+  });
+
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
   api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
   api.on("gateway_stop", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,9 +141,13 @@ export function register(api: OpenClawPluginApi) {
   });
 
   api.registerRuntimeLifecycle?.({
-    async onDisable() {
-      logger.info?.("LibraVDB disable — shutting down runtime");
-      await runtime.shutdown();
+    id: "libravdb-shutdown",
+    description: "Shut down the vector service runtime on plugin disable",
+    async cleanup(ctx) {
+      if (ctx.reason === "disable") {
+        logger.info?.("LibraVDB disable — shutting down runtime");
+        await runtime.shutdown();
+      }
     },
   });
 

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -95,6 +95,12 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       start(ctx: unknown): void | Promise<void>;
       stop?(ctx: unknown): void | Promise<void>;
     }): void;
+    registerRuntimeLifecycle?(callbacks: {
+      onDisable?(): void | Promise<void>;
+      onDelete?(): void | Promise<void>;
+      onReload?(): void | Promise<void>;
+      onReset?(): void | Promise<void>;
+    }): void;
     on(event: string, handler: (...args: unknown[]) => void | Promise<void>, opts?: { priority?: number }): void;
   }
 

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -95,11 +95,10 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       start(ctx: unknown): void | Promise<void>;
       stop?(ctx: unknown): void | Promise<void>;
     }): void;
-    registerRuntimeLifecycle?(callbacks: {
-      onDisable?(): void | Promise<void>;
-      onDelete?(): void | Promise<void>;
-      onReload?(): void | Promise<void>;
-      onReset?(): void | Promise<void>;
+    registerRuntimeLifecycle?(registration: {
+      id: string;
+      description?: string;
+      cleanup(ctx: { reason: "disable" | "reset" | "delete" | "restart" }): void | Promise<void>;
     }): void;
     on(event: string, handler: (...args: unknown[]) => void | Promise<void>, opts?: { priority?: number }): void;
   }


### PR DESCRIPTION
## Summary
- Registers an `onDisable` callback via `api.registerRuntimeLifecycle()` that shuts down the sidecar runtime
- Covers the disable-at-runtime path that `gateway_stop` does not fire for (plugin disabled via config while gateway is running)
- `runtime.shutdown()` is idempotent — guarded by `stopped`/`shuttingDown` flags preventing double-shutdown
- Adds `registerRuntimeLifecycle` to local SDK type declarations with optional chaining for SDK version compat

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Optional chaining used — graceful no-op on SDK versions without this API
- [x] Double-shutdown is safe: `plugin-runtime.ts` guards against it