### PR TITLE
fix: reset sidecar retry counter on successful reconnect

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -245,6 +245,7 @@ class SidecarSupervisor implements SidecarHandle {
   async start(): Promise<SidecarSocket> {
     const endpoint = await this.runtime.resolveEndpoint(this.cfg);
     const socket = await this.connectEndpointWithRetry(endpoint);
+    this.retries = 0;
     this.reconnectScheduled = false;
     if (this.socket instanceof SupervisorSocket) {
       this.socket.bind(socket);


### PR DESCRIPTION
## Summary

The `SidecarSupervisor` retry counter is never reset after a successful reconnect. The counter accumulates over the entire gateway lifetime, so the plugin permanently enters degraded mode after `maxRetries` (default 3) **cumulative** daemon crashes — not 3 consecutive failures.

- **Bug:** `this.retries` starts at 0, is incremented in `handleExit()`, and is never reset. After 3+ daemon crashes over the lifetime of the gateway process, the plugin gives up permanently.
- **Fix:** Add `this.retries = 0` in `start()` after a successful connection, so the retry budget resets per-incident rather than being lifetime-cumulative.

Closes #95

## Verification

Before: kill and restart the daemon 4 times over a gateway lifetime → permanent degraded mode after the 3rd crash, even though each crash was followed by a successful reconnect.

After: the retry counter resets to 0 on each successful reconnect, so the plugin tolerates up to 3 consecutive failures per incident.

> **Daemon source note:** This is a plugin-only fix, but we continue to note that issues like #76 (rebuild_index version conflicts) and #94 (gRPC HMAC key/message swap) require access to the daemon source code for a complete resolution. We are unable to submit fixes for daemon-side bugs without it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of internal service recovery handling by ensuring the retry counter resets properly during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

– Vale