### PR TITLE
fix: prevent TypeError when search results have missing text field in exact recall

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -426,7 +426,8 @@ function extractExactRecallTokens(text: string): string[] {
   return Array.from(tokens).slice(0, EXACT_RECALL_MAX_TOKENS);
 }
 
-function isExactRecallFact(text: string, token: string): boolean {
+function isExactRecallFact(text: string | undefined | null, token: string): boolean {
+  if (typeof text !== "string") return false;
   return (
     text.includes(token) &&
     /\bmeans\b/i.test(text) &&
@@ -444,11 +445,12 @@ function isQuestionShapedRecallCandidate(text: string): boolean {
 }
 
 function rankExactRecallCandidate(result: SearchResult, token: string): number {
-  if (!result.text.includes(token)) return Number.NEGATIVE_INFINITY;
+  const text = typeof result.text === "string" ? result.text : "";
+  if (!text.includes(token)) return Number.NEGATIVE_INFINITY;
   let rank = result.score;
-  if (/\bmeans\b/i.test(result.text)) rank += 100;
-  if (/\b(remember|durable|fact)\b/i.test(result.text)) rank += 10;
-  if (/\bwhat does\b/i.test(result.text) || result.text.includes("?")) rank -= 25;
+  if (/\bmeans\b/i.test(text)) rank += 100;
+  if (/\b(remember|durable|fact)\b/i.test(text)) rank += 10;
+  if (/\bwhat does\b/i.test(text) || text.includes("?")) rank -= 25;
   return rank;
 }
 


### PR DESCRIPTION
The Bug:
In isExactRecallFact, text is expected to be a string. If LibraVDB's search returns a result where the text field is missing or null, text.includes(token) will throw the TypeError we saw.

Similarly, in rankExactRecallCandidate, result.text is accessed without a null check before calling .includes(token).

Why it triggers with Skillporter:
When you search for "security researcher," the Exact Recall logic kicks in. It tries to find facts in your memory that "mean" security researcher. If it finds a broken or empty entry in the database (maybe an old failed turn), result.text is undefined, and it crashes.

The Fix:
I need to add defensive null checks to isExactRecallFact and rankExactRecallCandidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved defensive input handling in recall logic to properly manage null or undefined text values.
  * Enhanced candidate ranking logic to normalize text inputs before evaluation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->