### PR TITLE
fix: account for system prompt additions in assemble budget clamp

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -330,7 +330,10 @@ function trimMessagesToBudget(
   }
 
   const last = messages[messages.length - 1]!;
-  const contentBudget = Math.max(1, tokenBudget - 8);
+  const contentBudget = tokenBudget - 8;
+  if (contentBudget <= 0) {
+    return [];
+  }
   const truncated = truncateContentToTokenBudget(last.content, contentBudget);
   if (!truncated) {
     return [];
@@ -371,7 +374,7 @@ function enforceTokenBudgetInvariant(
     };
   }
 
-  const messageBudget = Math.max(1, effectiveBudget - systemPromptTokens);
+  const messageBudget = Math.max(0, effectiveBudget - systemPromptTokens);
   const trimmedMessages = trimMessagesToBudget(result.messages, messageBudget);
   const trimmedEstimate = approximateMessagesTokens(trimmedMessages);
   return {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -297,6 +297,14 @@ function truncateContentToTokenBudget(content: unknown, tokenBudget: number): st
   return normalized.slice(normalized.length - maxChars);
 }
 
+function truncateSystemPromptAdditionToTokenBudget(value: string, tokenBudget: number): string {
+  if (tokenBudget <= 0) return "";
+  const maxChars = Math.max(1, tokenBudget * APPROX_CHARS_PER_TOKEN);
+  if (value.length <= maxChars) return value;
+  // System additions are head-structured: preserve XML/preamble/instructions.
+  return value.slice(0, maxChars);
+}
+
 function trimMessagesToBudget(
   messages: OpenClawCompatibleMessage[],
   tokenBudget: number,
@@ -350,7 +358,7 @@ function enforceTokenBudgetInvariant(
   }
 
   if (systemPromptTokens >= effectiveBudget) {
-    const trimmedSystemPromptAddition = truncateContentToTokenBudget(
+    const trimmedSystemPromptAddition = truncateSystemPromptAdditionToTokenBudget(
       result.systemPromptAddition,
       effectiveBudget,
     );

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -341,18 +341,35 @@ function enforceTokenBudgetInvariant(
   const hardBudget = Math.max(1, Math.floor(tokenBudget));
   const effectiveBudget = resolveEffectiveAssembleBudget(hardBudget);
   const estimated = typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0;
+  const systemPromptTokens = approximateTokenCount(result.systemPromptAddition);
   const approxFromMessages = approximateMessagesTokens(result.messages);
+  const approxTotal = systemPromptTokens + approxFromMessages;
 
-  if (estimated <= effectiveBudget && approxFromMessages <= effectiveBudget) {
+  if (estimated <= effectiveBudget && approxTotal <= effectiveBudget) {
     return result;
   }
 
-  const trimmedMessages = trimMessagesToBudget(result.messages, effectiveBudget);
+  if (systemPromptTokens >= effectiveBudget) {
+    const trimmedSystemPromptAddition = truncateContentToTokenBudget(
+      result.systemPromptAddition,
+      effectiveBudget,
+    );
+    const trimmedSystemPromptTokens = approximateTokenCount(trimmedSystemPromptAddition);
+    return {
+      ...result,
+      systemPromptAddition: trimmedSystemPromptAddition,
+      messages: [],
+      estimatedTokens: Math.min(effectiveBudget, trimmedSystemPromptTokens),
+    };
+  }
+
+  const messageBudget = Math.max(1, effectiveBudget - systemPromptTokens);
+  const trimmedMessages = trimMessagesToBudget(result.messages, messageBudget);
   const trimmedEstimate = approximateMessagesTokens(trimmedMessages);
   return {
     ...result,
     messages: trimmedMessages,
-    estimatedTokens: Math.min(effectiveBudget, trimmedEstimate),
+    estimatedTokens: Math.min(effectiveBudget, systemPromptTokens + trimmedEstimate),
   };
 }
 

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -475,6 +475,34 @@ test("context engine assemble trims messages against remaining budget after syst
   assert.ok(assembled.estimatedTokens <= 44);
 });
 
+test("context engine assemble drops messages when system prompt leaves no wrapper budget", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [
+      { role: "assistant", content: "y".repeat(200) },
+    ],
+    estimatedTokens: 0,
+    systemPromptAddition: "x".repeat(172),
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn() {},
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "assemble with nearly full system addition")],
+    prompt: "assemble with nearly full system addition",
+    tokenBudget: 300,
+  });
+
+  assert.equal(assembled.systemPromptAddition, "x".repeat(172));
+  assert.equal(assembled.messages.length, 0);
+  assert.ok(assembled.estimatedTokens <= 44);
+});
+
 test("context engine exact recall skips additions that would exceed the token budget", async () => {
   const rpc = new FakeRpc();
   const marker = "BUDGET_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -418,6 +418,34 @@ test("context engine exact recall checks existing facts per block", async () => 
   assert.ok(assembled.systemPromptAddition.includes(`${secondMarker} means Jay prefers the second path.`));
 });
 
