### PR TITLE
fix(memory-runtime): add defensive guards for undefined metadata and results

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -229,13 +229,16 @@ function firstString(...values: Array<string | undefined>): string | undefined {
 }
 
 function toMemorySearchResult(item: SearchResult) {
-  const collection = typeof item.metadata.collection === "string" ? item.metadata.collection : "memory";
+  const metadata = item.metadata ?? {};
+  const collection = typeof metadata.collection === "string" ? metadata.collection : "memory";
+  const text = typeof item.text === "string" ? item.text : "";
+  const score = typeof item.score === "number" && Number.isFinite(item.score) ? item.score : 0;
   return {
     path: encodeSearchResultPath(collection, item.id),
     startLine: 1,
-    endLine: Math.max(1, item.text.split("\n").length),
-    score: item.score,
-    snippet: item.text,
+    endLine: Math.max(1, text.split("\n").length),
+    score,
+    snippet: text,
     source: collection.startsWith("session:") || collection.startsWith("session_") ? "sessions" : "memory",
     citation: `${collection}:${item.id}`,
   };
@@ -245,7 +248,8 @@ async function loadSearchResultText(getRpc: RpcGetter, relPath: string): Promise
   const { collection, id } = decodeSearchResultPath(relPath);
   const rpc = await getRpc();
   const result = await rpc.call<{ results: SearchResult[] }>("list_collection", { collection });
-  const item = result.results.find((entry) => entry.id === id);
+  const results = Array.isArray(result.results) ? result.results : [];
+  const item = results.find((entry) => entry.id === id);
   if (!item) {
     throw new Error(`LibraVDB memory path not found: ${relPath}`);
   }


### PR DESCRIPTION
## Summary

Two defensive guards in `memory-runtime.ts`:

1. **`toMemorySearchResult`**: `item.metadata` could be undefined if the daemon returns a result without the metadata field (or via a path that bypasses the protobuf codec's `normalizeSearchTextResponse`). Now destructures with `?? {}` fallback. Also guards `item.text` (default `""`) and `item.score` (default `0`) against undefined values.

2. **`loadSearchResultText`**: `result.results` could be undefined or non-array if the daemon returns a malformed response. Now normalizes to `[]` before `.find()`.

These are defensive — the protobuf codec layer already normalizes most of these — but they protect against raw gRPC or test paths that bypass the codec, and align with the same pattern used in PR #110 for the exact-recall path.

## Verification

- TypeScript compiles clean
- No behavioral change for well-formed responses
- Crashes prevented for malformed/undefined fields

– Vale
