### PR TITLE
fix: preserve unix scheme for grpc targets

### DIFF
--- a/src/grpc-client.ts
+++ b/src/grpc-client.ts
@@ -16,6 +16,10 @@ export interface GrpcClientOptions {
   timeoutMs?: number;
 }
 
+export function resolveGrpcTarget(endpoint: string): string {
+  return endpoint.startsWith("tcp:") ? endpoint.substring(4) : endpoint;
+}
+
 export class GrpcKernelClient {
   private client: any;
   private readonly secret: string | undefined;
@@ -37,11 +41,7 @@ export class GrpcKernelClient {
     const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
     const kernelService = protoDescriptor.intelligence_kernel.v1.IntelligenceKernel;
 
-    const target = options.endpoint.startsWith("tcp:") 
-      ? options.endpoint.substring(4) 
-      : options.endpoint.startsWith("unix:")
-        ? options.endpoint.substring(5)
-        : options.endpoint;
+    const target = resolveGrpcTarget(options.endpoint);
 
     this.client = new kernelService(target, grpc.credentials.createInsecure());
   }

--- a/test/unit/grpc-client.test.ts
+++ b/test/unit/grpc-client.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveGrpcTarget } from "../../src/grpc-client.js";
+
+test("resolveGrpcTarget strips tcp prefix for grpc-js host targets", () => {
+  assert.equal(resolveGrpcTarget("tcp:127.0.0.1:37421"), "127.0.0.1:37421");
+});
+
+test("resolveGrpcTarget preserves unix scheme for grpc-js UDS resolver", () => {
+  assert.equal(
+    resolveGrpcTarget("unix:/home/user/.clawdb/run/libravdb.sock"),
+    "unix:/home/user/.clawdb/run/libravdb.sock",
+  );
+});
+
+test("resolveGrpcTarget leaves ordinary grpc targets unchanged", () => {
+  assert.equal(resolveGrpcTarget("localhost:37421"), "localhost:37421");
+});


### PR DESCRIPTION
## Summary

`GrpcKernelClient` stripped both `tcp:` and `unix:` endpoint prefixes before constructing the generated grpc-js client.

Stripping `tcp:` is correct because grpc-js expects host targets like `127.0.0.1:37421`.

Stripping `unix:` is wrong. `@grpc/grpc-js` has a `unix` resolver and expects Unix-domain socket targets to keep the scheme, e.g.:

```txt
unix:/home/user/.clawdb/run/libravdb.sock
```

The previous normalization converted that to a bare path:

```txt
/home/user/.clawdb/run/libravdb.sock
```

At that point grpc-js cannot route through the UDS resolver.

This PR adds `resolveGrpcTarget()` and changes normalization to:

- strip only `tcp:` endpoints,
- preserve `unix:` endpoints,
- leave ordinary grpc targets unchanged.

Closes #102.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/grpc-client.test.js`
- `pnpm run check`

– Vale
