### PR TITLE
fix: make LibraVDB installer fully automated

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,44 +22,37 @@ New install? Start here: [Install guide](./docs/install.md).
 
 ## Install
 
-Install `libravdbd` with your system package manager, then install
-the OpenClaw plugin.
-
-**macOS (Homebrew)**
+Run the automated installer:
 
 ```bash
-brew tap xDarkicex/homebrew-openclaw-libravdb-memory
-brew install libravdbd
-brew services start libravdbd
+npx --yes @xdarkicex/openclaw-memory-libravdb --yes
 ```
 
-**Linux (APT)**
+The installer downloads or starts `libravdbd`, provisions ONNX Runtime and local
+model assets when needed, installs the OpenClaw plugin package, writes the
+current OpenClaw memory/context-engine slot config, and verifies the setup with
+`openclaw memory status`.
+
+From a source checkout, use the same installer script directly:
 
 ```bash
-sudo apt install libravdbd
-systemctl --user enable --now libravdbd
+bash scripts/auto-install.sh --yes
 ```
 
-**Linux (AUR)**
-
-```bash
-yay -S libravdbd-bin
-systemctl --user enable --now libravdbd
-```
-
-**Plugin (all platforms)**
+Operator-managed installs can still install the plugin package directly:
 
 ```bash
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-Then activate the plugin in `~/.openclaw/openclaw.json`:
+The installer writes this OpenClaw config shape:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -88,7 +81,7 @@ Runtime requirements:
 
 - OpenClaw `>= 2026.3.22`
 - Node.js `>= 22`
-- a separately installed `libravdbd` service
+- `curl`, `jq`, and `tar` for the automated installer
 
 Compatibility note:
 
@@ -119,8 +112,8 @@ If your service runs elsewhere, set `sidecarPath`:
 
 ## Highlights
 
-- **Memory capability ownership** - owns the OpenClaw `memory` slot and
-  registers the context engine capability at runtime.
+- **Memory and context-engine ownership** - owns the OpenClaw `memory` and
+  `contextEngine` slots.
 - **Memory runtime bridge** - routes built-in `memory_search` calls to the same
   libraVDB-backed sidecar on hosts that expose the runtime API.
 - **Three memory scopes** - keeps active session, durable user, and global memory
@@ -133,15 +126,15 @@ If your service runs elsewhere, set `sidecarPath`:
   newest working context.
 - **Local-first inference** - uses local embedding and compaction paths by
   default, with optional external summarizer configuration.
-- **Explicit service lifecycle** - the npm/OpenClaw package stays connect-only;
-  `libravdbd` is installed and supervised separately.
+- **Automated service lifecycle** - the installer handles daemon setup, model
+  assets, OpenClaw plugin activation, and verification.
 
 ## Security Defaults
 
 Stored memory is treated as untrusted historical context. Retrieved memory is
 framed before it reaches the downstream model, memory collections are scoped by
-session/user/global namespace, and service installation is outside the npm plugin
-package.
+session/user/global namespace, and service installation is performed only by the
+explicit installer command.
 
 Before exposing OpenClaw over remote channels, read [Security](./docs/security.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,8 +95,8 @@ The npm package contains:
 - `docs/`
 - `dist/`
 
-The package is connect-only. It does not compile Go code, download models, or
-manage the daemon process during plugin installation.
+The plugin package has no implicit `postinstall`. Full-stack machine setup is
+handled by the explicit package bin and `scripts/auto-install.sh`.
 
 ## Release Automation
 
@@ -113,5 +113,6 @@ label. The workflow auto-bumps, tags, and publishes.
 
 ## Auto-Install Script
 
-`scripts/auto-install.sh` automates daemon + plugin installation. Run it when
-setting up a machine that needs the full stack quickly.
+`scripts/auto-install.sh` automates daemon + plugin installation, local asset
+provisioning, OpenClaw config activation, and verification. Run it when setting
+up a machine that needs the full stack quickly.

--- a/docs/install.md
+++ b/docs/install.md
@@ -149,7 +149,7 @@ For a completely manual foreground run, download the matching published
 
 ```bash
 chmod +x ~/.local/bin/libravdbd
-libravdbd serve
+~/.local/bin/libravdbd serve
 ```
 
 Foreground mode is useful for release validation, but normal local use should

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Install Guide
 
-LibraVDB Memory is a connect-only OpenClaw plugin. Install the plugin as a
-normal package, install `libravdbd` separately, and point the plugin at the
-daemon endpoint when you need a non-default location.
+LibraVDB Memory ships an explicit automated installer for the full local stack:
+daemon, ONNX Runtime, model assets, OpenClaw plugin package, plugin activation,
+and verification.
 
 OpenClaw compatibility note:
 
@@ -11,24 +11,33 @@ OpenClaw compatibility note:
 For deeper operational detail, use the full
 [installation reference](./installation.md).
 
-## Recommended Path: Homebrew + OpenClaw Plugin
+## Recommended Path: Automated Installer
 
-On macOS, the shortest supported path is:
+Run:
 
 ```bash
-brew tap xDarkicex/homebrew-openclaw-libravdb-memory
-brew install libravdbd
-brew services start libravdbd
-openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+npx --yes @xdarkicex/openclaw-memory-libravdb --yes
 ```
 
 This gives you:
 
-- a managed `libravdbd` service
-- a scanner-clean plugin install
-- a clean separation between plugin lifecycle and daemon lifecycle
+- a running `libravdbd` service
+- provisioned ONNX Runtime and local model assets for installer-managed daemon installs
+- an installed OpenClaw plugin package
+- `~/.openclaw/openclaw.json` updated with the current `plugins.entries` config shape
+- a final `openclaw memory status` verification
 
-## Plugin Install
+From a source checkout, run the same installer script:
+
+```bash
+bash scripts/auto-install.sh --yes
+```
+
+On macOS, the installer tries Homebrew first when accepted. If Homebrew fails,
+it falls back to the published daemon binary plus installer-managed launchd,
+ONNX Runtime, and model assets.
+
+## Plugin-Only Install
 
 Install the plugin package with the OpenClaw CLI:
 
@@ -36,16 +45,27 @@ Install the plugin package with the OpenClaw CLI:
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-If you use the OpenClaw.ai plugin UI instead of the CLI, install the same
-package and then assign the plugin id `libravdb-memory` to the `memory` slot.
+Use this path only when an operator already manages `libravdbd` and assets.
+If you use the OpenClaw.ai plugin UI instead of the CLI, install the same package
+and then assign the plugin id `libravdb-memory` to both the `memory` and
+`contextEngine` slots.
 
-Activate the plugin in `~/.openclaw/openclaw.json`:
+The current config shape is:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    },
+    "entries": {
+      "libravdb-memory": {
+        "enabled": true,
+        "config": {
+          "sidecarPath": "auto"
+        }
+      }
     }
   }
 }
@@ -57,7 +77,8 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -115,26 +136,24 @@ brew info libravdbd
 
 ### Manual Service Management
 
-If you are not using Homebrew, manage the daemon explicitly.
-
-Linux user service from the repo template:
+If you are not using Homebrew, prefer the installer-managed manual service path.
+It writes the launchd/systemd wiring directly instead of relying on external
+service-template files:
 
 ```bash
-# Replace vX.Y.Z with the published libravdbd release you want to install.
-mkdir -p ~/.local/bin ~/.config/systemd/user
-# Download the matching published libravdbd binary and service template.
-curl -L -o ~/.local/bin/libravdbd <published-libravdbd-binary-url>
-chmod +x ~/.local/bin/libravdbd
-curl -L -o ~/.config/systemd/user/libravdbd.service <published-libravdbd-service-template-url>
-systemctl --user enable --now libravdbd.service
+bash scripts/auto-install.sh --yes
 ```
 
-macOS LaunchAgent from the repo template:
+For a completely manual foreground run, download the matching published
+`libravdbd` binary for your OS/architecture, make it executable, and run:
 
-1. Download the published `com.xdarkicex.libravdbd.plist` template for your release.
-2. Replace `__HOME__` with your home directory.
-3. Save it to `~/Library/LaunchAgents/com.xdarkicex.libravdbd.plist`.
-4. Load it with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.xdarkicex.libravdbd.plist`.
+```bash
+chmod +x ~/.local/bin/libravdbd
+libravdbd serve
+```
+
+Foreground mode is useful for release validation, but normal local use should
+use the automated installer or an operator-managed service.
 
 ### Windows
 
@@ -159,13 +178,10 @@ you wrap it in `brew services`, `systemd`, or `launchd`.
 
 ### Plugin Lifecycle
 
-- Install the package with `openclaw plugins install`.
-- Activate it by assigning `libravdb-memory` to the `memory` slot.
-- Update it with your normal OpenClaw plugin update flow.
+- Install the full stack with `npx --yes @xdarkicex/openclaw-memory-libravdb --yes`.
+- Update the plugin package with your normal OpenClaw plugin update flow.
+- Rerun the installer when daemon assets or local service wiring need repair.
 - Disable it by removing the slot assignment from `~/.openclaw/openclaw.json`.
