### PR TITLE
fix: expand deep status probe to cover user and global collections

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,11 +313,13 @@ async function runDeepStatusProbe(
   rpc: { call<T>(method: string, params: unknown): Promise<T> },
   cfg: PluginConfig,
 ): Promise<DeepStatusResult> {
-  // Resolve user namespace the same way the runtime does, so we probe
-  // the same collections that searchResolvedCollections would query.
+  // Resolve userId without triggering auto-derive file writes.
+  // status --deep should be read-only; if no userId is configured and no
+  // identity file exists, fall back to "default" rather than creating one.
   const { userId } = resolveIdentity({
     configUserId: cfg.userId,
     identityPath: cfg.identityPath,
+    noAutoPersist: true,
   });
   const durableCollections = [`user:${userId}`, "global"] as const;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { stdin, stdout } from "node:process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { MEMORY_CLI_DESCRIPTOR, isMemorySlotSelected } from "./cli-descriptors.js";
 import { resolveDurableNamespace } from "./memory-scopes.js";
+import { resolveIdentity } from "./identity.js";
 import { promoteDreamDiaryFile } from "./dream-promotion.js";
 import { buildMemoryRuntimeBridge } from "./memory-runtime.js";
 import type { PluginRuntime } from "./plugin-runtime.js";
@@ -251,7 +252,7 @@ async function runStatus(
   try {
     const rpc = await runtime.getRpc();
     const status = await rpc.call<StatusResult>("status", {});
-    const deep = opts.deep ? await runDeepStatusProbe(rpc) : undefined;
+    const deep = opts.deep ? await runDeepStatusProbe(rpc, cfg) : undefined;
     if (opts.json) {
       console.log(JSON.stringify({ status, ...(deep ? { deep } : {}) }, null, 2));
       if (deep && !deep.ok) {
@@ -306,11 +307,24 @@ async function runStatus(
   }
 }
 
-const DEEP_STATUS_COLLECTIONS = ["authored:hard", "authored:soft", "authored:variant"] as const;
+const AUTHORED_STATUS_COLLECTIONS = ["authored:hard", "authored:soft", "authored:variant"] as const;
 
-async function runDeepStatusProbe(rpc: { call<T>(method: string, params: unknown): Promise<T> }): Promise<DeepStatusResult> {
+async function runDeepStatusProbe(
+  rpc: { call<T>(method: string, params: unknown): Promise<T> },
+  cfg: PluginConfig,
+): Promise<DeepStatusResult> {
+  // Resolve user namespace the same way the runtime does, so we probe
+  // the same collections that searchResolvedCollections would query.
+  const { userId } = resolveIdentity({
+    configUserId: cfg.userId,
+    identityPath: cfg.identityPath,
+  });
+  const durableCollections = [`user:${userId}`, "global"] as const;
+
+  const allCollections = [...AUTHORED_STATUS_COLLECTIONS, ...durableCollections] as const;
+
   const probes: DeepStatusProbe[] = [];
-  for (const collection of DEEP_STATUS_COLLECTIONS) {
+  for (const collection of allCollections) {
     try {
       const result = await rpc.call<{ results?: unknown[] }>("search_text", {
         collection,

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -105,6 +105,9 @@ export function resolveIdentity(params: {
   identityPath?: string;
   sessionKey?: string;
   logger?: LoggerLike;
+  /** When true, skip writing the auto-derived identity file. Useful for
+   *  read-only commands (e.g. status --deep) that should not mutate disk. */
+  noAutoPersist?: boolean;
 }): ResolvedIdentity {
   // 1. Plugin config override (highest priority)
   const configUserId = params.configUserId?.trim();
@@ -148,6 +151,9 @@ export function resolveIdentity(params: {
   }
 
   const autoId = deriveAutoId(parts);
+  if (params.noAutoPersist) {
+    return { userId: autoId, source: "auto" };
+  }
   try {
     writeIdentityFile(filePath, autoId, parts);
     params.logger?.info?.(

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -416,7 +416,7 @@ test("status --deep probes authored collection search health", async () => {
         shutdownCalls += 1;
       },
     },
-    {},
+    { userId: "default" },
   );
 
   assert.ok(registered);
@@ -447,7 +447,7 @@ test("status --deep probes authored collection search health", async () => {
   assert.equal(payload.deep.ok, false);
   assert.deepEqual(
     rpcCalls.filter((call) => call.method === "search_text").map((call) => call.params.collection),
-    ["authored:hard", "authored:soft", "authored:variant"],
+    ["authored:hard", "authored:soft", "authored:variant", "user:default", "global"],
   );
   assert.match(payload.deep.probes[1]?.error ?? "", /dimension 384/);
   assert.equal(observedExitCode, 1);
@@ -473,7 +473,13 @@ test("status --deep includes authored probe rows in table output", async () => {
               return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
             }
             if (method === "search_text") {
-              return { results: params.collection === "authored:variant" ? [{ id: "v1" }] : [] };
+              if (params.collection === "authored:variant") {
+                return { results: [{ id: "v1" }] };
+              }
+              if (params.collection === "global") {
+                return { results: [{ id: "g1" }] };
+              }
+              return { results: [] };
             }
             throw new Error(`unexpected rpc method: ${method}`);
           },
@@ -484,7 +490,7 @@ test("status --deep includes authored probe rows in table output", async () => {
       onShutdown: async () => {},
       async shutdown() {},
     },
-    {},
+    { userId: "default" },
   );
 
   assert.ok(registered);
@@ -515,6 +521,8 @@ test("status --deep includes authored probe rows in table output", async () => {
   assert.equal(tables[0]?.["Probe authored:hard"], "ok (0 hits)");
   assert.equal(tables[0]?.["Probe authored:soft"], "ok (0 hits)");
   assert.equal(tables[0]?.["Probe authored:variant"], "ok (1 hits)");
+  assert.equal(tables[0]?.["Probe user:default"], "ok (0 hits)");
+  assert.equal(tables[0]?.["Probe global"], "ok (1 hits)");
 });
 
 test("non-full CLI registration exposes command structure without action handlers", () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildContextEngineFactory } from "../../src/context-engine.js";
+import fs from "node:fs";
 import { resolveIdentity } from "../../src/identity.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
@@ -742,4 +743,19 @@ test("resolveIdentity returns 'default' when no inputs are provided", () => {
   // When userInfo() works: auto-derived. An identity file or "default" may also apply.
   assert.ok(["auto", "default", "file"].includes(result.source));
   assert.ok(result.userId.length > 0);
+});
+
+test("resolveIdentity with noAutoPersist skips writing identity file", () => {
+  const tmpDir = `/tmp/libravdb-test-identity-${process.pid}`;
+  const identityPath = `${tmpDir}/libravdb-identity.json`;
+  try {
+    const result = resolveIdentity({ identityPath, noAutoPersist: true });
+    // Should still derive a userId
+    assert.ok(result.userId.length > 0);
+    assert.equal(result.source, "auto");
+    // But must not have written the file
+    assert.equal(fs.existsSync(identityPath), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

`memory status --deep` only probed authored collections (`authored:hard`, `authored:soft`, `authored:variant`). Corruption or dimension mismatch in `user:<userId>` or `global` collections was invisible to the deep probe, producing false `ok` status.

This directly relates to issue #84 where `status --deep` reported `ok` despite an index rebuild failure — the failure was in a collection the probe never checked.

**Changes:**
- Rename `DEEP_STATUS_COLLECTIONS` to `AUTHORED_STATUS_COLLECTIONS` for clarity.
- Resolve the userId via `resolveIdentity` (same path the runtime uses during search) and add `user:<userId>` and `global` to the probe set.
- `runDeepStatusProbe` now accepts `cfg: PluginConfig` as a second argument to resolve identity.
- Updated CLI tests to assert the new `user:default` and `global` probe rows.

## Verification

```
pnpm run check             # 100 unit tests pass
npm run test:integration   # 32 integration tests pass
```

Related: #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `memory status --deep` command to include user-specific and global collection probes for more comprehensive status reporting.
  * Added read-only identity resolution mode to support scenarios where persistent identity storage is not desired.

* **Tests**
  * Updated unit tests to validate new status probe coverage and read-only identity resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->