### PR TITLE
fix: limit after-turn replay to post-prompt messages

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -158,6 +158,29 @@ function approximateMessagesTokens(messages: OpenClawCompatibleMessage[]): numbe
   return messages.reduce((sum, message) => sum + approximateMessageTokens(message), 0);
 }
 
+function selectAfterTurnMessages<T>(
+  messages: T[],
+  prePromptMessageCount: number | undefined,
+  logger?: LoggerLike,
+): T[] {
+  if (
+    typeof prePromptMessageCount !== "number" ||
+    !Number.isFinite(prePromptMessageCount) ||
+    prePromptMessageCount <= 0
+  ) {
+    return messages;
+  }
+  const start = Math.floor(prePromptMessageCount);
+  if (start >= messages.length) {
+    logger?.warn?.(
+      `LibraVDB afterTurn prePromptMessageCount produced zero forwarded messages ` +
+      `prePromptMessageCount=${prePromptMessageCount} start=${start} totalMessages=${messages.length}`,
+    );
+    return [];
+  }
+  return messages.slice(start);
+}
+
 function normalizeCurrentTokenCount(currentTokenCount: number | undefined): number | undefined {
   if (
     typeof currentTokenCount !== "number" ||
@@ -969,11 +992,14 @@ export function buildContextEngineFactory(
         userIdOverride: args.userId,
         sessionKey: args.sessionKey,
       });
-      const messages = normalizeKernelMessages(args.messages);
+      const afterTurnMessages = selectAfterTurnMessages(args.messages, args.prePromptMessageCount, logger);
+      const messages = normalizeKernelMessages(afterTurnMessages);
       const msgCount = messages.length;
       logger.info?.(
         `LibraVDB afterTurn sessionId=${args.sessionId} userId=${userId} ` +
-        `messageCount=${msgCount} heartbeat=${args.isHeartbeat ?? false}`,
+        `messageCount=${msgCount} totalMessages=${args.messages.length} ` +
+        `prePromptMessageCount=${args.prePromptMessageCount ?? "unknown"} ` +
+        `heartbeat=${args.isHeartbeat ?? false}`,
       );
       try {
         const kernel = await getKernelOrNull("afterTurn");

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -435,7 +435,7 @@ test("compact omits invalid currentTokenCount values from the wire request", asy
   assert.equal("currentTokenCount" in params, false);
 });
 
-test("afterTurn forwards only daemon-relevant fields, strips prePromptMessageCount", async () => {
+test("afterTurn forwards only post-prompt messages and strips prePromptMessageCount", async () => {
   const rpc = new StaticContractRpc();
   const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
 
@@ -458,7 +458,34 @@ test("afterTurn forwards only daemon-relevant fields, strips prePromptMessageCou
   assert.ok(params, "Expected after_turn_kernel to be called");
   assert.equal(params.sessionId, "test-session");
   assert.equal(params.userId, "test-user");
-  assert.equal("prePromptMessageCount" in params, false, "prePromptMessageCount must not leak to daemon — daemon defaults to 0 and uses content-hash dedup");
+  assert.equal("prePromptMessageCount" in params, false, "prePromptMessageCount must not leak to daemon");
+  assert.equal(params.isHeartbeat, false);
+  assert.deepEqual(params.messages, [mockMessages[1]]);
+});
+
+test("afterTurn forwards all messages when prePromptMessageCount is absent", async () => {
+  const rpc = new StaticContractRpc();
+  const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
+
+  const context = buildContextEngineFactory(async () => rpc as never, cfg);
+
+  const mockMessages = [
+    { role: "user", content: "m1" },
+    { role: "assistant", content: "m2" },
+  ];
+
+  await context.afterTurn({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: mockMessages,
+    isHeartbeat: false,
+  });
+
+  const params = rpc.getLastCall("after_turn_kernel");
+  assert.ok(params, "Expected after_turn_kernel to be called");
+  assert.equal(params.sessionId, "test-session");
+  assert.equal(params.userId, "test-user");
+  assert.equal("prePromptMessageCount" in params, false, "prePromptMessageCount must not leak to daemon");
   assert.equal(params.isHeartbeat, false);
   assert.deepEqual(params.messages, mockMessages);
 });


### PR DESCRIPTION
## Summary

Refs #86.

Large existing sessions can make the context-engine `afterTurn` path send the entire transcript back to LibraVDB after every turn. On a smoke test this produced `afterTurn messageCount=1874`, timed out at 30s, and left the daemon continuing expensive compaction work in the background.

This PR changes `afterTurn` to use the host-provided `prePromptMessageCount` as a replay boundary:

- when `prePromptMessageCount` is present, only post-prompt messages are forwarded to `after_turn_kernel`
- when it is absent or invalid, behavior stays unchanged
- logging now reports forwarded `messageCount`, original `totalMessages`, and `prePromptMessageCount`
- regression coverage verifies the boundary is applied and the host-only field is not sent to the daemon

This keeps large historical sessions from being reprocessed after every turn while preserving compatibility for hosts that do not provide `prePromptMessageCount`.

## Verification

- `pnpm run check`
- `pnpm run test:integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message filtering in the afterTurn flow to correctly skip pre-prompt messages when applicable.
  * Enhanced logging to provide better visibility into message processing details during daemon interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->