### PR TITLE
fix: preserve runtime on plugin disable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ import type { PluginConfig } from "./types.js";
 export const MEMORY_ID = "libravdb-memory";
 
 const LIGHTWEIGHT_MODES = new Set(["cli-metadata", "setup-only"]);
+type RuntimeLifecycleCleanupReason = "disable" | "reset" | "delete" | "restart";
+
+export function shouldShutdownRuntimeForLifecycleReason(reason: RuntimeLifecycleCleanupReason): boolean {
+  return reason !== "disable";
+}
 
 export function register(api: OpenClawPluginApi) {
   const registrationMode = api.registrationMode;
@@ -142,12 +147,14 @@ export function register(api: OpenClawPluginApi) {
 
   api.registerRuntimeLifecycle?.({
     id: "libravdb-shutdown",
-    description: "Shut down the vector service runtime on plugin disable",
+    description: "Shut down the vector service runtime for destructive lifecycle cleanup",
     async cleanup(ctx) {
-      if (ctx.reason === "disable") {
-        logger.info?.("LibraVDB disable — shutting down runtime");
+      if (shouldShutdownRuntimeForLifecycleReason(ctx.reason)) {
+        logger.info?.(`LibraVDB ${ctx.reason} — shutting down runtime`);
         await runtime.shutdown();
+        return;
       }
+      logger.info?.("LibraVDB disable — preserving runtime until gateway_stop");
     },
   });
 

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 // Import the real register function from src/index.ts so tests actually
 // exercise the production code path.
-import { register, MEMORY_ID } from "../../src/index.js";
+import { register, MEMORY_ID, shouldShutdownRuntimeForLifecycleReason } from "../../src/index.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
 /** Builds a fake OpenClawPluginApi for register(). */
@@ -101,4 +101,11 @@ test("combined — cli-metadata with conflicting slot: mode gate blocks before s
     threw = true;
   }
   assert.ok(!threw, "no error in cli-metadata even with conflicting slot — mode guard exits first");
+});
+
+test("runtime lifecycle disable cleanup preserves active runtime", () => {
+  assert.equal(shouldShutdownRuntimeForLifecycleReason("disable"), false);
+  assert.equal(shouldShutdownRuntimeForLifecycleReason("reset"), true);
+  assert.equal(shouldShutdownRuntimeForLifecycleReason("delete"), true);
+  assert.equal(shouldShutdownRuntimeForLifecycleReason("restart"), true);
 });


### PR DESCRIPTION
## Summary
- Avoid shutting down the LibraVDB runtime when OpenClaw runs plugin disable lifecycle cleanup during an active turn
- Keep runtime shutdown for destructive lifecycle cleanup while preserving the existing gateway_stop shutdown path
- Add unit coverage for lifecycle reason handling

## Testing
- pnpm run check
- pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js
- pnpm run plugin:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced runtime lifecycle management to properly handle shutdown for reset, delete, and restart operations, while preserving runtime during disable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->