### PR TITLE
fix(markdown-ingest): detect CRLF frontmatter in looksLikeObsidianNote

### DIFF
--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -595,17 +595,20 @@ function matchesGlob(value: string, pattern: string): boolean {
 }
 
 function looksLikeObsidianNote(filePath: string, text: string): boolean {
-  if (!text.startsWith("---\n")) {
+  const isCrlf = text.startsWith("---\r\n");
+  const hasFrontmatterOpen = isCrlf || text.startsWith("---\n");
+  if (!hasFrontmatterOpen) {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatterEnd = findFrontmatterEnd(text, 4);
+  const openLen = isCrlf ? 5 : 4; // "---\r\n" vs "---\n"
+  const frontmatterEnd = findFrontmatterEnd(text, openLen);
   if (frontmatterEnd < 0) {
     return hasInlineObsidianTag(text);
   }
 
-  const frontmatter = text.slice(4, frontmatterEnd);
-  const lines = frontmatter.split("\n");
+  const frontmatter = text.slice(openLen, frontmatterEnd);
+  const lines = frontmatter.split(/\r?\n/);
   for (const line of lines) {
     const trimmed = line.trimStart();
     if (
@@ -618,7 +621,11 @@ function looksLikeObsidianNote(filePath: string, text: string): boolean {
     }
   }
 
-  return hasInlineObsidianTag(text.slice(frontmatterEnd + 4));
+  // The closing delimiter length matches the opening: "---\r\n" (5) or "---\n" (4).
+  // findFrontmatterEnd returns the position of the opening "-" of the closing "---",
+  // so we skip past the entire closing delimiter.
+  const closeLen = text.charCodeAt(frontmatterEnd + 3) === 13 ? 5 : 4;
+  return hasInlineObsidianTag(text.slice(frontmatterEnd + closeLen));
 }
 
 function findFrontmatterEnd(text: string, offset: number): number {


### PR DESCRIPTION
## Summary

`looksLikeObsidianNote` gated frontmatter detection with `text.startsWith("---\n")`, which fails for CRLF files starting with `"---\r\n"`. Those files were sent directly to `hasInlineObsidianTag` without ever parsing frontmatter for `tags:`, `memory:`, or `openclaw:` keys.

PR #101 fixed `findFrontmatterEnd` to handle CRLF closing delimiters, but missed the upstream gate that decides *whether* to call it at all.

## Fix

Accept both `"---\n"` and `"---\r\n"` as frontmatter openers. Pass the correct offset (4 for LF, 5 for CRLF) to `findFrontmatterEnd`.

## Verification

- TypeScript compiles clean
- A CRLF file with `---\r\ntags: [memory]\r\n---\r\n` is now correctly detected as an Obsidian note

– Vale