### PR TITLE
fix(ingest-queue): prevent infinite loop when chunkTokens <= 0

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -120,6 +120,11 @@ export class IngestQueue {
 
 function splitIntoChunks(text: string, maxTokens: number): Array<{ text: string; ordinal: number }> {
   // Approximate: 4 chars per token for typical English text
+  // Guard: zero/negative budget would make maxChars <= 0, causing an infinite
+  // loop because the offset never advances past an empty slice.
+  if (!(maxTokens > 0)) {
+    return [{ text, ordinal: 0 }];
+  }
   const maxChars = maxTokens * 4;
   if (text.length <= maxChars) {
     return [{ text, ordinal: 0 }];


### PR DESCRIPTION
## Summary

`splitIntoChunks` enters an infinite loop when `maxTokens` (i.e. `chunkTokens`) is 0 or negative. `maxChars` becomes 0, the while-loop never advances the offset (`text.slice(0, 0)` = `""`), and empty strings are pushed indefinitely until OOM.

The `IngestQueue` constructor accepts `Partial<IngestQueueOptions>` without validating `chunkTokens`, so a misconfigured value of `0` is a realistic input path.

## Fix

Guard at the top of `splitIntoChunks`: if `maxTokens <= 0`, return the full text as a single chunk. This matches the existing `Infinity` bypass semantics (retry-only mode sends the full text).

## Verification

- TypeScript compiles clean (`tsc --noEmit`)
- Existing tests pass
- Manual: `splitIntoChunks("hello", 0)` previously hung → now returns `[{ text: "hello", ordinal: 0 }]`

– Vale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stability issue where the ingest queue could become stuck during text chunking with certain configuration values, improving reliability of the document ingestion process when handling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->