### PR TITLE
fix(context-engine): invalidate cached identity when sessionKey changes

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -522,6 +522,7 @@ export function buildContextEngineFactory(
   logger: LoggerLike = console,
 ) {
   let cachedIdentity: ResolvedIdentity | null = null;
+  let cachedSessionKey: string | undefined;
 
   function resolveUserId(args?: {
     userIdOverride?: string;
@@ -531,13 +532,15 @@ export function buildContextEngineFactory(
     const fwUserId = args?.userIdOverride?.trim();
     if (fwUserId) return fwUserId;
 
-    if (!cachedIdentity) {
+    const sessionKey = args?.sessionKey?.trim() || undefined;
+    if (!cachedIdentity || cachedSessionKey !== sessionKey) {
       cachedIdentity = resolveIdentity({
         configUserId: cfg.userId,
         identityPath: cfg.identityPath,
-        sessionKey: args?.sessionKey,
+        sessionKey,
         logger,
       });
+      cachedSessionKey = sessionKey;
     }
     return cachedIdentity.userId;
   }


### PR DESCRIPTION
## Summary

`cachedIdentity` in `buildContextEngineFactory` was set once and never invalidated. When the first `resolveUserId` call had no `sessionKey`, the cache stored a file-derived or auto-derived identity. Subsequent calls with a different `sessionKey` still returned the stale cached identity, causing `resolveDurableNamespace` to produce the wrong namespace — cross-session recall would search the wrong collection.

## Fix

Track the `sessionKey` used to derive the cached identity alongside the cached result. When `sessionKey` changes, re-resolve identity. This is cheap (one string comparison per call) and preserves the performance benefit of caching within a session.

The `configUserId` and `identityPath` inputs are static `cfg` properties that don't change, so only `sessionKey` needs cache invalidation.

## Verification

- TypeScript compiles clean
- Same-session calls still hit the cache (no re-resolution)
- Cross-session calls with different sessionKey values now re-resolve correctly

– Vale
