### PR TITLE
fix: validate CLI numeric options and require namespace for export

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -415,9 +415,18 @@ async function runSearch(
     return;
   }
 
+  let maxResults: number | undefined;
+  let explicitMinScore: number | undefined;
   try {
-    const maxResults = normalizeCliLimit(opts?.maxResults ?? opts?.limit, "--max-results");
-    const explicitMinScore = normalizeCliScore(opts?.minScore, "--min-score");
+    maxResults = normalizeCliLimit(opts?.maxResults ?? opts?.limit, "--max-results");
+    explicitMinScore = normalizeCliScore(opts?.minScore, "--min-score");
+  } catch (validationError) {
+    logger.error(formatError(validationError));
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
     const bridge = buildMemoryRuntimeBridge(runtime.getRpc, cfg);
     const { manager } = await bridge.getMemorySearchManager({
       agentId: opts?.agent,
@@ -508,8 +517,16 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
 }
 
 async function runJournal(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
+  let limit: number | undefined;
   try {
-    const limit = normalizeCliLimit(opts?.limit, "--limit");
+    limit = normalizeCliLimit(opts?.limit, "--limit");
+  } catch (validationError) {
+    logger.error(formatError(validationError));
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
     const rpc = await runtime.getRpc();
     const result = await rpc.call<JournalResult>("list_lifecycle_journal", {
       sessionId: opts?.sessionId?.trim() || undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -416,12 +416,12 @@ async function runSearch(
   }
 
   try {
+    const maxResults = normalizeCliLimit(opts?.maxResults ?? opts?.limit, "--max-results");
+    const explicitMinScore = normalizeCliScore(opts?.minScore, "--min-score");
     const bridge = buildMemoryRuntimeBridge(runtime.getRpc, cfg);
     const { manager } = await bridge.getMemorySearchManager({
       agentId: opts?.agent,
     });
-    const maxResults = normalizeLimit(opts?.maxResults ?? opts?.limit);
-    const explicitMinScore = normalizeNumber(opts?.minScore);
     const minScore = explicitMinScore ?? resolveDefaultSearchMinScore(manager.status(), cfg);
     const results = (await manager.search(
       {
@@ -486,10 +486,17 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 }
 
 async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
+  const namespace = resolveCliNamespace(opts);
+  if (!namespace) {
+    logger.error("LibraVDB export requires a namespace. Provide --user-id or --session-key.");
+    process.exitCode = 1;
+    return;
+  }
+
   try {
     const rpc = await runtime.getRpc();
     const result = await rpc.call<ExportResult>("export_memory", {
-      namespace: resolveCliNamespace(opts),
+      namespace,
     });
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);
@@ -502,10 +509,11 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
 
 async function runJournal(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
   try {
+    const limit = normalizeCliLimit(opts?.limit, "--limit");
     const rpc = await runtime.getRpc();
     const result = await rpc.call<JournalResult>("list_lifecycle_journal", {
       sessionId: opts?.sessionId?.trim() || undefined,
-      limit: normalizeLimit(opts?.limit),
+      limit,
     });
     for (const record of result.results ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);
@@ -554,17 +562,30 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-function normalizeLimit(limit: string | number | undefined): number | undefined {
-  if (typeof limit === "number" && Number.isFinite(limit) && limit > 0) {
-    return Math.floor(limit);
+function normalizeCliLimit(limit: string | number | undefined, optionName: string): number | undefined {
+  if (limit === undefined) return undefined;
+  const parsed = parseStrictNumber(limit);
+  if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
   }
-  if (typeof limit === "string") {
-    const parsed = Number.parseInt(limit, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
+  throw new Error(`Invalid value for ${optionName}: must be a positive integer`);
+}
+
+function normalizeCliScore(value: string | number | undefined, optionName: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = parseStrictNumber(value);
+  if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+    return parsed;
   }
-  return undefined;
+  throw new Error(`Invalid value for ${optionName}: must be a number between 0 and 1`);
+}
+
+function parseStrictNumber(value: string | number): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? NaN : Number(trimmed);
 }
 
 function normalizeNumber(value: string | number | undefined): number | undefined {

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -42,6 +42,7 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
 
   interface PluginsSlots {
     memory?: string;
+    contextEngine?: string;
   }
 
   interface PluginsConfig {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -166,7 +166,7 @@ function formatError(error: unknown): string {
 export function enrichStartupError(error: unknown, healthMessage?: string): Error {
   const rawMessage = error instanceof Error ? error.message : String(error);
   const message = rawMessage.trim() || "LibraVDB daemon startup failed";
-  if (message.includes("install and start libravdbd separately") || message.includes("package does not provision the daemon binary")) {
+  if (message.includes("package does not provision the daemon binary")) {
     return error instanceof Error ? error : new Error(message);
   }
   const shouldHint = /health check|daemon unavailable|connection refused|ECONNREFUSED|ENOENT|fallback mode|ONNX Runtime|embedder/i.test(


### PR DESCRIPTION
## Summary
- **Fix CLI numeric option validation**: `memory search` previously used `parseFloat`/`parseInt` which fell back silently to defaults on invalid input. Now `--min-score` and `--limit`/`--max-results` strictly parse to numbers and throw clear errors if out of bounds (e.g. `< 0` or `> 1`) or malformed.
- **Require namespace for export**: `memory export` with no namespace previously exited 0 with empty output, masking missing data. It now errors out, prompting the user to provide `--user-id` or `--session-key`.
- Closes #79 and #80.
- Applies CodeRabbit feedback: moved CLI option validation before RPC setup to fail fast without network overhead, and added missing `contextEngine` property to SDK type stubs.

## Verification
- `PATH=/tmp/corepack-shims:$PATH pnpm run check`
- `corepack npm run test:integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI numeric arguments now strictly validate and produce explicit errors for invalid values.
  * Export command validates required credentials up front to fail early.
  * Startup error messaging refined to reduce incorrect special-case hints.

* **New Features**
  * Plugin SDK adds optional context engine configuration in plugin slot settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->