### PR TITLE
fix: skip common irrelevant directories during markdown ingestion walk

### DIFF
--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -11,6 +11,22 @@ const DEFAULT_DEBOUNCE_MS = 150;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
+
+/** Directories that are always skipped during markdown ingestion walks. */
+const DEFAULT_SKIP_DIR_NAMES = new Set([
+  "node_modules",
+  ".git",
+  ".svn",
+  ".hg",
+  "dist",
+  "build",
+  "__pycache__",
+  ".venv",
+  "venv",
+  ".next",
+  ".nuxt",
+  ".cache",
+]);
 type Disposable = { close(): void };
 
 interface RpcLike {
@@ -350,6 +366,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       const child = path.join(dir, entry.name);
       if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIR_NAMES.has(entry.name)) {
+          continue;
+        }
         await this.walkDirectory(rootState, child, currentFiles);
         continue;
       }

--- a/test/unit/markdown-ingest.test.ts
+++ b/test/unit/markdown-ingest.test.ts
@@ -16,3 +16,12 @@ test("markdown hash sentinel is stable and changes with content", () => {
 test("markdown hash sentinel uses the wasm backend when available", () => {
   assert.equal(getHashBackendName(), "wasm-fnv1a64");
 });
+
+test("DEFAULT_SKIP_DIR_NAMES includes known irrelevant directories", async () => {
+  const { readFileSync } = await import("node:fs");
+  const source = readFileSync(new URL("../../src/markdown-ingest.ts", import.meta.url), "utf-8");
+  const expected = ["node_modules", ".git", ".svn", ".hg", "dist", "build", "__pycache__", ".venv", "venv", ".next", ".nuxt", ".cache"];
+  for (const name of expected) {
+    assert.ok(source.includes(`"${name}"`), `DEFAULT_SKIP_DIR_NAMES should contain "${name}"`);
+  }
+});


### PR DESCRIPTION
## Summary

When `markdownIngestionRoots` is set to a workspace directory, the markdown-ingest filesystem walker recurses into `node_modules/`, `.git/`, `dist/`, `build/`, `__pycache__/`, `.venv/`, `venv/`, `.next/`, `.nuxt/`, `.cache/`, `.svn/`, and `.hg/` directories. This causes hundreds of irrelevant README/CHANGELOG files to be ingested, RPC timeout cascades during startup, and bloated collections.

Add a `DEFAULT_SKIP_DIR_NAMES` set and check it before recursing into any subdirectory in `walkDirectory`. These directories are always skipped regardless of `markdownIngestionExclude` config — they never contain content that should be ingested for memory purposes.

The existing `markdownIngestionExclude` config still applies to file-level filtering. This change adds directory-level pruning that the config cannot express (previously `walkDirectory` recursed into everything).

Closes #118.

## Verification

- `tsc --noEmit` passes (pre-existing `IngestMode` import error in `ingest-queue.ts` is unrelated)
- Source-level test verifies `DEFAULT_SKIP_DIR_NAMES` contains all expected directory names
- Existing `markdown-ingest.test.ts` tests still pass

– Vale