-
-The plugin does not manage the daemon process. Treat plugin activation and
-daemon supervision as separate lifecycle decisions.
 
 ### Daemon Lifecycle
 
@@ -185,7 +201,7 @@ openclaw memory status
 Healthy output should show that:
 
 - the daemon answered the local health check
-- the memory slot is active
+- the memory and context-engine slots are active
 - the plugin can read stored counts and runtime settings
 
 If OpenClaw cannot reach the daemon, verify the endpoint first:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,11 +24,28 @@ OpenClaw compatibility note:
 
 ## Install Flow
 
-The published plugin package is connect-only. It installs TypeScript plugin code
-and docs; it does not compile Go code, download model assets, or supervise the
-daemon.
+Use the automated installer for normal setup:
 
-Recommended macOS path:
+```bash
+npx --yes @xdarkicex/openclaw-memory-libravdb --yes
+```
+
+From a source checkout:
+
+```bash
+bash scripts/auto-install.sh --yes
+```
+
+The installer:
+
+- installs or starts `libravdbd`
+- falls back from Homebrew to published daemon assets on macOS when Homebrew fails
+- provisions ONNX Runtime and local model assets for installer-managed daemon installs
+- installs the OpenClaw plugin package
+- updates `~/.openclaw/openclaw.json`
+- verifies the result with `openclaw memory status`
+
+Operator-managed macOS path:
 
 ```bash
 brew tap xDarkicex/homebrew-openclaw-libravdb-memory
@@ -37,16 +54,18 @@ brew services start libravdbd
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
-Manual Linux sketch:
+Manual Linux foreground sketch for operators who do not use the automated installer:
 
 ```bash
-mkdir -p ~/.local/bin ~/.config/systemd/user
+mkdir -p ~/.local/bin
 curl -L -o ~/.local/bin/libravdbd <published-libravdbd-binary-url>
 chmod +x ~/.local/bin/libravdbd
-curl -L -o ~/.config/systemd/user/libravdbd.service <published-libravdbd-service-template-url>
-systemctl --user enable --now libravdbd.service
-openclaw plugins install @xdarkicex/openclaw-memory-libravdb
+~/.local/bin/libravdbd serve
 ```
+
+The automated installer writes systemd user services and macOS LaunchAgents
+directly; this repository no longer documents nonexistent service-template
+downloads as a manual requirement.
 
 Windows uses a loopback TCP endpoint by default:
 
@@ -60,20 +79,30 @@ or run `libravdbd serve` in a terminal for validation.
 
 ## Activation
 
-Assign `libravdb-memory` to the OpenClaw memory slot:
+Assign `libravdb-memory` to the OpenClaw memory and context-engine slots:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    },
+    "entries": {
+      "libravdb-memory": {
+        "enabled": true,
+        "config": {
+          "sidecarPath": "auto"
+        }
+      }
     }
   }
 }
 ```
 
-The plugin registers both memory and context-engine capabilities at runtime;
-current OpenClaw config only needs the `memory` slot assignment.
+The plugin registers both memory and context-engine capabilities at runtime.
+Both exclusive slots should point at the plugin so retrieval and context
+assembly use the same LibraVDB sidecar.
 
 If the daemon uses a non-default endpoint, add `sidecarPath`:
 
@@ -81,7 +110,8 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -144,8 +174,9 @@ Interpretation:
 
 - `Sidecar=running` means the daemon answered the health check.
 - `Gate threshold=0.35` confirms the default durable-memory gate.
-- `Abstractive model=not provisioned` is acceptable; compaction falls back to
-  the extractive path.
+- `Abstractive model=ready` confirms local T5-small assets were provisioned.
+  `not provisioned` is still usable because compaction falls back to the
+  extractive path.
 
 ## Troubleshooting
 
