### PR TITLE
fix: require namespace for memory export

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -486,10 +486,17 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 }
 
 async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
+  const namespace = resolveCliNamespace(opts);
+  if (!namespace) {
+    logger.error("LibraVDB export requires a namespace. Please provide --user-id <userId> or --session-key <sessionKey>.");
+    process.exitCode = 1;
+    return;
+  }
+
   try {
     const rpc = await runtime.getRpc();
     const result = await rpc.call<ExportResult>("export_memory", {
-      namespace: resolveCliNamespace(opts),
+      namespace,
     });
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);


### PR DESCRIPTION
## Summary

- Fixes #80.
- `memory export` with no arguments previously executed successfully but returned an empty dataset, misleading users.
- `resolveCliNamespace` explicitly returns `undefined` when no options are provided.
- Added validation in `runExport` to explicitly reject unrestricted exports and prompt the user to supply either `--user-id` or `--session-key`.

## Verification

- `pnpm run check` passes.
- `pnpm run test:integration` passes.
- Tested locally: `openclaw --profile Libra memory export` now fails with code 1 and prints the correct requirement log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory export validation to require a namespace parameter, preventing incomplete exports and providing clearer error messaging when a namespace is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->