### PR TITLE
fix: stop overwriting dream promotion source line with array index

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -204,10 +204,9 @@ export function createDreamPromotionHandle(
       sourceMtimeMs: stat.mtimeMs,
       ingestVersion: DREAM_PROMOTION_VERSION,
       hashBackend: getHashBackendName(),
-      entries: candidates.map((candidate, index) => ({
+      entries: candidates.map((candidate) => ({
         ...candidate,
         sourceLine: candidate.line,
-        line: index + 1,
       })),
     };
     await rpc.call<DreamPromotionResult>("promote_dream_entries", params);
@@ -308,10 +307,9 @@ export async function promoteDreamDiaryFile(
     sourceMtimeMs: sourceMtimeMs ?? 0,
     ingestVersion: DREAM_PROMOTION_VERSION,
     hashBackend: getHashBackendName(),
-    entries: candidates.map((candidate, index) => ({
+    entries: candidates.map((candidate) => ({
       ...candidate,
       sourceLine: candidate.line,
-      line: index + 1,
     })),
   });
 }

--- a/test/integration/dream-promotion.test.ts
+++ b/test/integration/dream-promotion.test.ts
@@ -89,14 +89,25 @@ test("dream promotion handle reads diary bullets and forwards them to the sideca
     userId: string;
     sourceDoc: string;
     sourceKind: string;
-    entries: Array<{ text: string; score: number; recallCount: number; uniqueQueries: number }>;
+    entries: Array<{
+      text: string;
+      score: number;
+      recallCount: number;
+      uniqueQueries: number;
+      line: number;
+      sourceLine: number;
+    }>;
   };
   assert.equal(params.userId, "u1");
   assert.equal(params.sourceDoc, diaryPath);
   assert.equal(params.sourceKind, "dream");
   assert.equal(params.entries.length, 2);
   assert.equal(params.entries[0]?.text, "Preserve the recent tail buffer");
+  assert.equal(params.entries[0]?.line, 4);
+  assert.equal(params.entries[0]?.sourceLine, 4);
   assert.equal(params.entries[1]?.score, 0.2);
+  assert.equal(params.entries[1]?.line, 5);
+  assert.equal(params.entries[1]?.sourceLine, 5);
 
   await fsp.writeFile(
     diaryPath,


### PR DESCRIPTION
## Summary

Both `scanDiary()` and `promoteDreamDiaryFile()` in `src/dream-promotion.ts` overwrite the parsed diary source line with the candidate array index:

```ts
entries: candidates.map((candidate, index) => ({
  ...candidate,
  sourceLine: candidate.line,  // real diary line
  line: index + 1,             // overwrites it with array position
})),
```

`parseDreamPromotionCandidates()` already sets `candidate.line` to the 1-indexed source line in the diary file. After the spread, `line: index + 1` replaces that real line with `1`, `2`, `3`, etc.

That makes daemon-side logging, errors, or deduplication point at the candidate position rather than the actual source line.

**Fix:** remove `line: index + 1` from both paths. The parsed source line is preserved through the spread, and `sourceLine` remains an explicit copy of the same real diary line.

Closes #96.

## Verification

- Added integration coverage asserting promoted entries preserve both `line` and `sourceLine` as real diary file line numbers.
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/dream-promotion.test.js`
- `rm -rf .ts-build && pnpm run check` → 106 tests pass.

Before: candidates from diary lines 42, 87, 103 would be sent as `line: 1, 2, 3`.

After: the same candidates are sent as `line: 42, 87, 103`.

– Vale
