### PR TITLE
fix: swap HMAC key and message in gRPC challenge-response

### DIFF
--- a/src/grpc-client.ts
+++ b/src/grpc-client.ts
@@ -52,8 +52,12 @@ export class GrpcKernelClient {
       if (!this.nonceHex) {
         throw new Error("call initializeSession before authenticated RPCs");
       }
-      const hmac = createHmac("sha256", Buffer.from(this.nonceHex, "hex"));
-      hmac.update(this.secret);
+      // Challenge-response: HMAC(secret, nonce) — the secret is the HMAC key,
+      // the server-issued nonce is the message. The previous implementation
+      // swapped these, computing HMAC(nonce, secret), which is cryptographically
+      // incorrect: the nonce is sent in the clear and must not be used as the key.
+      const hmac = createHmac("sha256", this.secret);
+      hmac.update(this.nonceHex);
       const signature = hmac.digest("hex");
       md.add("x-libravdb-auth", signature);
     }

--- a/test/unit/grpc-client.test.ts
+++ b/test/unit/grpc-client.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GrpcKernelClient } from "../../src/grpc-client.js";
+
+type MetadataProbe = {
+  secret?: string;
+  nonceHex?: string;
+  getMetadata(signed?: boolean): { get(key: string): unknown[] };
+};
+
+function createMetadataProbe(secret?: string, nonceHex?: string): MetadataProbe {
+  return Object.assign(
+    Object.create(GrpcKernelClient.prototype),
+    { secret, nonceHex },
+  ) as MetadataProbe;
+}
+
+test("gRPC auth metadata signs the server nonce with the shared secret", () => {
+  const client = createMetadataProbe("test-secret", "00112233445566778899aabbccddeeff");
+
+  const metadata = client.getMetadata(true);
+
+  assert.deepEqual(metadata.get("x-libravdb-auth"), [
+    "84b7660ccd62a3d5848a05112cd1cff4e753779cb4464c156e0e57d7c9b6cef3",
+  ]);
+});
+
+test("gRPC auth metadata requires initializeSession nonce before signed calls", () => {
+  const client = createMetadataProbe("test-secret");
+
+  assert.throws(
+    () => client.getMetadata(true),
+    /call initializeSession before authenticated RPCs/,
+  );
+});


### PR DESCRIPTION
## Summary

The gRPC client computed the auth signature as `HMAC(nonce, secret)`: the server nonce was used as the HMAC key and the shared secret was used as the message.

Challenge-response auth should prove possession of the shared secret by signing the server-issued nonce:

```ts
HMAC(secret, nonce)
```

This PR changes the client to use the configured shared secret as the HMAC key and the hex-encoded nonce string as the message, matching the protocol expectation documented here.

## Compatibility warning

This is a coordinated protocol fix. If the daemon currently validates the same swapped construction, a client-only change will break authenticated gRPC calls until the daemon validates `HMAC(secret, nonce)` too.

So: correct fix, but do not merge/deploy blindly without daemon-side alignment.

Closes #94.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/grpc-client.test.js` — PASS
- `pnpm run check` — PASS, 119 tests

The new tests use a fixed HMAC vector and assert that signed metadata contains the expected `x-libravdb-auth` signature. They also check that signed calls still require an initialized server nonce. Follow-up merge commit `2f376fa` resolved the current-main `grpc-client.test.ts` conflict while keeping both the target-resolution and HMAC coverage.

– Vale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication credential generation in gRPC client to ensure secure and proper communication between client and server

* **Tests**
  * Expanded test suite to verify authentication flows, including session initialization requirements and credential validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
