### PR TITLE
fix: validate chunkTokens at IngestQueue constructor boundary

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -56,7 +56,7 @@ export class IngestQueue {
     this.rpcCall = rpcCall;
     this.logger = logger;
     this.options = { ...DEFAULT_OPTIONS, ...options };
-    if (this.options.chunkTokens !== Infinity && this.options.chunkTokens <= 0) {
+    if (!(this.options.chunkTokens > 0)) {
       this.logger.warn?.(`[libravdb] chunkTokens ${this.options.chunkTokens} is invalid; using default ${DEFAULT_OPTIONS.chunkTokens}`);
       this.options.chunkTokens = DEFAULT_OPTIONS.chunkTokens;
     }

--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -56,6 +56,10 @@ export class IngestQueue {
     this.rpcCall = rpcCall;
     this.logger = logger;
     this.options = { ...DEFAULT_OPTIONS, ...options };
+    if (this.options.chunkTokens !== Infinity && this.options.chunkTokens <= 0) {
+      this.logger.warn?.(`[libravdb] chunkTokens ${this.options.chunkTokens} is invalid; using default ${DEFAULT_OPTIONS.chunkTokens}`);
+      this.options.chunkTokens = DEFAULT_OPTIONS.chunkTokens;
+    }
   }
 
   async enqueueIngest(


### PR DESCRIPTION
## Summary

Complement to #113: the `splitIntoChunks` guard prevents the infinite loop, but the `chunkTokens > 0 || chunkTokens === Infinity` invariant should be enforced at the constructor boundary where the option enters the component.

When `chunkTokens` is invalid (0, negative, NaN), the constructor now resets it to the default (8192) with a warning. This means:
- `splitIntoChunks` can trust its input rather than silently patching bad data
- The operator gets a warning their config is wrong instead of silently disabling chunking
- The function-level guard in #113 remains as defense-in-depth

## Verification

- TypeScript compiles clean
- `{ chunkTokens: 0 }` → warns and uses 8192
- `{ chunkTokens: Infinity }` → unchanged (valid sentinel for "no chunking")
- `{ chunkTokens: 8192 }` → unchanged (valid value)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for text chunking configuration to prevent invalid settings from causing processing issues. Invalid configurations are now automatically corrected to safe defaults with a warning notification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->