+test("context engine assemble clamps system prompt additions within token budget", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [
+      { role: "assistant", content: "this message should be dropped because the system addition consumes the budget" },
+    ],
+    estimatedTokens: 0,
+    systemPromptAddition: "x".repeat(2000),
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn() {},
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "assemble with large system addition")],
+    prompt: "assemble with large system addition",
+    tokenBudget: 300,
+  });
+
+  assert.equal(assembled.messages.length, 0);
+  assert.ok(assembled.systemPromptAddition.length < 2000);
+  assert.ok(assembled.estimatedTokens <= 44);
+});
+
 test("context engine exact recall skips additions that would exceed the token budget", async () => {
   const rpc = new FakeRpc();
   const marker = "BUDGET_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -446,6 +446,35 @@ test("context engine assemble clamps system prompt additions within token budget
   assert.ok(assembled.estimatedTokens <= 44);
 });
 
+test("context engine assemble trims messages against remaining budget after system prompt additions", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [
+      { role: "assistant", content: "y".repeat(200) },
+    ],
+    estimatedTokens: 0,
+    systemPromptAddition: "x".repeat(100),
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn() {},
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "assemble with fitting system addition and oversized messages")],
+    prompt: "assemble with fitting system addition and oversized messages",
+    tokenBudget: 300,
+  });
+
+  assert.equal(assembled.systemPromptAddition, "x".repeat(100));
+  assert.equal(assembled.messages.length, 1);
+  assert.ok(String(assembled.messages[0]!.content).length < 200);
+  assert.ok(assembled.estimatedTokens <= 44);
+});
+
 test("context engine exact recall skips additions that would exceed the token budget", async () => {
   const rpc = new FakeRpc();
   const marker = "BUDGET_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -442,7 +442,7 @@ test("context engine assemble clamps system prompt additions within token budget
   });
 
   assert.equal(assembled.messages.length, 0);
-  assert.ok(assembled.systemPromptAddition.length < 2000);
+  assert.equal(assembled.systemPromptAddition, "x".repeat(176));
   assert.ok(assembled.estimatedTokens <= 44);
 });
 


### PR DESCRIPTION
## Summary

`enforceTokenBudgetInvariant()` only considered replay messages when clamping context-engine assemble output to `tokenBudget`. It ignored `systemPromptAddition`, even though that text is also injected into the final prompt and consumes budget.

If the daemon/kernel returned a large `systemPromptAddition` with stale or underreported `estimatedTokens`, the invariant could pass and return the full addition unchanged.

This PR:

- includes `systemPromptAddition` in the approximate budget calculation,
- returns unchanged only when both `estimatedTokens` and approximate prompt content fit,
- reserves budget for `systemPromptAddition` before trimming replay messages,
- truncates the system prompt addition and drops replay messages when the addition alone exceeds the effective budget,
- drops replay messages when the residual budget cannot even cover message wrapper overhead,
- uses head-preserving truncation for system prompt additions, so XML-ish/preamble structure is not preferentially discarded,
- adds unit coverage for oversized additions, additions that fit while forcing message trimming, and near-zero residual message budgets.

Closes #104.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js` — PASS
- `pnpm run check` — PASS, 110 tests

Follow-up commit `5ce9860` fixed the wrapper-overhead residual-budget edge case found during audit.

– Vale
