### PR TITLE
fix: support recursive wildcards, character classes, and brace expansion in matchesGlob

### DIFF
--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -586,12 +586,98 @@ function isMarkdownFile(fileName: string): boolean {
   return lower.endsWith(".md") || lower.endsWith(".markdown");
 }
 
-function matchesGlob(value: string, pattern: string): boolean {
-  const escaped = pattern
-    .split("*")
-    .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
-    .join(".*");
-  return new RegExp(`^${escaped}$`).test(value);
+export function matchesGlob(value: string, pattern: string): boolean {
+  // Convert a glob pattern to a RegExp, supporting:
+  //   **/  — match zero or more path segments
+  //   **   — match any path (including /)
+  //   *   — match within a single segment (no slashes)
+  //   ?   — match a single character (no slashes)
+  //   [...] — character classes
+  //   {a,b} — brace expansion (comma-separated alternatives)
+  // Anything else is matched literally.
+  const len = pattern.length;
+  let re = "";
+  let i = 0;
+  while (i < len) {
+    const ch = pattern[i];
+    if (ch === "*" && pattern[i + 1] === "*") {
+      i += 2;
+      if (pattern[i] === "/") {
+        // **/ — zero or more complete path segments ending in /
+        i++; // consume the /
+        re += "(?:.+/)?";
+      } else {
+        // standalone ** — match any path including /
+        re += ".*?";
+      }
+    } else if (ch === "*") {
+      // * matches anything except /
+      re += "[^/]*";
+      i++;
+    } else if (ch === "?") {
+      // ? matches a single character except /
+      re += "[^/]";
+      i++;
+    } else if (ch === "[") {
+      // Character class — find the closing ]
+      const end = pattern.indexOf("]", i + 1);
+      if (end === -1) {
+        // No closing bracket, treat literally
+        re += "\\[";
+        i++;
+      } else {
+        re += pattern.slice(i, end + 1);
+        i = end + 1;
+      }
+    } else if (ch === "{") {
+      // Brace expansion {a,b} → (?:a|b)
+      const end = pattern.indexOf("}", i + 1);
+      if (end === -1) {
+        re += "\\{";
+        i++;
+      } else {
+        const inner = pattern.slice(i + 1, end);
+        const alternatives = inner.split(",").map((s) => globToRegexFragment(s)).join("|");
+        re += "(?:" + alternatives + ")";
+        i = end + 1;
+      }
+    } else {
+      // Literal character — escape regex metacharacters
+      re += ch.replace(/[.+^${}()|\\]/g, "\\$&");
+      i++;
+    }
+  }
+  return new RegExp(`^${re}$`).test(value);
+}
+
+function globToRegexFragment(pattern: string): string {
+  // Minimal version of matchesGlob for use inside brace expansions.
+  // Supports *, **, ?, and literal characters (no nested braces/classes).
+  const len = pattern.length;
+  let re = "";
+  let i = 0;
+  while (i < len) {
+    const ch = pattern[i];
+    if (ch === "*" && pattern[i + 1] === "*") {
+      i += 2;
+      if (pattern[i] === "/") {
+        i++;
+        re += "(?:.+/)?";
+      } else {
+        re += ".*?";
+      }
+    } else if (ch === "*") {
+      re += "[^/]*";
+      i++;
+    } else if (ch === "?") {
+      re += "[^/]";
+      i++;
+    } else {
+      re += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      i++;
+    }
+  }
+  return re;
 }
 
 function looksLikeObsidianNote(filePath: string, text: string): boolean {

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -592,7 +592,7 @@ export function matchesGlob(value: string, pattern: string): boolean {
   //   **   — match any path (including /)
   //   *   — match within a single segment (no slashes)
   //   ?   — match a single character (no slashes)
-  //   [...] — character classes
+  //   [...] — character classes (including [!...] negation → [^...])
   //   {a,b} — brace expansion (comma-separated alternatives)
   // Anything else is matched literally.
   const len = pattern.length;
@@ -605,7 +605,7 @@ export function matchesGlob(value: string, pattern: string): boolean {
       if (pattern[i] === "/") {
         // **/ — zero or more complete path segments ending in /
         i++; // consume the /
-        re += "(?:.+/)?";
+        re += "(?:[^/]+/)*";
       } else {
         // standalone ** — match any path including /
         re += ".*?";
@@ -626,7 +626,9 @@ export function matchesGlob(value: string, pattern: string): boolean {
         re += "\\[";
         i++;
       } else {
-        re += pattern.slice(i, end + 1);
+        // Translate glob [!...] negation to regex [^...] notation
+        const cls = pattern.slice(i + 1, end).replace(/^!/, "^");
+        re += "[" + cls + "]";
         i = end + 1;
       }
     } else if (ch === "{") {
@@ -662,7 +664,7 @@ function globToRegexFragment(pattern: string): string {
       i += 2;
       if (pattern[i] === "/") {
         i++;
-        re += "(?:.+/)?";
+        re += "(?:[^/]+/)*";
       } else {
         re += ".*?";
       }

--- a/test/unit/matchesGlob.test.ts
+++ b/test/unit/matchesGlob.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { matchesGlob } from "../../src/markdown-ingest.js";
+
+test("matchesGlob: single-segment wildcard matches files in same directory", () => {
+  assert.equal(matchesGlob("notes/draft.md", "notes/*.md"), true);
+  assert.equal(matchesGlob("notes/final.md", "notes/*.md"), true);
+  assert.equal(matchesGlob("notes/sub/deep.md", "notes/*.md"), false);
+  assert.equal(matchesGlob("draft.md", "*.md"), true);
+});
+
+test("matchesGlob: **/ matches across path segments", () => {
+  assert.equal(matchesGlob("private/secret.md", "**/private/**"), true);
+  assert.equal(matchesGlob("a/private/b/secret.md", "**/private/**"), true);
+  assert.equal(matchesGlob("deep/nested/private/dir/secret.md", "**/private/**"), true);
+  assert.equal(matchesGlob("private.md", "**/private/**"), false);
+  assert.equal(matchesGlob("xprivate/y.md", "**/private/**"), false);
+});
+
+test("matchesGlob: **/*.md matches deeply nested markdown files", () => {
+  assert.equal(matchesGlob("docs/readme.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("docs/a/b/c.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("docs/guide/intro.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("src/index.ts", "docs/**/*.md"), false);
+  assert.equal(matchesGlob("other/readme.md", "docs/**/*.md"), false);
+});
+
+test("matchesGlob: ? matches a single non-slash character", () => {
+  assert.equal(matchesGlob("ab", "??"), true);
+  assert.equal(matchesGlob("a", "??"), false);
+  assert.equal(matchesGlob("abc", "??"), false);
+  assert.equal(matchesGlob("a/b", "??"), false);
+  assert.equal(matchesGlob("Makefile", "?akefile"), true);
+  assert.equal(matchesGlob("makefile", "?akefile"), true);
+});
+
+test("matchesGlob: character classes match single characters", () => {
+  assert.equal(matchesGlob("Makefile", "[Mm]akefile"), true);
+  assert.equal(matchesGlob("makefile", "[Mm]akefile"), true);
+  assert.equal(matchesGlob("akefile", "[Mm]akefile"), false);
+  assert.equal(matchesGlob("akefile", "[a-c]kefile"), true);
+});
+
+test("matchesGlob: brace expansion matches alternatives", () => {
+  assert.equal(matchesGlob("notes/draft.md", "notes/{draft,final}.md"), true);
+  assert.equal(matchesGlob("notes/final.md", "notes/{draft,final}.md"), true);
+  assert.equal(matchesGlob("notes/archive.md", "notes/{draft,final}.md"), false);
+});
+
+test("matchesGlob: literal characters and dots match exactly", () => {
+  assert.equal(matchesGlob("config.yaml", "config.yaml"), true);
+  assert.equal(matchesGlob("configyml", "config.yaml"), false);
+  assert.equal(matchesGlob(".hidden", ".hidden"), true);
+  assert.equal(matchesGlob("hidden", ".hidden"), false);
+});
+
+test("matchesGlob: combined patterns work together", () => {
+  assert.equal(matchesGlob("src/utils/helpers.ts", "src/**/*.ts"), true);
+  assert.equal(matchesGlob("src/utils/helpers.js", "src/**/*.ts"), false);
+  assert.equal(matchesGlob("docs/v2/guide.md", "docs/v[12]/**/*.{md,txt}"), true);
+  assert.equal(matchesGlob("docs/v2/guide.txt", "docs/v[12]/**/*.{md,txt}"), true);
+  assert.equal(matchesGlob("docs/v3/guide.md", "docs/v[12]/**/*.{md,txt}"), false);
+});

--- a/test/unit/matchesGlob.test.ts
+++ b/test/unit/matchesGlob.test.ts
@@ -42,6 +42,13 @@ test("matchesGlob: character classes match single characters", () => {
   assert.equal(matchesGlob("akefile", "[a-c]kefile"), true);
 });
 
+test("matchesGlob: negated character classes with !", () => {
+  // [!abc] is glob syntax for "not a, b, or c" — should translate to [^abc]
+  assert.equal(matchesGlob("draft.md", "[!.]*"), true);
+  assert.equal(matchesGlob(".hidden", "[!.]*"), false);
+  assert.equal(matchesGlob("readme.md", "[!.]*"), true);
+});
+
 test("matchesGlob: brace expansion matches alternatives", () => {
   assert.equal(matchesGlob("notes/draft.md", "notes/{draft,final}.md"), true);
   assert.equal(matchesGlob("notes/final.md", "notes/{draft,final}.md"), true);


### PR DESCRIPTION
## Summary

Replaces the markdown-ingest glob matcher that only handled `*` with a small matcher for the pattern forms exposed through config.

## Scope

Supported pattern forms:

- `**/` recursive directory prefixes;
- standalone `**`;
- single-segment `*`;
- `?` single non-slash character;
- basic `[...]` character classes, including `[!...]`;
- simple `{a,b}` brace alternatives.

## Audit Notes

- This is intentionally not a full Bash/minimatch clone.
- Nested brace expansion and other advanced shell-glob behavior remain out of scope.
- Regex compilation remains per-call. That is acceptable for correctness, but caching compiled patterns is a reasonable follow-up if directory walks get large.
- PR #131 depends on this because its default exclude patterns use recursive globs.

## Review Follow-up

- This is a documented glob subset, not minimatch compatibility.
- Known unsupported/limited cases include escaped literal glob metacharacters, bracket-literal class forms, nested braces, and Windows path separator normalization.
- Add docs or follow-up coverage before users assume full shell/minimatch semantics.
- PR #131 depends on the recursive glob behavior from this PR.

## Verification

- Unit coverage for recursive wildcards, `?`, character classes, negated classes, and brace alternatives.
- Existing markdown ingestion include/exclude paths continue to use the same `matchesGlob` entry point.

Fixes #97.
Unblocks #131.

– Vale