### PR TITLE
Run plugin inspector before tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ CLAUDE.md
 *.docx
 *.tgz
 *.pl
+reports/plugin-inspector*
 
 node_modules/
 .DS_Store

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,7 @@ pnpm check
 
 ```bash
 tsc --noEmit
-tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js
+pnpm run test:ts
 ```
 
 ## Local Daemon Build

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/bundle-entrypoint.mjs && mkdir -p dist/proto && cp -rf api/proto/. dist/proto/",
     "check": "tsc --noEmit && pnpm run test:ts",
-    "test:ts": "tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js",
-    "test:integration": "tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js .ts-build/test/integration/sidecar-lifecycle.test.js",
+    "test:inspect": "pnpm run plugin:ci",
+    "test:ts": "pnpm run test:inspect && tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js",
+    "test:integration": "pnpm run test:inspect && tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js .ts-build/test/integration/sidecar-lifecycle.test.js",
     "benchmark:session_search_mid": "tsc -p tsconfig.tests.json && OPENCLAW_PROFILE_ASSEMBLE=1 node --test --test-name-pattern=\"real sidecar mid-sized session search benchmark\" .ts-build/test/integration/host-flow.test.js",
     "gate:assemble_optimization": "tsc -p tsconfig.tests.json && OPENCLAW_PROFILE_ASSEMBLE=1 OPENCLAW_ENFORCE_ASSEMBLE_EVIDENCE_GATE=1 node --test --test-name-pattern=\"real sidecar mid-sized session search benchmark\" .ts-build/test/integration/host-flow.test.js",
     "probe:session_recall": "tsc -p tsconfig.tests.json && OPENCLAW_PROFILE_ASSEMBLE=1 node --test --test-name-pattern=\"real sidecar mid-sized session search benchmark\" .ts-build/test/integration/host-flow.test.js",

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -14,7 +14,7 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.equal(manifest.configSchema.additionalProperties, false);
   assert.deepEqual(
     Object.keys(manifest).sort(),
-    ["activation", "configSchema", "description", "id", "kind", "name", "version"],
+    ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "version"],
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);


### PR DESCRIPTION
## Summary
- add a `test:inspect` script that runs the plugin inspector CI check
- run `test:inspect` before unit and integration test scripts
- ignore generated plugin-inspector reports and update development docs to use the test script
- refresh the checklist test for the existing manifest `contracts` key

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run test:ts`
- `pnpm run test:integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development test invocation instructions.

* **Chores**
  * Restructured test script dependencies for improved organization.
  * Added exclusion pattern for plugin-inspector report files.
  * Enhanced manifest validation to reflect updated schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->