### PR TITLE
fix: replace first chunk during markdown ingest

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -83,14 +83,14 @@ export class IngestQueue {
       });
     }
 
-    // Multiple chunks: use APPEND mode for all but last (which can be REPLACE)
+    // Multiple chunks: replace the previous document first, then append remaining chunks.
     for (let i = 0; i < chunks.length; i++) {
-      const isLast = i === chunks.length - 1;
+      const isFirst = i === 0;
       const chunkParams: IngestMarkdownDocumentParams = {
         ...baseParams,
         sourceDoc,
         text: chunks[i].text,
-        mode: isLast ? IngestMode.REPLACE : IngestMode.APPEND,
+        mode: isFirst ? IngestMode.REPLACE : IngestMode.APPEND,
       };
       await this.ingestWithRetry(chunkParams);
     }

--- a/test/unit/ingest-queue.test.ts
+++ b/test/unit/ingest-queue.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { IngestMode } from "@xdarkicex/libravdb-contracts";
+import { IngestQueue } from "../../src/ingest-queue.js";
+
+const baseParams = {
+  tokenizerId: "test-tokenizer",
+  coreDoc: false,
+  sourceMeta: {
+    sourceRoot: "/repo",
+    sourcePath: "notes/large.md",
+    sourceKind: "test",
+    fileHash: "hash",
+    sourceSize: 18,
+    sourceMtimeMs: 1,
+    ingestVersion: 1,
+    hashBackend: "test",
+  },
+};
+
+test("chunked markdown ingest replaces first, then appends remaining chunks", async () => {
+  const calls: Array<{ method: string; params: { mode?: IngestMode; text?: string } }> = [];
+  const queue = new IngestQueue(
+    async <T>(method: string, params: unknown): Promise<T> => {
+      calls.push({ method, params: params as { mode?: IngestMode; text?: string } });
+      return undefined as T;
+    },
+    { error() {} },
+    { chunkTokens: 1, maxRetries: 0 },
+  );
+
+  await queue.enqueueIngest("doc-1", "aaaa bbbb cccc", baseParams);
+
+  assert.ok(calls.length > 1);
+  assert.deepEqual(
+    calls.map((call) => call.params.mode),
+    [IngestMode.REPLACE, ...Array(calls.length - 1).fill(IngestMode.APPEND)],
+  );
+  assert.equal(calls.map((call) => call.params.text).join(""), "aaaa bbbb cccc");
+});


### PR DESCRIPTION
## Summary
- send the first chunk of a multi-chunk markdown ingest as REPLACE
- send remaining chunks as APPEND so earlier chunks are not deleted by the final call
- add unit coverage for chunk ingest mode ordering and content preservation

## Verification
- pnpm exec tsc -p tsconfig.tests.json
- node --test .ts-build/test/unit/ingest-queue.test.js
- pnpm run check

Fixes #106