### PR TITLE
fix: recognize Obsidian CRLF frontmatter and heading tags

### DIFF
--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -600,12 +600,12 @@ function looksLikeObsidianNote(filePath: string, text: string): boolean {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatterEnd = findFrontmatterEnd(text, frontmatterStart);
-  if (frontmatterEnd < 0) {
+  const parsed = findFrontmatterEnd(text, frontmatterStart);
+  if (!parsed) {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatter = text.slice(frontmatterStart, frontmatterEnd);
+  const frontmatter = text.slice(frontmatterStart, parsed.position);
   const lines = frontmatter.split(/\r?\n/);
   for (const line of lines) {
     const trimmed = line.trimStart();
@@ -619,7 +619,7 @@ function looksLikeObsidianNote(filePath: string, text: string): boolean {
     }
   }
 
-  return hasInlineObsidianTag(text.slice(frontmatterEnd + 4));
+  return hasInlineObsidianTag(text.slice(parsed.bodyOffset));
 }
 
 function parseFrontmatterStart(text: string): number | null {
@@ -632,20 +632,20 @@ function parseFrontmatterStart(text: string): number | null {
   return null;
 }
 
-function findFrontmatterEnd(text: string, offset: number): number {
+function findFrontmatterEnd(text: string, offset: number): { position: number; bodyOffset: number } | null {
   for (let i = offset; i < text.length - 3; i++) {
     if (text.charCodeAt(i) !== 45 || text.charCodeAt(i + 1) !== 45 || text.charCodeAt(i + 2) !== 45) {
       continue;
     }
     const next = text.charCodeAt(i + 3);
     if (next === 10) {
-      return i;
+      return { position: i, bodyOffset: i + 4 };
     }
     if (next === 13 && text.charCodeAt(i + 4) === 10) {
-      return i;
+      return { position: i, bodyOffset: i + 5 };
     }
   }
-  return -1;
+  return null;
 }
 
 function hasInlineObsidianTag(text: string): boolean {

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -606,7 +606,7 @@ function looksLikeObsidianNote(filePath: string, text: string): boolean {
   }
 
   const frontmatter = text.slice(frontmatterStart, frontmatterEnd);
-  const lines = frontmatter.split("\n");
+  const lines = frontmatter.split(/\r?\n/);
   for (const line of lines) {
     const trimmed = line.trimStart();
     if (

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -595,16 +595,17 @@ function matchesGlob(value: string, pattern: string): boolean {
 }
 
 function looksLikeObsidianNote(filePath: string, text: string): boolean {
-  if (!text.startsWith("---\n")) {
+  const frontmatterStart = parseFrontmatterStart(text);
+  if (frontmatterStart == null) {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatterEnd = findFrontmatterEnd(text, 4);
+  const frontmatterEnd = findFrontmatterEnd(text, frontmatterStart);
   if (frontmatterEnd < 0) {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatter = text.slice(4, frontmatterEnd);
+  const frontmatter = text.slice(frontmatterStart, frontmatterEnd);
   const lines = frontmatter.split("\n");
   for (const line of lines) {
     const trimmed = line.trimStart();
@@ -619,6 +620,16 @@ function looksLikeObsidianNote(filePath: string, text: string): boolean {
   }
 
   return hasInlineObsidianTag(text.slice(frontmatterEnd + 4));
+}
+
+function parseFrontmatterStart(text: string): number | null {
+  if (text.startsWith("---\n")) {
+    return 4;
+  }
+  if (text.startsWith("---\r\n")) {
+    return 5;
+  }
+  return null;
 }
 
 function findFrontmatterEnd(text: string, offset: number): number {
@@ -649,10 +660,8 @@ function hasInlineObsidianTag(text: string): boolean {
     if (inFence) {
       continue;
     }
-    if (trimmed.startsWith("#")) {
-      continue;
-    }
-    if (/(^|[^A-Za-z0-9_])#([A-Za-z][A-Za-z0-9/_-]*)\b/.test(line)) {
+    const searchable = trimmed.replace(/^#{1,6}\s+/, "");
+    if (/(^|[^A-Za-z0-9_])#([A-Za-z][A-Za-z0-9/_-]*)\b/.test(searchable)) {
       return true;
     }
   }

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -301,6 +301,76 @@ test("obsidian markdown ingestion accepts inline tags like #project", async () =
   await handle.stop();
 });
 
+test("obsidian markdown ingestion accepts CRLF frontmatter tags", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-obsidian-crlf-"));
+  const filePath = path.join(tempRoot, "windows-note.md");
+  await fsp.writeFile(
+    filePath,
+    [
+      "---",
+      "tags: [openclaw]",
+      "---",
+      "",
+      "# Vault",
+      "This note uses CRLF frontmatter.",
+    ].join("\r\n"),
+  );
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: false,
+      markdownIngestionObsidianEnabled: true,
+      markdownIngestionObsidianRoots: [tempRoot],
+      markdownIngestionObsidianDebounceMs: 0,
+    },
+    async () => rpc,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 1);
+  assert.equal(rpc.documents.get(filePath)?.sourceMeta.sourceKind, "obsidian");
+
+  await handle.stop();
+});
+
+test("obsidian markdown ingestion accepts tags in headings", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-obsidian-heading-tag-"));
+  const filePath = path.join(tempRoot, "heading-tag.md");
+  await fsp.writeFile(
+    filePath,
+    [
+      "# Project #openclaw",
+      "This note only has an Obsidian tag in the heading.",
+    ].join("\n"),
+  );
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: false,
+      markdownIngestionObsidianEnabled: true,
+      markdownIngestionObsidianRoots: [tempRoot],
+      markdownIngestionObsidianDebounceMs: 0,
+    },
+    async () => rpc,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 1);
+  assert.equal(rpc.documents.get(filePath)?.sourceMeta.sourceKind, "obsidian");
+
+  await handle.stop();
+});
+
 test("markdown ingestion stop waits for an in-flight startup scan", async () => {
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-stop-"));
   const notePath = path.join(tempRoot, "slow.md");


### PR DESCRIPTION
## Summary

Obsidian note detection missed two valid tagged note shapes when `markdownIngestionObsidianInclude` was not set:

- YAML frontmatter using CRLF line endings (`---\r\n...`) was skipped because detection only checked `text.startsWith("---\n")`.
- Inline tags in Markdown headings were skipped because `hasInlineObsidianTag()` ignored every line beginning with `#` before scanning for tags.

This PR:

- accepts both LF and CRLF frontmatter openings,
- uses the parsed frontmatter content offset when scanning metadata,
- strips only the ATX heading marker before checking for inline tags, so `# Project #openclaw` is recognized while fenced-code tags are still ignored,
- adds integration coverage for both skipped cases.

Closes #100.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/markdown-ingest.test.js`
- `pnpm run check`

– Vale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Obsidian note detection to handle both Unix and CRLF line endings.
  * Enhanced tag recognition in frontmatter and inline markdown headings.
  * Added fallback logic for more robust tag detection when frontmatter parsing is unavailable.

* **Tests**
  * Added integration tests for CRLF line ending compatibility.
  * Added integration tests for inline tag detection in markdown headings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->