@@ -171,6 +202,14 @@ For foreground debugging:
 libravdbd serve
 ```
 
+### Homebrew stops on Command Line Tools
+
+On macOS, Homebrew can refuse to install even prebuilt formula assets when the
+local Command Line Tools are too old. The automated installer falls back to the
+published daemon binary and installer-managed launchd/model assets when the
+Homebrew step fails. If you require the Homebrew-managed service specifically,
+update Command Line Tools and rerun the Homebrew commands.
+
 ### Hash mismatch
 
 Do not bypass a checksum mismatch. Delete the corrupt or stale asset and rerun
@@ -178,9 +217,9 @@ setup, or republish the release with corrected checksums.
 
 ### Default memory still appears active
 
-Confirm that `libravdb-memory` is assigned to `plugins.slots.memory`.
-Without that slot entry, OpenClaw's default memory path can continue to run in
-parallel.
+Confirm that `libravdb-memory` is assigned to both `plugins.slots.memory` and
+`plugins.slots.contextEngine`. Without those slot entries, OpenClaw's default
+memory path or legacy context engine can continue to run in parallel.
 
 ### Lifecycle journal looks empty
 

--- a/docs/performance-and-tuning.md
+++ b/docs/performance-and-tuning.md
@@ -14,19 +14,19 @@ Measured local asset sizes:
 
 - daemon binary: `7.7M`
 - bundled Nomic model directory: `523M`
-- bundled MiniLM fallback model directory: `87M`
+- bundled BGE fallback model directory: about `128M`
 - optional T5 summarizer directory: `371M`
 - unpacked ONNX Runtime directory on macOS arm64: `44M`
 - ONNX Runtime archive download on macOS arm64: `9.5M`
 
 Vector payload lower bounds:
 
-- MiniLM `384d`: `384 * 4 = 1536 bytes` per vector
+- BGE `384d`: `384 * 4 = 1536 bytes` per vector
 - Nomic `768d`: `768 * 4 = 3072 bytes` per vector
 
 Estimated lower-bound vector payload for `10,000` stored turns:
 
-- MiniLM: about `15.4 MB`
+- BGE: about `15.4 MB`
 - Nomic: about `30.7 MB`
 
 Actual on-disk LibraVDB usage is higher because text, metadata, collection
@@ -48,8 +48,7 @@ Not yet bench-measured in this repo:
 
 Measured from the current Go benchmark harness on Apple M2:
 
-- MiniLM bundled query embedding: about `22.6 ms/op`
-- MiniLM onnx-local query embedding: about `16.3 ms/op`
+- BGE fallback query embedding: not yet bench-measured in this repo
 - Nomic onnx-local query embedding: about `43.7 ms/op`
 
 Measured from a one-off 40-query timing sample on Apple M2:

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,10 +16,11 @@ The system is designed so a failure in one layer does not automatically collapse
 
 ## Supply Chain and Installer Trust Boundary
 
-The published plugin package intentionally avoids install-time process execution.
-That is a deliberate trust and distribution choice: the OpenClaw plugin is a
-thin client, and the local `libravdbd` daemon is a separate operator-managed
-component.
+The published plugin package intentionally avoids implicit install-time process
+execution. That is a deliberate trust and distribution choice: the OpenClaw
+plugin is a thin client, and the local `libravdbd` daemon is installed by the
+explicit `npx --yes @xdarkicex/openclaw-memory-libravdb --yes` command or by an
+operator-managed package channel.
 
 Current implementation facts:
 
@@ -28,7 +29,8 @@ Current implementation facts:
 - the published plugin source contains no direct `child_process` usage
 - the plugin connects only to a configured local endpoint such as
   `unix:/Users/<you>/.libravdbd/run/libravdb.sock` or `tcp:127.0.0.1:37421`
-- daemon installation and lifecycle are explicit user or operator actions
+- daemon installation and lifecycle happen through the explicit installer or
+  operator-managed service tooling
 
 The daemon distribution surface should be evaluated separately from the plugin
 package. If you install `libravdbd` from release assets or another package

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,14 +1,20 @@
 # Uninstall Guide
 
 This guide covers safe removal of the OpenClaw / OpenClaw.ai plugin and the
-separately managed `libravdbd` daemon.
+`libravdbd` daemon.
 
-If you only want to disable the memory replacement temporarily, remove the
-plugin slot assignment first and leave the daemon plus data in place.
+For installer-managed setups, start with:
+
+```bash
+npx --yes @xdarkicex/openclaw-memory-libravdb --uninstall
+```
+
+If you only want to disable the memory/context-engine replacement temporarily,
+remove the plugin slot assignments first and leave the daemon plus data in place.
 
 ## 1. Disable the Plugin
 
-Remove the plugin from the active OpenClaw slot in `~/.openclaw/openclaw.json`:
+Remove the plugin from the active OpenClaw slots in `~/.openclaw/openclaw.json`:
 
 ```json
 {
@@ -19,8 +25,8 @@ Remove the plugin from the active OpenClaw slot in `~/.openclaw/openclaw.json`:
 ```
 
 Treat that JSON as a minimal example only. If you assigned
-`libravdb-memory` under `memory`, remove that slot entry and leave any other
-plugin slots intact.
+`libravdb-memory` under `memory` and `contextEngine`, remove those slot entries
+and leave any other plugin slots intact.
 
 If you installed the package through the OpenClaw.ai plugin UI, remove or
 disable the same package there as well. If you use the CLI, remove it through

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -9,6 +9,10 @@ For installer-managed setups, start with:
 npx --yes @xdarkicex/openclaw-memory-libravdb --uninstall
 ```
 
+This removes installer-managed service wiring, the manual daemon binary, and
+runtime/model assets under `~/.local/share/libravdb` while preserving memory
+data under `~/.libravdbd`.
+
 If you only want to disable the memory/context-engine replacement temporarily,
 remove the plugin slot assignments first and leave the daemon plus data in place.
 
@@ -83,6 +87,8 @@ Common locations:
 - `~/.config/systemd/user/libravdbd.service`
 - `~/Library/LaunchAgents/com.xdarkicex.libravdbd.plist`
 - `~/.local/bin/libravdbd`
+- `~/.local/share/libravdb/onnxruntime/`
+- `~/.local/share/libravdb/models/`
 
 ## 4. Optional Full Data Cleanup
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "openclaw-memory-libravdb": "./scripts/auto-install.sh",
+    "openclaw-memory-libravdb-install": "./scripts/auto-install.sh"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -21,6 +25,7 @@
     "HOOK.md",
     "index.js",
     "cli-metadata.js",
+    "scripts/auto-install.sh",
     "openclaw.plugin.json",
     "package.json",
     "docs/",

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -12,7 +12,8 @@ PLUGIN_ID="libravdb-memory"
 PLUGIN_PACKAGE="@${REPO_OWNER_LOWER}/${PLUGIN_REPO}"
 DAEMON_RELEASE_BASE="https://github.com/${REPO_OWNER_LOWER}/${TAP_REPO}/releases/download"
 OPENCLAW_MIN_VERSION="2026.3.22"
-INSTALLER_VERSION="1.1.0"
+INSTALLER_VERSION="1.2.0"
+ONNXRUNTIME_VERSION="1.25.1"
 
 ASSUME_YES=0
 DRY_RUN=0
@@ -127,6 +128,77 @@ daemon_asset_name() {
   esac
 }
 
+onnxruntime_archive_name() {
+  local os="$1"
+  local arch="$2"
+  case "${os}-${arch}" in
+    darwin-arm64) echo "onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}.tgz" ;;
+    darwin-amd64) echo "onnxruntime-osx-x86_64-${ONNXRUNTIME_VERSION}.tgz" ;;
+    linux-amd64) echo "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz" ;;
+    linux-arm64) echo "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}.tgz" ;;
+    *) return 1 ;;
+  esac
+}
+
+onnxruntime_extract_dir() {
+  local os="$1"
+  local arch="$2"
+  case "${os}-${arch}" in
+    darwin-arm64) echo "onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}" ;;
+    darwin-amd64) echo "onnxruntime-osx-x86_64-${ONNXRUNTIME_VERSION}" ;;
+    linux-amd64) echo "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}" ;;
+    linux-arm64) echo "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}" ;;
+    *) return 1 ;;
+  esac
+}
+
+onnxruntime_sha256() {
+  local os="$1"
+  local arch="$2"
+  case "${os}-${arch}" in
+    darwin-arm64) echo "18987ec3187b5f29ba798109750f6135060560ad4e0a52678fcc753ee8fb3091" ;;
+    darwin-amd64) echo "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5" ;;
+    linux-amd64) echo "eb566a49cfc49ef0642f809b69340b5bb656c7c4905ba873526d226f2c005816" ;;
+    linux-arm64) echo "daa71b56b00c4ab34798a3d96ca41a32ece4d3e302dc2386d3cca83fd4491214" ;;
+    *) return 1 ;;
+  esac
+}
+
+onnxruntime_url() {
+  local os="$1"
+  local arch="$2"
+  local archive
+  archive="$(onnxruntime_archive_name "$os" "$arch")" || return 1
+  echo "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${archive}"
+}
+
+manual_asset_root() {
+  echo "$HOME/.local/share/libravdb"
+}
+
+manual_models_dir() {
+  echo "$(manual_asset_root)/models"
+}
+
+manual_runtime_dir() {
+  echo "$(manual_asset_root)/onnxruntime"
+}
+
+manual_runtime_lib_path() {
+  local os="$1"
+  local arch="$2"
+  local lib_name="libonnxruntime.so"
+  if [[ "$os" == "darwin" ]]; then
+    lib_name="libonnxruntime.dylib"
+  fi
+  echo "$(manual_runtime_dir)/$(onnxruntime_extract_dir "$os" "$arch")/lib/${lib_name}"
+}
+
+daemon_version() {
+  local bin="${1:-libravdbd}"
+  "$bin" version 2>/dev/null | head -1 || echo unknown
+}
+
 latest_release_tag() {
   local api_url="https://api.github.com/repos/${REPO_OWNER_LOWER}/${TAP_REPO}/releases/latest"
   local had_xtrace=0
@@ -181,6 +253,159 @@ sha256_file() {
   die "No SHA-256 tool found (need sha256sum or shasum)."
 }
 
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local actual
+  [[ -f "$file" ]] || return 1
+  actual="$(sha256_file "$file")"
+  [[ "$actual" == "$expected" ]]
+}
+
+download_verified_asset() {
+  local name="$1"
+  local url="$2"
+  local dest="$3"
+  local expected_sha="$4"
+  local tmp
+
+  mkdir -p "$(dirname "$dest")"
+  if verify_sha256 "$dest" "$expected_sha"; then
+    info "${name} already present."
+    return 0
+  fi
+
+  info "Downloading ${name}"
+  tmp="${dest}.tmp.$$"
+  TMP_FILES+=("$tmp")
+  curl -fL --retry 3 --retry-delay 1 --connect-timeout 10 --max-time 600 --progress-bar -o "$tmp" "$url"
+  if ! verify_sha256 "$tmp" "$expected_sha"; then
+    rm -f "$tmp"
+    die "Checksum mismatch for ${name}."
+  fi
+  mv -f "$tmp" "$dest"
+}
+
+write_embedding_manifest() {
+  local dir="$1"
+  local profile="$2"
+  local dimensions="$3"
+  mkdir -p "$dir"
+  cat > "$dir/embedding.json" <<EOF
+{
+  "backend": "onnx-local",
+  "profile": "${profile}",
+  "family": "${profile}",
+  "model": "model.onnx",
+  "tokenizer": "tokenizer.json",
+  "dimensions": ${dimensions},
+  "normalize": true,
+  "inputNames": ["input_ids", "attention_mask", "token_type_ids"],
+  "outputName": "last_hidden_state",
+  "pooling": "mean",
+  "addSpecialTokens": true
+}
+EOF
+}
+
+write_summarizer_manifest() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/summarizer.json" <<'EOF'
+{
+  "backend": "onnx-local",
+  "profile": "t5-small",
+  "family": "t5-small",
+  "encoder": "encoder_model.onnx",
+  "decoder": "decoder_model.onnx",
+  "tokenizer": "tokenizer.json",
+  "maxContextTokens": 512
+}
+EOF
+}
+
+provision_manual_assets() {
+  local os="$1"
+  local arch="$2"
+  local models_dir runtime_dir runtime_archive runtime_lib runtime_url runtime_sha
+  local nomic_dir bge_dir t5_dir
+
+  models_dir="$(manual_models_dir)"
+  runtime_dir="$(manual_runtime_dir)"
+  runtime_archive="${runtime_dir}/$(onnxruntime_archive_name "$os" "$arch")"
+  runtime_lib="$(manual_runtime_lib_path "$os" "$arch")"
+  runtime_url="$(onnxruntime_url "$os" "$arch")"
+  runtime_sha="$(onnxruntime_sha256 "$os" "$arch")"
+  nomic_dir="${models_dir}/nomic-embed-text-v1.5"
+  bge_dir="${models_dir}/bge-small-en-v1.5"
+  t5_dir="${models_dir}/t5-small"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "[dry-run] provision ONNX Runtime and model assets under $(manual_asset_root)"
+    return 0
+  fi
+
+  mkdir -p "$nomic_dir" "$bge_dir" "$t5_dir" "$runtime_dir"
+
+  download_verified_asset \
+    "nomic-embed-text-v1.5 model" \
+    "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/resolve/main/onnx/model.onnx" \
+    "${nomic_dir}/model.onnx" \
+    "147d5aa88c2101237358e17796cf3a227cead1ec304ec34b465bb08e9d952965"
+  download_verified_asset \
+    "nomic-embed-text-v1.5 tokenizer" \
+    "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/resolve/main/tokenizer.json" \
+    "${nomic_dir}/tokenizer.json" \
+    "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66"
+  write_embedding_manifest "$nomic_dir" "nomic-embed-text-v1.5" "768"
+
+  download_verified_asset \
+    "bge-small-en-v1.5 model" \
+    "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/onnx/model.onnx" \
+    "${bge_dir}/model.onnx" \
+    "828e1496d7fabb79cfa4dcd84fa38625c0d3d21da474a00f08db0f559940cf35"
+  download_verified_asset \
+    "bge-small-en-v1.5 tokenizer" \
+    "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/tokenizer.json" \
+    "${bge_dir}/tokenizer.json" \
+    "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66"
+  write_embedding_manifest "$bge_dir" "bge-small-en-v1.5" "384"
+
+  download_verified_asset \
+    "t5-small encoder" \
+    "https://huggingface.co/optimum/t5-small/resolve/main/encoder_model.onnx" \
+    "${t5_dir}/encoder_model.onnx" \
+    "41d326633f1b85f526508cc0db78a5d40877c292c1b6dccae2eacd7d2a53480d"
+  download_verified_asset \
+    "t5-small decoder" \
+    "https://huggingface.co/optimum/t5-small/resolve/main/decoder_model.onnx" \
+    "${t5_dir}/decoder_model.onnx" \
+    "0a1451011d61bcc796a87b7306c503562e910f110f884d0cc08532972c2cc584"
+  download_verified_asset \
+    "t5-small tokenizer" \
+    "https://huggingface.co/optimum/t5-small/resolve/main/tokenizer.json" \
+    "${t5_dir}/tokenizer.json" \
+    "5f0ed8ab5b8cfa9812bb73752f1d80c292e52bcf5a87a144dc9ab2d251056cbb"
+  download_verified_asset \
+    "t5-small tokenizer config" \
+    "https://huggingface.co/optimum/t5-small/resolve/main/tokenizer_config.json" \
+    "${t5_dir}/tokenizer_config.json" \
+    "4969f8d76ef05a16553bd2b07b3501673ae8d36972aea88a0f78ad31a3ff2de9"
+  download_verified_asset \
+    "t5-small config" \
+    "https://huggingface.co/optimum/t5-small/resolve/main/config.json" \
+    "${t5_dir}/config.json" \
+    "d112428e703aa7ea0d6b17a77e9739fcc15b87653779d9b7942d5ecbc61c00ed"
+  write_summarizer_manifest "$t5_dir"
+
+  if [[ ! -f "$runtime_lib" ]]; then
+    download_verified_asset "ONNX Runtime" "$runtime_url" "$runtime_archive" "$runtime_sha"
+    info "Extracting ONNX Runtime"
+    tar -xzf "$runtime_archive" -C "$runtime_dir"
+  fi
+  [[ -f "$runtime_lib" ]] || die "ONNX Runtime library not found after extraction: ${runtime_lib}"
+}
+
 check_openclaw_version() {
   local raw detected
   raw="$(openclaw --version 2>/dev/null || openclaw version 2>/dev/null || true)"
@@ -230,16 +455,38 @@ install_daemon_macos_brew() {
   fi
   info "Installing daemon with Homebrew tap ${REPO_OWNER_LOWER}/${TAP_REPO}"
   warn "If the tap requires credentials, Homebrew may prompt interactively."
-  brew tap "${REPO_OWNER_LOWER}/${TAP_REPO}"
+  brew tap "${REPO_OWNER_LOWER}/${TAP_REPO}" || return 1
   if brew list libravdbd >/dev/null 2>&1; then
     info "Existing Homebrew daemon install found; upgrading libravdbd."
-    brew upgrade libravdbd
-    brew services restart libravdbd
+    brew upgrade libravdbd || return 1
+    brew services restart libravdbd || return 1
   else
-    brew install libravdbd
-    brew services start libravdbd
+    brew install libravdbd || return 1
+    brew services start libravdbd || return 1
   fi
   return 0
+}
+
+install_openclaw_plugin_package() {
+  local output
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "[dry-run] openclaw plugins install ${PLUGIN_PACKAGE}"
+    return 0
+  fi
+  if output="$(openclaw plugins install "$PLUGIN_PACKAGE" 2>&1)"; then
+    printf '%s\n' "$output"
+    return 0
+  fi
+  if printf '%s\n' "$output" | grep -qi "plugin already exists"; then
+    warn "Plugin package already installed; attempting update and continuing with existing package if already current."
+    if openclaw plugins update "$PLUGIN_ID"; then
+      return 0
+    fi
+    warn "OpenClaw plugin update did not complete; continuing because ${PLUGIN_ID} is already installed."
+    return 0
+  fi
+  printf '%s\n' "$output" >&2
+  die "Plugin install failed. Try: openclaw plugins install ${PLUGIN_PACKAGE}"
 }
 
 install_daemon_manual() {
@@ -251,6 +498,7 @@ install_daemon_manual() {
     info "[dry-run] resolve latest release tag from ${REPO_OWNER_LOWER}/${TAP_REPO}"
     info "[dry-run] download daemon asset for ${os}/${arch} into ~/.local/bin/libravdbd"
     info "[dry-run] verify checksum and mark daemon executable"
+    provision_manual_assets "$os" "$arch"
     return 0
   fi
 
@@ -267,10 +515,11 @@ install_daemon_manual() {
   mkdir -p "$bin_dir"
 
   if [[ -x "$bin_path" ]]; then
-    current="$("$bin_path" --version 2>/dev/null | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    current="$(daemon_version "$bin_path" | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     current_norm="${current#v}"
     if [[ -n "$current_norm" && "$current_norm" == "$tag_norm" ]]; then
       info "libravdbd ${tag} already installed at ${bin_path}; skipping manual daemon download."
+      provision_manual_assets "$os" "$arch"
       return 0
     fi
   fi
@@ -293,31 +542,25 @@ install_daemon_manual() {
   DOWNLOADED_BIN_PATH=""
   append_path_once
   export PATH="$bin_dir:$PATH"
-
-  warn "Manual daemon install does not provision Homebrew-managed runtime/model assets."
-  warn "If the daemon fails to start, prefer Homebrew on macOS or follow docs for manual provisioning."
+  provision_manual_assets "$os" "$arch"
 }
 
 write_launchd_plist() {
   local dst="$HOME/Library/LaunchAgents/com.xdarkicex.libravdbd.plist"
   local daemon_bin="$HOME/.local/bin/libravdbd"
-  local runtime_lib="$HOME/.local/share/libravdb/onnxruntime/lib/libonnxruntime.dylib"
-  local escaped_home escaped_daemon_bin escaped_runtime_lib
-  local runtime_block=""
+  local os arch models_dir runtime_lib
+  local escaped_home escaped_daemon_bin escaped_runtime_lib escaped_models_dir
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  models_dir="$(manual_models_dir)"
+  runtime_lib="$(manual_runtime_lib_path "$os" "$arch")"
 
   mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs" "$HOME/.libravdbd/run"
   escaped_home="$(xml_escape "$HOME")"
   escaped_daemon_bin="$(xml_escape "$daemon_bin")"
   escaped_runtime_lib="$(xml_escape "$runtime_lib")"
-  if [[ -f "$runtime_lib" ]]; then
-    runtime_block=$(cat <<EOF
-      <key>LIBRAVDB_ONNX_RUNTIME</key>
-      <string>${escaped_runtime_lib}</string>
-EOF
-)
-  else
-    warn "ONNX runtime library not found at ${runtime_lib}; launchd env will omit LIBRAVDB_ONNX_RUNTIME."
-  fi
+  escaped_models_dir="$(xml_escape "$models_dir")"
   cat > "$dst" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -336,14 +579,33 @@ EOF
       <string>unix:${escaped_home}/.libravdbd/run/libravdb.sock</string>
       <key>LIBRAVDB_DB_PATH</key>
       <string>${escaped_home}/.libravdbd/data_nomic-embed-text-v1_5.libravdb</string>
-${runtime_block}
+      <key>LIBRAVDB_ONNX_RUNTIME</key>
+      <string>${escaped_runtime_lib}</string>
+      <key>LIBRAVDB_EMBEDDING_BACKEND</key>
+      <string>onnx-local</string>
+      <key>LIBRAVDB_EMBEDDING_PROFILE</key>
+      <string>nomic-embed-text-v1.5</string>
+      <key>LIBRAVDB_EMBEDDING_MODEL</key>
+      <string>${escaped_models_dir}/nomic-embed-text-v1.5/model.onnx</string>
+      <key>LIBRAVDB_EMBEDDING_TOKENIZER</key>
+      <string>${escaped_models_dir}/nomic-embed-text-v1.5/tokenizer.json</string>
+      <key>LIBRAVDB_EMBEDDING_DIMENSIONS</key>
+      <string>768</string>
+      <key>LIBRAVDB_EMBEDDING_NORMALIZE</key>
+      <string>true</string>
+      <key>LIBRAVDB_FALLBACK_PROFILE</key>
+      <string>bge-small-en-v1.5</string>
       <key>LIBRAVDB_SUMMARIZER_BACKEND</key>
-      <string>bundled</string>
+      <string>onnx-local</string>
+      <key>LIBRAVDB_SUMMARIZER_MODEL_PATH</key>
+      <string>${escaped_models_dir}/t5-small</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>WorkingDirectory</key>
+    <string>${escaped_home}/.libravdbd</string>
     <key>StandardOutPath</key>
     <string>${escaped_home}/Library/Logs/libravdbd.log</string>
     <key>StandardErrorPath</key>
@@ -368,29 +630,52 @@ setup_launchd_manual() {
       fi
     fi
   fi
-  launchctl bootstrap "gui/$(id -u)" "$plist"
-  launchctl kickstart -k "gui/$(id -u)/com.xdarkicex.libravdbd"
+  rm -f "$HOME/.libravdbd/run/libravdb.sock"
+  if ! launchctl bootstrap "gui/$(id -u)" "$plist"; then
+    warn "Failed to bootstrap LaunchAgent ${plist}."
+    return 1
+  fi
+  if ! launchctl kickstart -k "gui/$(id -u)/com.xdarkicex.libravdbd"; then
+    warn "Failed to kickstart LaunchAgent com.xdarkicex.libravdbd."
+    return 1
+  fi
 }
 
 setup_systemd_manual() {
   local service="$HOME/.config/systemd/user/libravdbd.service"
+  local os arch models_dir runtime_lib
   if [[ "$DRY_RUN" -eq 1 ]]; then
     info "[dry-run] write ${service}"
     info "[dry-run] systemctl --user enable --now libravdbd.service"
     return 0
   fi
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  models_dir="$(manual_models_dir)"
+  runtime_lib="$(manual_runtime_lib_path "$os" "$arch")"
   mkdir -p "$HOME/.config/systemd/user" "$HOME/.libravdbd/run"
-  cat > "$service" <<'EOF'
+  cat > "$service" <<EOF
 [Unit]
 Description=LibraVDB daemon (user)
 After=network.target
 
 [Service]
-ExecStart=%h/.local/bin/libravdbd serve
+ExecStart=${HOME}/.local/bin/libravdbd serve
 Restart=on-failure
 RestartSec=5
-Environment=LIBRAVDB_RPC_ENDPOINT=unix:%h/.libravdbd/run/libravdb.sock
-Environment=LIBRAVDB_DB_PATH=%h/.libravdbd/data_nomic-embed-text-v1_5.libravdb
+WorkingDirectory=${HOME}/.libravdbd
+Environment=LIBRAVDB_RPC_ENDPOINT=unix:${HOME}/.libravdbd/run/libravdb.sock
+Environment=LIBRAVDB_DB_PATH=${HOME}/.libravdbd/data_nomic-embed-text-v1_5.libravdb
+Environment=LIBRAVDB_ONNX_RUNTIME=${runtime_lib}
+Environment=LIBRAVDB_EMBEDDING_BACKEND=onnx-local
+Environment=LIBRAVDB_EMBEDDING_PROFILE=nomic-embed-text-v1.5
+Environment=LIBRAVDB_EMBEDDING_MODEL=${models_dir}/nomic-embed-text-v1.5/model.onnx
+Environment=LIBRAVDB_EMBEDDING_TOKENIZER=${models_dir}/nomic-embed-text-v1.5/tokenizer.json
+Environment=LIBRAVDB_EMBEDDING_DIMENSIONS=768
+Environment=LIBRAVDB_EMBEDDING_NORMALIZE=true
+Environment=LIBRAVDB_FALLBACK_PROFILE=bge-small-en-v1.5
+Environment=LIBRAVDB_SUMMARIZER_BACKEND=onnx-local
+Environment=LIBRAVDB_SUMMARIZER_MODEL_PATH=${models_dir}/t5-small
 
 [Install]
 WantedBy=default.target
@@ -400,22 +685,7 @@ EOF
   systemctl --user enable --now libravdbd.service
 }
 
-start_manual_daemon() {
-  local os="$1"
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    info "[dry-run] start manual daemon for ${os}"
-    return 0
-  fi
-  if [[ "$os" == "darwin" ]]; then
-    setup_launchd_manual
-    return 0
-  fi
-
-  if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
-    setup_systemd_manual
-    return 0
-  fi
-
+start_background_daemon() {
   if [[ -f "$HOME/.libravdbd/libravdbd.pid" ]]; then
     local pid
     pid="$(cat "$HOME/.libravdbd/libravdbd.pid" 2>/dev/null || true)"
@@ -431,9 +701,50 @@ start_manual_daemon() {
   fi
 
   mkdir -p "$HOME/.libravdbd" "$HOME/.libravdbd/run"
-  nohup "$HOME/.local/bin/libravdbd" serve > "$HOME/.libravdbd/libravdbd.log" 2>&1 &
+  rm -f "$HOME/.libravdbd/run/libravdb.sock"
+  local os arch models_dir runtime_lib
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  models_dir="$(manual_models_dir)"
+  runtime_lib="$(manual_runtime_lib_path "$os" "$arch")"
+  LIBRAVDB_RPC_ENDPOINT="unix:${HOME}/.libravdbd/run/libravdb.sock" \
+    LIBRAVDB_DB_PATH="${HOME}/.libravdbd/data_nomic-embed-text-v1_5.libravdb" \
+    LIBRAVDB_ONNX_RUNTIME="$runtime_lib" \
+    LIBRAVDB_EMBEDDING_BACKEND="onnx-local" \
+    LIBRAVDB_EMBEDDING_PROFILE="nomic-embed-text-v1.5" \
+    LIBRAVDB_EMBEDDING_MODEL="${models_dir}/nomic-embed-text-v1.5/model.onnx" \
+    LIBRAVDB_EMBEDDING_TOKENIZER="${models_dir}/nomic-embed-text-v1.5/tokenizer.json" \
+    LIBRAVDB_EMBEDDING_DIMENSIONS="768" \
+    LIBRAVDB_EMBEDDING_NORMALIZE="true" \
+    LIBRAVDB_FALLBACK_PROFILE="bge-small-en-v1.5" \
+    LIBRAVDB_SUMMARIZER_BACKEND="onnx-local" \
+    LIBRAVDB_SUMMARIZER_MODEL_PATH="${models_dir}/t5-small" \
+    nohup "$HOME/.local/bin/libravdbd" serve > "$HOME/.libravdbd/libravdbd.log" 2>&1 &
   echo $! > "$HOME/.libravdbd/libravdbd.pid"
-  warn "Started manual background daemon (no system service)."
+  warn "Started background daemon without systemd. The pid file is ${HOME}/.libravdbd/libravdbd.pid."
+}
+
+start_manual_daemon() {
+  local platform="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "[dry-run] start manual daemon for ${platform}"
+    return 0
+  fi
+  if [[ "$platform" == "darwin" ]]; then
+    if setup_launchd_manual; then
+      return 0
+    fi
+    warn "LaunchAgent startup failed; falling back to a background daemon for this login session."
+    start_background_daemon
+    return 0
+  fi
+
+  if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+    setup_systemd_manual
+    return 0
+  fi
+
+  start_background_daemon
 }
 
 xml_escape() {
@@ -449,13 +760,13 @@ xml_escape() {
 verify_manual_daemon_ready() {
   local socket_path="$HOME/.libravdbd/run/libravdb.sock"
   local i
-  for i in {1..20}; do
+  for i in {1..120}; do
     if [[ -S "$socket_path" ]]; then
       info "Manual daemon socket detected at ${socket_path}."
       info "Daemon socket is present; OpenClaw RPC health is verified in the later status retry check."
       return 0
     fi
-    sleep 0.5
+    sleep 1
   done
   warn "Manual daemon socket was not detected at ${socket_path} after waiting."
   warn "If startup failed, inspect logs under ~/.libravdbd or ~/Library/Logs/libravdbd.log."
@@ -486,7 +797,7 @@ configure_openclaw_json() {
   local tmp
 
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    info "[dry-run] backup and update ${config_file} with plugin slots/config"
+    info "[dry-run] backup and update ${config_file} with memory/context-engine slots and config"
     return 0
   fi
 
@@ -503,9 +814,11 @@ configure_openclaw_json() {
     .plugins.slots |= (. // {}) |
     .plugins.slots.memory = $plugin |
     .plugins.slots.contextEngine = $plugin |
-    .plugins.configs |= (. // {}) |
-    .plugins.configs[$plugin] |= (. // {}) |
-    .plugins.configs[$plugin].sidecarPath = (.plugins.configs[$plugin].sidecarPath // "auto")
+    .plugins.entries |= (. // {}) |
+    .plugins.entries[$plugin] = ((.plugins.entries[$plugin] // {}) + { enabled: true }) |
+    .plugins.entries[$plugin].config = ((.plugins.entries[$plugin].config // {}) + {
+      sidecarPath: (.plugins.entries[$plugin].config.sidecarPath // "auto")
+    })
   ' "$config_file" > "$tmp"; then
     die "Failed to update ${config_file}. Original config left unchanged."
   fi
@@ -526,12 +839,12 @@ print_header() {
 ${BOLD}LibraVDB Memory Auto-Installer${RESET}
 Version: ${INSTALLER_VERSION}
 Target: ${os}/${arch}
-Requires: openclaw >= ${OPENCLAW_MIN_VERSION}, curl, jq
+Requires: openclaw >= ${OPENCLAW_MIN_VERSION}, curl, jq, tar
 ${dry_run_notice}
 This script will:
 1) Install and start the local 'libravdbd' daemon.
 2) Install the OpenClaw plugin package '${PLUGIN_PACKAGE}'.
-3) Update '${HOME}/.openclaw/openclaw.json' so both plugin slots use '${PLUGIN_ID}'.
+3) Update '${HOME}/.openclaw/openclaw.json' so the memory and context-engine slots use '${PLUGIN_ID}'.
 4) Run 'openclaw memory status' to verify connectivity.
 
 No task/memory/spec databases in this repository are modified by this installer.
@@ -560,7 +873,7 @@ print_summary() {
   fi
   daemon_bin="$(command -v libravdbd || true)"
   if [[ -n "$daemon_bin" ]]; then
-    daemon_version="$(libravdbd --version 2>/dev/null | head -1 || echo unknown)"
+    daemon_version="$(daemon_version "$daemon_bin")"
   fi
   cat <<EOF
 
@@ -582,11 +895,11 @@ uninstall_openclaw_config() {
   fi
   if ! command -v jq >/dev/null 2>&1; then
     warn "jq not found; skipping OpenClaw config cleanup."
-    warn "Plugin slots/config entries for ${PLUGIN_ID} may still be present in ${config_file}."
+    warn "Plugin slot/config entries for ${PLUGIN_ID} may still be present in ${config_file}."
     return 0
   fi
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    info "[dry-run] remove ${PLUGIN_ID} from OpenClaw slots/config in ${config_file}"
+    info "[dry-run] remove ${PLUGIN_ID} from OpenClaw memory/context-engine slots and config in ${config_file}"
     return 0
   fi
   backup_file="${config_file}.bak.$(date +%Y%m%d_%H%M%S)_uninstall_$$"
@@ -597,10 +910,10 @@ uninstall_openclaw_config() {
   if ! jq --arg plugin "$PLUGIN_ID" '
     .plugins |= (. // {}) |
     .plugins.slots |= (. // {}) |
-    .plugins.configs |= (. // {}) |
+    .plugins.entries |= (. // {}) |
     if .plugins.slots.memory == $plugin then del(.plugins.slots.memory) else . end |
     if .plugins.slots.contextEngine == $plugin then del(.plugins.slots.contextEngine) else . end |
-    del(.plugins.configs[$plugin])
+    del(.plugins.entries[$plugin])
   ' "$config_file" > "$tmp"; then
     die "Failed to update ${config_file} during uninstall."
   fi
@@ -623,7 +936,7 @@ uninstall_plugin_package() {
   if openclaw plugins uninstall "$PLUGIN_PACKAGE" >/dev/null 2>&1; then
     info "Uninstalled plugin package ${PLUGIN_PACKAGE}."
   else
-    warn "Plugin uninstall command did not complete cleanly. You may need to remove it manually."
+    warn "Plugin uninstall command did not complete cleanly. You may need to remove it with the OpenClaw CLI."
   fi
 }
 
@@ -760,6 +1073,7 @@ main() {
   check_command "openclaw" "OpenClaw CLI"
   check_command "curl" "curl"
   check_command "jq" "jq"
+  check_command "tar" "tar"
   check_openclaw_version
 
   if command -v node >/dev/null 2>&1; then
@@ -784,10 +1098,19 @@ main() {
 
   if [[ "$os" == "darwin" ]]; then
     if confirm "Use Homebrew for daemon install/management (recommended on macOS)?"; then
-      install_daemon_macos_brew || die "Homebrew daemon install failed. Try 'brew logs libravdbd' and rerun."
+      if ! install_daemon_macos_brew; then
+        warn "Homebrew daemon install failed; falling back to installer-managed daemon assets."
+        install_daemon_manual "$os" "$arch"
+        if confirm "Create/load LaunchAgent for manual daemon startup?"; then
+          start_manual_daemon "$os"
+          if [[ "$DRY_RUN" -eq 0 ]]; then
+            verify_manual_daemon_ready || true
+          fi
+        fi
+      fi
     else
       warn "Switching to manual daemon install on macOS."
-      warn "Manual mode can require extra runtime/model provisioning and is best-effort only."
+      warn "Manual mode downloads the published daemon, ONNX Runtime, model assets, and LaunchAgent wiring."
       install_daemon_manual "$os" "$arch"
       if confirm "Create/load LaunchAgent for manual daemon startup?"; then
         start_manual_daemon "$os"
@@ -807,20 +1130,16 @@ main() {
   fi
 
   if confirm "Install OpenClaw plugin package (${PLUGIN_PACKAGE}) now?"; then
-    if [[ "$DRY_RUN" -eq 1 ]]; then
-      info "[dry-run] openclaw plugins install ${PLUGIN_PACKAGE}"
-    else
-      openclaw plugins install "$PLUGIN_PACKAGE" || die "Plugin install failed. Try: openclaw plugins install ${PLUGIN_PACKAGE}"
-    fi
+    install_openclaw_plugin_package
   else
     warn "Skipping plugin install. Re-run later with: openclaw plugins install ${PLUGIN_PACKAGE}"
     exit 0
   fi
 
-  if confirm "Update ~/.openclaw/openclaw.json plugin slots/config now?"; then
+  if confirm "Update ~/.openclaw/openclaw.json memory/context-engine slots and config now?"; then
     configure_openclaw_json
   else
-    warn "Skipped openclaw.json update. You must set plugin slots manually."
+    warn "Skipped OpenClaw config update. Rerun this installer to apply the plugin slot/config."
   fi
 
   info "Verifying installation with: openclaw memory status"

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -519,6 +519,8 @@ install_daemon_manual() {
     current_norm="${current#v}"
     if [[ -n "$current_norm" && "$current_norm" == "$tag_norm" ]]; then
       info "libravdbd ${tag} already installed at ${bin_path}; skipping manual daemon download."
+      append_path_once
+      export PATH="$bin_dir:$PATH"
       provision_manual_assets "$os" "$arch"
       return 0
     fi
@@ -972,12 +974,16 @@ stop_daemon_services() {
     return 0
   fi
 
-  if command -v systemctl >/dev/null 2>&1 && [[ -f "$systemd_service" ]]; then
+  if [[ -f "$systemd_service" ]]; then
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      info "[dry-run] systemctl --user disable --now libravdbd.service"
+      if command -v systemctl >/dev/null 2>&1; then
+        info "[dry-run] systemctl --user disable --now libravdbd.service"
+      fi
       info "[dry-run] rm -f ${systemd_service}"
     else
-      systemctl --user disable --now libravdbd.service || warn "Failed to disable user systemd service."
+      if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user disable --now libravdbd.service || warn "Failed to disable user systemd service."
+      fi
       rm -f "$systemd_service"
     fi
   fi
@@ -1012,6 +1018,23 @@ remove_manual_daemon_binary() {
   info "Removed manual daemon binary at ${bin_path}."
 }
 
+remove_manual_assets() {
+  local asset_root
+  asset_root="$(manual_asset_root)"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "[dry-run] rm -rf ${asset_root}/onnxruntime ${asset_root}/models"
+    return 0
+  fi
+
+  if [[ ! -d "${asset_root}/onnxruntime" && ! -d "${asset_root}/models" ]]; then
+    return 0
+  fi
+
+  rm -rf "${asset_root}/onnxruntime" "${asset_root}/models"
+  info "Removed installer-managed assets under ${asset_root}."
+}
+
 run_uninstall_mode() {
   local os
   os="$(detect_os)"
@@ -1030,6 +1053,7 @@ run_uninstall_mode() {
   uninstall_openclaw_config
   uninstall_plugin_package
   remove_manual_daemon_binary
+  remove_manual_assets
 
   echo
   if [[ "$DRY_RUN" -eq 1 ]]; then

--- a/scripts/build-daemon.sh
+++ b/scripts/build-daemon.sh
@@ -16,9 +16,9 @@ fi
 
 copy_assets() {
   local asset_root="$1"
-  if [[ -d "$asset_root/all-minilm-l6-v2" ]]; then
-    rm -rf "$OUT_MODELS_DIR/all-minilm-l6-v2"
-    cp -R "$asset_root/all-minilm-l6-v2" "$OUT_MODELS_DIR/all-minilm-l6-v2"
+  if [[ -d "$asset_root/bge-small-en-v1.5" ]]; then
+    rm -rf "$OUT_MODELS_DIR/bge-small-en-v1.5"
+    cp -R "$asset_root/bge-small-en-v1.5" "$OUT_MODELS_DIR/bge-small-en-v1.5"
   fi
   if [[ -d "$asset_root/nomic-embed-text-v1.5" ]]; then
     rm -rf "$OUT_MODELS_DIR/nomic-embed-text-v1.5"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -30,9 +30,9 @@ rmSync(outModelsDir, { recursive: true, force: true });
 rmSync(outRuntimeDir, { recursive: true, force: true });
 mkdirSync(outModelsDir, { recursive: true });
 
-const bundledMiniLM = path.join(modelsDir, "all-minilm-l6-v2");
-if (existsSync(bundledMiniLM)) {
-  cpSync(bundledMiniLM, path.join(outModelsDir, "all-minilm-l6-v2"), { recursive: true });
+const bundledBge = path.join(modelsDir, "bge-small-en-v1.5");
+if (existsSync(bundledBge)) {
+  cpSync(bundledBge, path.join(outModelsDir, "bge-small-en-v1.5"), { recursive: true });
 }
 
 const bundledNomic = path.join(modelsDir, "nomic-embed-text-v1.5");

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -52,20 +52,20 @@ const nomicAssets: AssetSpec[] = [
   },
 ];
 
-const miniLMAssets: AssetSpec[] = [
+const bgeAssets: AssetSpec[] = [
   {
-    name: "all-minilm-l6-v2 model",
-    dest: path.join(modelsDir, "all-minilm-l6-v2", "model.onnx"),
-    localSource: path.join(rootDir, ".models", "all-minilm-l6-v2", "model.onnx"),
-    url: "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx",
-    sha256: "759c3cd2b7fe7e93933ad23c4c9181b7396442a2ed746ec7c1d46192c469c46e",
+    name: "bge-small-en-v1.5 model",
+    dest: path.join(modelsDir, "bge-small-en-v1.5", "model.onnx"),
+    localSource: path.join(rootDir, ".models", "bge-small-en-v1.5", "model.onnx"),
+    url: "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/onnx/model.onnx",
+    sha256: "828e1496d7fabb79cfa4dcd84fa38625c0d3d21da474a00f08db0f559940cf35",
   },
   {
-    name: "all-minilm-l6-v2 tokenizer",
-    dest: path.join(modelsDir, "all-minilm-l6-v2", "tokenizer.json"),
-    localSource: path.join(rootDir, ".models", "all-minilm-l6-v2", "tokenizer.json"),
-    url: "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json",
-    sha256: "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0",
+    name: "bge-small-en-v1.5 tokenizer",
+    dest: path.join(modelsDir, "bge-small-en-v1.5", "tokenizer.json"),
+    localSource: path.join(rootDir, ".models", "bge-small-en-v1.5", "tokenizer.json"),
+    url: "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/tokenizer.json",
+    sha256: "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66",
   },
 ];
 
@@ -163,10 +163,10 @@ async function main(): Promise<void> {
     await ensureAsset(asset);
   }
   writeEmbeddingManifest();
-  for (const asset of miniLMAssets) {
+  for (const asset of bgeAssets) {
     await ensureAsset(asset);
   }
-  writeMiniLMManifest();
+  writeBgeManifest();
 
   console.log("[openclaw-memory-libravdb] Provisioning ONNX runtime...");
   await ensureRuntime();
@@ -247,13 +247,13 @@ function writeEmbeddingManifest(): void {
   }, null, 2)}\n`);
 }
 
-function writeMiniLMManifest(): void {
-  const dir = path.join(modelsDir, "all-minilm-l6-v2");
+function writeBgeManifest(): void {
+  const dir = path.join(modelsDir, "bge-small-en-v1.5");
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "embedding.json"), `${JSON.stringify({
     backend: "onnx-local",
-    profile: "all-minilm-l6-v2",
-    family: "all-minilm-l6-v2",
+    profile: "bge-small-en-v1.5",
+    family: "bge-small-en-v1.5",
     model: "model.onnx",
     tokenizer: "tokenizer.json",
     dimensions: 384,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,9 @@ export function register(api: OpenClawPluginApi) {
   const runtime = runtimeOrNull;
   if (!runtime) return; // unreachable but satisfies the type checker
 
-  // Exclusive slot check: refuse to register if another plugin owns the memory slot.
-  // plugins.slots.memory is the only configurable slot; context engine exclusivity
-  // is enforced by the registry at runtime (no config surface for it).
+  // Exclusive slot check: refuse to register memory if another plugin owns the memory slot.
+  // Context-engine selection is handled by plugins.slots.contextEngine and the
+  // registry at runtime.
   // "none" means memory is disabled, not a conflict, allow registration.
   const memSlot = api.config?.plugins?.slots?.memory;
   if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -166,7 +166,7 @@ function formatError(error: unknown): string {
 export function enrichStartupError(error: unknown, healthMessage?: string): Error {
   const rawMessage = error instanceof Error ? error.message : String(error);
   const message = rawMessage.trim() || "LibraVDB daemon startup failed";
-  if (message.includes("install and start libravdbd separately") || message.includes("package does not provision the daemon binary")) {
+  if (message.includes("@xdarkicex/openclaw-memory-libravdb") || message.includes("install and start libravdbd separately")) {
     return error instanceof Error ? error : new Error(message);
   }
   const shouldHint = /health check|daemon unavailable|connection refused|ECONNREFUSED|ENOENT|fallback mode|ONNX Runtime|embedder/i.test(

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -387,7 +387,7 @@ export function resolveConfiguredEndpoint(cfg: PluginConfig): string {
 }
 
 export function daemonProvisioningHint(): string {
-  return "If you installed the npm package, install and start libravdbd separately; the package does not provision the daemon binary, ONNX Runtime, or model assets.";
+  return "Run `npx --yes @xdarkicex/openclaw-memory-libravdb --yes` to install libravdbd, ONNX Runtime, model assets, the OpenClaw plugin package, and the memory/context-engine slot config.";
 }
 
 export function defaultEndpoint(

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -70,10 +70,22 @@ test("auto installer owns daemon assets and current OpenClaw config shape", asyn
   assert.match(installer, /start_background_daemon/);
   assert.match(installer, /LaunchAgent startup failed; falling back/);
   assert.match(installer, /rm -f "\$HOME\/\.libravdbd\/run\/libravdb\.sock"/);
+  assert.match(
+    installer,
+    /libravdbd \$\{tag\} already installed[^\n]*\n\s+append_path_once\n\s+export PATH="\$bin_dir:\$PATH"\n\s+provision_manual_assets/,
+  );
+  assert.match(installer, /remove_manual_assets/);
+  assert.match(installer, /rm -rf "\$\{asset_root\}\/onnxruntime" "\$\{asset_root\}\/models"/);
   assert.match(installer, /for i in \{1\.\.120\}/);
   assert.match(installer, /\.plugins\.entries\[\$plugin\]/);
   assert.match(installer, /\.plugins\.slots\.memory = \$plugin/);
   assert.match(installer, /\.plugins\.slots\.contextEngine = \$plugin/);
   assert.doesNotMatch(installer, /\.plugins\.configs/);
   assert.doesNotMatch(installer, /libravdbd --version/);
+});
+
+test("install docs foreground daemon command works without PATH setup", async () => {
+  const installMd = await readFile(path.join(repoRoot, "docs", "install.md"), "utf8");
+
+  assert.match(installMd, /chmod \+x ~\/\.local\/bin\/libravdbd\n~\/\.local\/bin\/libravdbd serve/);
 });

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -14,17 +14,21 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.equal(manifest.configSchema.additionalProperties, false);
   assert.deepEqual(
     Object.keys(manifest).sort(),
-    ["activation", "configSchema", "description", "id", "kind", "name", "version"],
+    ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "version"],
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);
+  assert.equal(manifest.configSchema.properties.fallbackProfile.default, "bge-small-en-v1.5");
 
   assert.equal(pkg.main, "./dist/index.js");
   assert.equal(pkg.types, "./dist/index.d.ts");
   assert.ok(Array.isArray(pkg.openclaw?.extensions));
   assert.ok(pkg.openclaw.extensions.includes("./dist/index.js"));
   assert.equal(pkg.exports["."].import, "./dist/index.js");
+  assert.equal(pkg.bin["openclaw-memory-libravdb"], "./scripts/auto-install.sh");
+  assert.equal(pkg.bin["openclaw-memory-libravdb-install"], "./scripts/auto-install.sh");
   assert.ok(pkg.files.includes("cli-metadata.js"));
+  assert.ok(pkg.files.includes("scripts/auto-install.sh"));
   assert.match(hookMd, /name:\s*libravdb-memory/);
 });
 
@@ -49,4 +53,27 @@ test("source checklist invariants are present in host code", async () => {
   assert.doesNotMatch(indexTs, /async register\s*\(/);
   assert.match(memoryProviderTs, /availableTools/);
   assert.match(memoryProviderTs, /context-engine assembler/);
+});
+
+test("auto installer owns daemon assets and current OpenClaw config shape", async () => {
+  const installer = await readFile(path.join(repoRoot, "scripts", "auto-install.sh"), "utf8");
+
+  assert.match(installer, /provision_manual_assets/);
+  assert.match(installer, /LIBRAVDB_EMBEDDING_MODEL/);
+  assert.match(installer, /LIBRAVDB_SUMMARIZER_MODEL_PATH/);
+  assert.match(installer, /bge-small-en-v1\.5/);
+  assert.doesNotMatch(installer, /all-minilm-l6-v2/);
+  assert.match(installer, /falling back to installer-managed daemon assets/);
+  assert.match(installer, /brew install libravdbd \|\| return 1/);
+  assert.match(installer, /plugin already exists/);
+  assert.match(installer, /openclaw plugins update "\$PLUGIN_ID"/);
+  assert.match(installer, /start_background_daemon/);
+  assert.match(installer, /LaunchAgent startup failed; falling back/);
+  assert.match(installer, /rm -f "\$HOME\/\.libravdbd\/run\/libravdb\.sock"/);
+  assert.match(installer, /for i in \{1\.\.120\}/);
+  assert.match(installer, /\.plugins\.entries\[\$plugin\]/);
+  assert.match(installer, /\.plugins\.slots\.memory = \$plugin/);
+  assert.match(installer, /\.plugins\.slots\.contextEngine = \$plugin/);
+  assert.doesNotMatch(installer, /\.plugins\.configs/);
+  assert.doesNotMatch(installer, /libravdbd --version/);
 });

--- a/test/integration/sidecar-lifecycle.test.ts
+++ b/test/integration/sidecar-lifecycle.test.ts
@@ -238,7 +238,7 @@ test("missing daemon errors point users at libravdbd instead of spawn internals"
 
   await assert.rejects(
     () => startSidecar({ rpcTimeoutMs: 50 }, createMemoryLogger(), runtime.runtime),
-    /install and start libravdbd separately/i,
+    /npx --yes @xdarkicex\/openclaw-memory-libravdb --yes/i,
   );
 });
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -188,7 +188,7 @@ test("status command shuts the plugin runtime down after printing status", async
               lifecycleHintCount: 1,
               gatingThreshold: 0.35,
               abstractiveReady: true,
-              embeddingProfile: "all-minilm-l6-v2",
+              embeddingProfile: "bge-small-en-v1.5",
               message: "ok",
             };
           },
@@ -247,7 +247,7 @@ test("status --deep probes authored collection search health", async () => {
           async call(method: string, params: Record<string, unknown>) {
             rpcCalls.push({ method, params });
             if (method === "status") {
-              return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
+              return { ok: true, message: "ok", embeddingProfile: "bge-small-en-v1.5" };
             }
             if (method === "search_text") {
               if (params.collection === "authored:soft") {
@@ -320,7 +320,7 @@ test("status --deep includes authored probe rows in table output", async () => {
         return {
           async call(method: string, params: Record<string, unknown>) {
             if (method === "status") {
-              return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
+              return { ok: true, message: "ok", embeddingProfile: "bge-small-en-v1.5" };
             }
             if (method === "search_text") {
               return { results: params.collection === "authored:variant" ? [{ id: "v1" }] : [] };

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -44,7 +44,7 @@ class FakeRpc {
           memoryCount: 4,
           gatingThreshold: 0.35,
           abstractiveReady: false,
-          embeddingProfile: "all-minilm-l6-v2",
+          embeddingProfile: "bge-small-en-v1.5",
           sessionTurnCount: 7,
         } as T;
       case "list_collection":
@@ -219,7 +219,7 @@ test("memory runtime bridge exposes cached status and keeps legacy helpers deleg
   assert.equal(status.backend, "builtin");
   assert.equal(status.provider, "libravdb");
   assert.equal(status.turnCount, 12);
-  assert.equal(status.embeddingProfile, "all-minilm-l6-v2");
+  assert.equal(status.embeddingProfile, "bge-small-en-v1.5");
   assert.equal(status.sessionTurnCount, 7);
   assert.deepEqual(ingest, { ingested: false, delegatedToContextEngine: true });
   assert.deepEqual(sync, { synced: true, delegatedToContextEngine: true });

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -7,7 +7,7 @@ test("enrichStartupError adds provisioning guidance for daemon startup failures"
   const err = enrichStartupError("LibraVDB daemon failed health check", "embedder running in deterministic fallback mode");
   assert.match(err.message, /daemon failed health check/);
   assert.match(err.message, /deterministic fallback mode/);
-  assert.match(err.message, /install and start libravdbd separately/);
+  assert.match(err.message, /npx --yes @xdarkicex\/openclaw-memory-libravdb --yes/);
 });
 
 test("enrichStartupError leaves unrelated errors alone", () => {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -91,7 +91,7 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
     onnxDevice: "cpu",
     embeddingBackend: "custom-local",
     embeddingProfile: "nomic-embed-text-v1.5",
-    fallbackProfile: "all-minilm-l6-v2",
+    fallbackProfile: "bge-small-en-v1.5",
     embeddingModelPath: "/models/custom.onnx",
     embeddingTokenizerPath: "/models/tokenizer.json",
     embeddingDimensions: 768,
@@ -105,7 +105,7 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
     LIBRAVDB_ONNX_DEVICE: "cpu",
     LIBRAVDB_EMBEDDING_BACKEND: "custom-local",
     LIBRAVDB_EMBEDDING_PROFILE: "nomic-embed-text-v1.5",
-    LIBRAVDB_FALLBACK_PROFILE: "all-minilm-l6-v2",
+    LIBRAVDB_FALLBACK_PROFILE: "bge-small-en-v1.5",
     LIBRAVDB_EMBEDDING_MODEL: "/models/custom.onnx",
     LIBRAVDB_EMBEDDING_TOKENIZER: "/models/tokenizer.json",
     LIBRAVDB_EMBEDDING_DIMENSIONS: "768",
@@ -114,7 +114,7 @@ test("buildSidecarEnv maps embedding config into sidecar environment", () => {
   });
 });
 
-test("daemonProvisioningHint explains the npm vs Homebrew split", () => {
-  assert.match(daemonProvisioningHint(), /npm package/);
-  assert.match(daemonProvisioningHint(), /install and start libravdbd separately/);
+test("daemonProvisioningHint points to the automated installer", () => {
+  assert.match(daemonProvisioningHint(), /npx --yes @xdarkicex\/openclaw-memory-libravdb --yes/);
+  assert.match(daemonProvisioningHint(), /memory\/context-engine slot config/);
 });


### PR DESCRIPTION
## Summary
- expose the automated installer as package bins so users can run `npx --yes @xdarkicex/openclaw-memory-libravdb --yes`
- make manual daemon install provision the daemon, ONNX Runtime, Nomic/BGE/T5 assets, launchd/systemd env, and current `plugins.entries` OpenClaw config shape
- assign both exclusive slots: `plugins.slots.memory` and `plugins.slots.contextEngine`
- fall back from Homebrew to installer-managed daemon assets when Homebrew fails, tolerate launchd bootstrap failures by falling back to a background daemon, and handle already-installed plugin packages idempotently
- preserve the intended fallback profile contract: `bge-small-en-v1.5`

## Installation issues addressed
- README/docs routed users through `openclaw plugins install`, which enabled the package but did not assign the required exclusive slots or write `plugins.entries[libravdb-memory].config`
- `scripts/auto-install.sh` wrote stale `plugins.configs`; it now writes `plugins.entries` while assigning both `memory` and `contextEngine` slots
- Homebrew failures were swallowed because the function ended with `return 0`; failures now return nonzero and trigger fallback
- rerunning the installer failed when the plugin was already installed; it now updates or continues with the existing package
- launchd bootstrap failures could abort before config assignment; the installer now falls back to a login-session background daemon
- manual macOS docs referenced service-template downloads that were not present; installer now writes service files directly
- manual installer launchd/runtime wiring missed the ONNX Runtime path actually produced by asset provisioning
- installer-managed model provisioning now uses `bge-small-en-v1.5` for fallback, not `all-minilm-l6-v2`
- first-time BGE/CoreML startup can exceed the old readiness window; the installer now removes stale sockets and waits longer for the daemon socket

## Verification
- `bash -n scripts/auto-install.sh`
- `bash scripts/auto-install.sh --dry-run --yes`
- `bash scripts/auto-install.sh --yes`
- `npm pack --dry-run`
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/unit/sidecar.test.js .ts-build/test/unit/plugin-runtime.test.js .ts-build/test/integration/sidecar-lifecycle.test.js`
- `pnpm check`
- `pnpm run plugin:check`
- `openclaw memory status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated installer (npx/bundled script) to provision daemon, ONNX runtime, model assets, plugin, and slot config; verifier via `openclaw memory status`.
  * Plugin now claims both memory and context-engine slots.

* **Documentation**
  * Install/uninstall/activation docs rewritten to center automated workflow and verification steps.
  * Security and troubleshooting guidance clarified.

* **Improvements**
  * macOS Homebrew fallback, asset provisioning, and installer repair flows improved.
  * Installer now checks for required CLI tools and cleans up installed assets on uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->