### PR TITLE
fix: escape newline, carriage return, and tab in memory fact text

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -466,7 +466,10 @@ function escapeMemoryFactText(text: string): string {
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+    .replaceAll("'", "&#39;")
+    .replaceAll("\r", "&#13;")
+    .replaceAll("\n", "&#10;")
+    .replaceAll("\t", "&#9;");
 }
 
 function buildExactRecallFact(result: SearchResult, token: string): string {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -795,25 +795,41 @@ test("resolveIdentity with noAutoPersist skips writing identity file", () => {
   }
 });
 
-test("escapeMemoryFactText escapes control characters (newline, tab, carriage return)", () => {
-  // Mirrors the private escapeMemoryFactText in context-engine.ts.
-  // Verifies that \n, \r, \t are escaped to XML character references,
-  // and that existing XML entity escapes remain correct.
-  const input = "line1\nline2\rline3\ttab&<>";
-  const escaped = input
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;")
-    .replaceAll("\r", "&#13;")
-    .replaceAll("\n", "&#10;")
-    .replaceAll("\t", "&#9;");
-  assert.equal(escaped.includes("\n"), false, "should not contain raw newline");
-  assert.equal(escaped.includes("\r"), false, "should not contain raw carriage return");
-  assert.equal(escaped.includes("\t"), false, "should not contain raw tab");
-  assert.equal(escaped.includes("&amp;"), true, "should escape ampersand");
-  assert.equal(escaped.includes("&#10;"), true, "should escape newline to &#10;");
-  assert.equal(escaped.includes("&#13;"), true, "should escape carriage return to &#13;");
-  assert.equal(escaped.includes("&#9;"), true, "should escape tab to &#9;");
+test("context engine exact recall escapes control characters inside injected memory facts", async () => {
+  const rpc = new FakeRpc();
+  const marker = "CONTROL_CHAR_MEMORY_MARKER_1234567890";
+  rpc.searchResults = [
+    {
+      id: "fact",
+      score: 0.9,
+      text: `${marker} means line1\nline2\rline3\ttab & <tag> "quoted" 'single'.`,
+      metadata: { collection: "user:fixed-user", role: "user" },
+    },
+  ];
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user", topK: 4 });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", `What does ${marker} mean?`)],
+    prompt: `What does ${marker} mean?`,
+    tokenBudget: 4000,
+  });
+
+  const match = assembled.systemPromptAddition.match(
+    /<memory_fact source="exact_recalled">([\s\S]*?)<\/memory_fact>/,
+  );
+  assert.ok(match, "exact recall fact should be injected through the context engine");
+  const factText = match[1]!;
+
+  assert.equal(factText.includes("\n"), false, "memory fact text should not contain raw newline");
+  assert.equal(factText.includes("\r"), false, "memory fact text should not contain raw carriage return");
+  assert.equal(factText.includes("\t"), false, "memory fact text should not contain raw tab");
+  assert.ok(factText.includes("&#10;"), "newline should be escaped to XML char reference");
+  assert.ok(factText.includes("&#13;"), "carriage return should be escaped to XML char reference");
+  assert.ok(factText.includes("&#9;"), "tab should be escaped to XML char reference");
+  assert.ok(factText.includes("&amp;"), "ampersand should still be escaped");
+  assert.ok(factText.includes("&lt;tag&gt;"), "angle brackets should still be escaped");
+  assert.ok(factText.includes("&quot;quoted&quot;"), "double quotes should still be escaped");
+  assert.ok(factText.includes("&#39;single&#39;"), "single quotes should still be escaped");
 });

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -794,3 +794,26 @@ test("resolveIdentity with noAutoPersist skips writing identity file", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test("escapeMemoryFactText escapes control characters (newline, tab, carriage return)", () => {
+  // Mirrors the private escapeMemoryFactText in context-engine.ts.
+  // Verifies that \n, \r, \t are escaped to XML character references,
+  // and that existing XML entity escapes remain correct.
+  const input = "line1\nline2\rline3\ttab&<>";
+  const escaped = input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("\r", "&#13;")
+    .replaceAll("\n", "&#10;")
+    .replaceAll("\t", "&#9;");
+  assert.equal(escaped.includes("\n"), false, "should not contain raw newline");
+  assert.equal(escaped.includes("\r"), false, "should not contain raw carriage return");
+  assert.equal(escaped.includes("\t"), false, "should not contain raw tab");
+  assert.equal(escaped.includes("&amp;"), true, "should escape ampersand");
+  assert.equal(escaped.includes("&#10;"), true, "should escape newline to &#10;");
+  assert.equal(escaped.includes("&#13;"), true, "should escape carriage return to &#13;");
+  assert.equal(escaped.includes("&#9;"), true, "should escape tab to &#9;");
+});


### PR DESCRIPTION
## Summary

`escapeMemoryFactText` escaped the five XML entities (`&`, `<`, `>`, `"`, `'`) but left `\n`, `\r`, and `\t` raw inside `<memory_fact>` tags injected into system prompt additions.

This is a low-severity prompt-structure/data-integrity bug, not a remote exploit: user-authored memory fact text with raw control characters can make the XML-ish prompt block harder to parse or create injection-looking artifacts inside the fact tag.

This PR adds escaping for:

- `\r` → `&#13;`
- `\n` → `&#10;`
- `\t` → `&#9;`

The ampersand escape still runs first, so these introduced character references are not double-escaped.

Closes #123.

## Verification

- `pnpm run plugin:ci`
- `pnpm exec tsc -p tsconfig.tests.json`
- `node --test --test-name-pattern='exact recall escapes control characters|injects exact factual recall' .ts-build/test/unit/context-engine.test.js`

The test now exercises the public context-engine assemble path and verifies the injected `<memory_fact>` content, instead of mirroring the private helper.

– Vale
