### PR TITLE
fix: apply default threshold to memory search

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -421,12 +421,13 @@ async function runSearch(
       agentId: opts?.agent,
     });
     const maxResults = normalizeLimit(opts?.maxResults ?? opts?.limit);
-    const minScore = normalizeNumber(opts?.minScore);
+    const explicitMinScore = normalizeNumber(opts?.minScore);
+    const minScore = explicitMinScore ?? resolveDefaultSearchMinScore(manager.status(), cfg);
     const results = (await manager.search(
       {
         query,
         ...(maxResults ? { maxResults } : {}),
-        ...(minScore !== undefined ? { minScore } : {}),
+        minScore,
       },
     )) as Array<{
       path: string;
@@ -452,6 +453,10 @@ async function runSearch(
     logger.error(`LibraVDB search failed: ${formatError(error)}`);
     process.exitCode = 1;
   }
+}
+
+function resolveDefaultSearchMinScore(status: { gatingThreshold?: number } | undefined, cfg: PluginConfig): number {
+  return normalizeNumber(status?.gatingThreshold) ?? normalizeNumber(cfg.ingestionGateThreshold) ?? 0.35;
 }
 
 async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -14,7 +14,7 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.equal(manifest.configSchema.additionalProperties, false);
   assert.deepEqual(
     Object.keys(manifest).sort(),
-    ["activation", "configSchema", "description", "id", "kind", "name", "version"],
+    ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "version"],
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -247,7 +247,7 @@ test("search command applies the status gate threshold by default", async () => 
               return {
                 ok: true,
                 message: "ok",
-                gatingThreshold: 0.35,
+                gatingThreshold: 0.5,
                 embeddingProfile: "all-minilm-l6-v2",
               };
             }
@@ -258,6 +258,12 @@ test("search command applies the status gate threshold by default", async () => 
                     id: "low",
                     score: 0.25,
                     text: "weak unrelated memory",
+                    metadata: { collection: "user:test-user" },
+                  },
+                  {
+                    id: "mid",
+                    score: 0.4,
+                    text: "mid-range memory gated by status threshold",
                     metadata: { collection: "user:test-user" },
                   },
                   {
@@ -300,6 +306,7 @@ test("search command applies the status gate threshold by default", async () => 
   }
 
   assert.equal(logs.some((line) => line.includes("weak unrelated memory")), false);
+  assert.equal(logs.some((line) => line.includes("mid-range memory gated by status threshold")), false);
   assert.equal(logs.some((line) => line.includes("strong relevant memory")), true);
 });
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -228,6 +228,149 @@ test("status command shuts the plugin runtime down after printing status", async
 });
 
 
+test("search command applies the status gate threshold by default", async () => {
+  let registered: RegisteredCli | null = null;
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string) {
+            if (method === "status") {
+              return {
+                ok: true,
+                message: "ok",
+                gatingThreshold: 0.35,
+                embeddingProfile: "all-minilm-l6-v2",
+              };
+            }
+            if (method === "search_text_collections") {
+              return {
+                results: [
+                  {
+                    id: "low",
+                    score: 0.25,
+                    text: "weak unrelated memory",
+                    metadata: { collection: "user:test-user" },
+                  },
+                  {
+                    id: "high",
+                    score: 0.76,
+                    text: "strong relevant memory",
+                    metadata: { collection: "user:test-user" },
+                  },
+                ],
+              };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel: async () => null,
+      async emitLifecycleHint() {},
+      onShutdown: async () => {},
+      async shutdown() {},
+    },
+    { userId: "test-user" },
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const search = memory?.commands.find((command) => command.name() === "search");
+  assert.ok(search?.handler);
+
+  const originalLog = console.log;
+  const logs: string[] = [];
+  console.log = ((message?: unknown) => { logs.push(String(message)); }) as typeof console.log;
+  try {
+    await search.handler?.("query", {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(logs.some((line) => line.includes("weak unrelated memory")), false);
+  assert.equal(logs.some((line) => line.includes("strong relevant memory")), true);
+});
+
+test("search command honors an explicit min-score below the default threshold", async () => {
+  let registered: RegisteredCli | null = null;
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string) {
+            if (method === "status") {
+              return {
+                ok: true,
+                message: "ok",
+                gatingThreshold: 0.35,
+                embeddingProfile: "all-minilm-l6-v2",
+              };
+            }
+            if (method === "search_text_collections") {
+              return {
+                results: [
+                  {
+                    id: "low",
+                    score: 0.25,
+                    text: "weak but explicitly requested memory",
+                    metadata: { collection: "user:test-user" },
+                  },
+                ],
+              };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel: async () => null,
+      async emitLifecycleHint() {},
+      onShutdown: async () => {},
+      async shutdown() {},
+    },
+    { userId: "test-user" },
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const search = memory?.commands.find((command) => command.name() === "search");
+  assert.ok(search?.handler);
+
+  const originalLog = console.log;
+  const logs: string[] = [];
+  console.log = ((message?: unknown) => { logs.push(String(message)); }) as typeof console.log;
+  try {
+    await search.handler?.("query", { minScore: "0.2" });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(logs.some((line) => line.includes("weak but explicitly requested memory")), true);
+});
+
 test("status --deep probes authored collection search health", async () => {
   let registered: RegisteredCli | null = null;
   let shutdownCalls = 0;


### PR DESCRIPTION
## Summary

- apply the sidecar/status gate threshold as the default `memory search` `minScore`
- keep explicit `--min-score` overrides working, including lower thresholds
- update the checklist integration test for the existing `contracts` manifest key so the contributor gate passes on current main

Fixes #77.

## Verification

- `PATH=/tmp/corepack-shims:$PATH pnpm check`
- `PATH=/tmp/corepack-shims:$PATH npm run test:integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result filtering with consistent minimum score threshold handling. The search command now always applies a minimum score—either from the `--min-score` flag or intelligent defaults—ensuring predictable result filtering behavior.

* **Tests**
  * Added unit tests for search gating behavior.
  * Updated integration test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->