### PR TITLE
fix: restrict dream diary path to allowed roots and reject traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ openclaw memory search "prior context"
 openclaw memory export --user-id <userId>
 openclaw memory flush --user-id <userId>
 openclaw memory journal --limit 50
-openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
+openclaw memory dream-promote --user-id <userId> --dream-file ~/DREAMS.md
 ```
 
 Use [Install](./docs/install.md) for service lifecycle commands and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `dreamPromotionEnabled` | boolean | `false` | Enable dream diary promotion |
-| `dreamPromotionDiaryPath` | string | — | Path to dream diary markdown file |
+| `dreamPromotionDiaryPath` | string | — | Path to dream diary markdown file under the operator home directory or `OPENCLAW_STATE_DIR` |
 | `dreamPromotionUserId` | string | — | User ID for dream collection scoping |
 | `dreamPromotionDebounceMs` | number | `150` | Debounce window for dream diary changes |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,11 +105,12 @@ Automatic diary watching:
 Manual run:
 
 ```bash
-openclaw memory dream-promote --user-id <userId> --dream-file /path/to/DREAMS.md
+openclaw memory dream-promote --user-id <userId> --dream-file ~/DREAMS.md
 ```
 
-The manual command and watcher both use the same sidecar promotion RPC, so
-admission gates and provenance metadata are identical.
+Dream diary files must live under the operator's home directory or the configured
+`OPENCLAW_STATE_DIR`. The manual command and watcher both use the same sidecar
+promotion RPC, so admission gates and provenance metadata are identical.
 
 ## Memory CLI
 
@@ -126,7 +127,7 @@ CLI API.
 | `openclaw memory flush --user-id <userId>` | Delete one durable user namespace after confirmation. |
 | `openclaw memory flush --session-key <sessionKey>` | Delete a namespace derived from a session key after confirmation. |
 | `openclaw memory journal --limit 50` | Inspect bounded lifecycle hints recorded by the sidecar. |
-| `openclaw memory dream-promote --user-id <userId> --dream-file <path>` | Promote vetted dream diary bullets. |
+| `openclaw memory dream-promote --user-id <userId> --dream-file <path>` | Promote vetted dream diary bullets from a file under the operator home directory or `OPENCLAW_STATE_DIR`. |
 
 Use `--yes` with `flush` only when you intentionally want to skip the
 confirmation prompt.

--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { getHashBackendName, hashBytes } from "./markdown-hash.js";
@@ -88,9 +89,17 @@ export function createDreamPromotionHandle(
   logger: LoggerLike = console,
   fsApi: FsApi = createRealFsApi(),
 ): DreamPromotionHandle {
-  const diaryPath = normalizeDiaryPath(cfg.dreamPromotionDiaryPath);
   const userId = cfg.dreamPromotionUserId?.trim() ?? "";
-  if (cfg.dreamPromotionEnabled !== true || !diaryPath || !userId) {
+  if (cfg.dreamPromotionEnabled !== true || !userId) {
+    return {
+      async start() {},
+      async refresh() {},
+      async stop() {},
+    };
+  }
+
+  const diaryPath = normalizeDiaryPath(cfg.dreamPromotionDiaryPath);
+  if (!diaryPath) {
     return {
       async start() {},
       async refresh() {},
@@ -467,7 +476,37 @@ function normalizeDiaryPath(value?: string): string {
   if (!trimmed) {
     return "";
   }
-  return path.resolve(trimmed);
+
+  // Reject traversal components — even though path.resolve collapses them,
+  // their presence signals an attempt to escape intended boundaries.
+  const segments = trimmed.split(/[/\\]+/);
+  if (segments.some((s) => s === "..")) {
+    throw new Error(
+      `dream diary path must not contain ".." traversal: ${trimmed}`,
+    );
+  }
+
+  const resolved = path.resolve(trimmed);
+
+  // Restrict to known-safe locations to prevent arbitrary file reads.
+  // Allowed roots: home directory and the configured OpenClaw state dir.
+  const allowedRoots = [
+    os.homedir(),
+    process.env.OPENCLAW_STATE_DIR,
+  ]
+    .filter((r): r is string => typeof r === "string" && r.trim().length > 0)
+    .map((root) => path.resolve(root));
+
+  const isAllowed = allowedRoots.some(
+    (root) => resolved.startsWith(root + path.sep) || resolved === root,
+  );
+  if (!isAllowed) {
+    throw new Error(
+      `dream diary path must be within an allowed root: ${allowedRoots.join(", ")}. Got: ${resolved}`,
+    );
+  }
+
+  return resolved;
 }
 
 function createRealFsApi(): FsApi {

--- a/test/integration/dream-promotion.test.ts
+++ b/test/integration/dream-promotion.test.ts
@@ -53,76 +53,88 @@ function delay(ms: number): Promise<void> {
 }
 
 test("dream promotion handle reads diary bullets and forwards them to the sidecar", async () => {
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-dream-"));
-  const diaryPath = path.join(tempRoot, "DREAMS.md");
-  await fsp.writeFile(
-    diaryPath,
-    [
-      "# DREAMS",
-      "",
-      "## Deep Sleep",
-      "- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}",
-      "- Too weak to promote {score=0.2 recall=1 unique=1}",
-    ].join("\n"),
-  );
+  let handle: ReturnType<typeof createDreamPromotionHandle> | null = null;
+  process.env.OPENCLAW_STATE_DIR = tempRoot;
 
-  const rpc = new FakeRpcClient();
-  const fsApi = new FakeFsApi();
-  const handle = createDreamPromotionHandle(
-    {
-      dreamPromotionEnabled: true,
-      dreamPromotionDiaryPath: diaryPath,
-      dreamPromotionUserId: "u1",
-      dreamPromotionDebounceMs: 0,
-    },
-    async () => rpc,
-    console,
-    fsApi as never,
-  );
+  try {
+    const diaryPath = path.join(tempRoot, "DREAMS.md");
+    await fsp.writeFile(
+      diaryPath,
+      [
+        "# DREAMS",
+        "",
+        "## Deep Sleep",
+        "- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}",
+        "- Too weak to promote {score=0.2 recall=1 unique=1}",
+      ].join("\n"),
+    );
 
-  await handle.start();
-  await delay(25);
+    const rpc = new FakeRpcClient();
+    const fsApi = new FakeFsApi();
+    handle = createDreamPromotionHandle(
+      {
+        dreamPromotionEnabled: true,
+        dreamPromotionDiaryPath: diaryPath,
+        dreamPromotionUserId: "u1",
+        dreamPromotionDebounceMs: 0,
+      },
+      async () => rpc,
+      console,
+      fsApi as never,
+    );
 
-  const promoteCall = rpc.calls.find((call) => call.method === "promote_dream_entries");
-  assert.ok(promoteCall, "expected dream promotion RPC to fire");
-  const params = promoteCall?.params as {
-    userId: string;
-    sourceDoc: string;
-    sourceKind: string;
-    entries: Array<{
-      text: string;
-      score: number;
-      recallCount: number;
-      uniqueQueries: number;
-      line: number;
-      sourceLine: number;
-    }>;
-  };
-  assert.equal(params.userId, "u1");
-  assert.equal(params.sourceDoc, diaryPath);
-  assert.equal(params.sourceKind, "dream");
-  assert.equal(params.entries.length, 2);
-  assert.equal(params.entries[0]?.text, "Preserve the recent tail buffer");
-  assert.equal(params.entries[0]?.line, 4);
-  assert.equal(params.entries[0]?.sourceLine, 4);
-  assert.equal(params.entries[1]?.score, 0.2);
-  assert.equal(params.entries[1]?.line, 5);
-  assert.equal(params.entries[1]?.sourceLine, 5);
+    await handle.start();
+    await delay(25);
 
-  await fsp.writeFile(
-    diaryPath,
-    [
-      "# DREAMS",
-      "",
-      "## Deep Sleep",
-      "- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}",
-      "- Too weak to promote {score=0.2 recall=1 unique=1}",
-    ].join("\n"),
-  );
-  fsApi.callbacks.get(path.dirname(diaryPath))?.[0]?.("change", path.basename(diaryPath));
-  await delay(25);
+    const promoteCall = rpc.calls.find((call) => call.method === "promote_dream_entries");
+    assert.ok(promoteCall, "expected dream promotion RPC to fire");
+    const params = promoteCall?.params as {
+      userId: string;
+      sourceDoc: string;
+      sourceKind: string;
+      entries: Array<{
+        text: string;
+        score: number;
+        recallCount: number;
+        uniqueQueries: number;
+        line: number;
+        sourceLine: number;
+      }>;
+    };
+    assert.equal(params.userId, "u1");
+    assert.equal(params.sourceDoc, diaryPath);
+    assert.equal(params.sourceKind, "dream");
+    assert.equal(params.entries.length, 2);
+    assert.equal(params.entries[0]?.text, "Preserve the recent tail buffer");
+    assert.equal(params.entries[0]?.line, 4);
+    assert.equal(params.entries[0]?.sourceLine, 4);
+    assert.equal(params.entries[1]?.score, 0.2);
+    assert.equal(params.entries[1]?.line, 5);
+    assert.equal(params.entries[1]?.sourceLine, 5);
 
-  assert.equal(rpc.calls.filter((call) => call.method === "promote_dream_entries").length, 1);
+    await fsp.writeFile(
+      diaryPath,
+      [
+        "# DREAMS",
+        "",
+        "## Deep Sleep",
+        "- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}",
+        "- Too weak to promote {score=0.2 recall=1 unique=1}",
+      ].join("\n"),
+    );
+    fsApi.callbacks.get(path.dirname(diaryPath))?.[0]?.("change", path.basename(diaryPath));
+    await delay(25);
 
-  await handle.stop();
+    assert.equal(rpc.calls.filter((call) => call.method === "promote_dream_entries").length, 1);
+  } finally {
+    await handle?.stop();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/test/unit/dream-promotion.test.ts
+++ b/test/unit/dream-promotion.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { parseDreamPromotionCandidates } from "../../src/dream-promotion.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createDreamPromotionHandle, parseDreamPromotionCandidates, promoteDreamDiaryFile } from "../../src/dream-promotion.js";
 
 test("dream promotion parser only accepts explicit deep-sleep candidate bullets", () => {
   const candidates = parseDreamPromotionCandidates(
@@ -26,4 +30,113 @@ test("dream promotion parser only accepts explicit deep-sleep candidate bullets"
   assert.equal(candidates[0]?.recallCount, 3);
   assert.equal(candidates[0]?.uniqueQueries, 2);
   assert.equal(candidates[1]?.text, "too weak to promote");
+});
+
+test("disabled dream promotion does not validate unused diary paths", () => {
+  assert.doesNotThrow(() => {
+    createDreamPromotionHandle(
+      {
+        dreamPromotionEnabled: false,
+        dreamPromotionDiaryPath: "/etc/passwd",
+        dreamPromotionUserId: "fixed-user",
+      },
+      async () => ({ call: async <T>() => ({ promoted: 0 }) as T }),
+    );
+  });
+});
+
+test("enabled dream promotion validates configured diary paths", () => {
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  delete process.env.OPENCLAW_STATE_DIR;
+
+  try {
+    assert.throws(
+      () => createDreamPromotionHandle(
+        {
+          dreamPromotionEnabled: true,
+          dreamPromotionDiaryPath: "/etc/passwd",
+          dreamPromotionUserId: "fixed-user",
+        },
+        async () => ({ call: async <T>() => ({ promoted: 0 }) as T }),
+      ),
+      /must be within an allowed root/,
+    );
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+  }
+});
+
+test("dream promotion rejects traversal and paths outside allowed roots", async () => {
+  const rpc = { call: async <T>() => ({ promoted: 0 }) as T };
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  delete process.env.OPENCLAW_STATE_DIR;
+
+  try {
+    await assert.rejects(
+      () => promoteDreamDiaryFile(rpc, {
+        userId: "fixed-user",
+        diaryPath: `${os.tmpdir()}/../etc/passwd`,
+        text: "",
+      }),
+      /must not contain "\.\." traversal/,
+    );
+
+    await assert.rejects(
+      () => promoteDreamDiaryFile(rpc, {
+        userId: "fixed-user",
+        diaryPath: "/etc/passwd",
+        text: "",
+      }),
+      /must be within an allowed root/,
+    );
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+  }
+});
+
+test("dream promotion accepts explicit diary files under an allowed root", async () => {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const rpc = {
+    call: async <T>(method: string, params: unknown): Promise<T> => {
+      calls.push({ method, params });
+      return { promoted: 1 } as T;
+    },
+  };
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "libravdb-state-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+
+  try {
+    const diaryPath = path.join(stateDir, "libravdb-dreams.md");
+
+    await promoteDreamDiaryFile(rpc, {
+      userId: "fixed-user",
+      diaryPath,
+      text: [
+        "## Deep Sleep",
+        "- Keep this durable fact {score=0.9 recall=3 unique=2}",
+      ].join("\n"),
+    });
+
+    assert.equal(calls.length, 1);
+    const params = calls[0]?.params as { sourceDoc: string; sourceRoot: string; sourcePath: string };
+    assert.equal(params.sourceDoc, path.resolve(diaryPath));
+    assert.equal(params.sourceRoot, path.dirname(path.resolve(diaryPath)));
+    assert.equal(params.sourcePath, path.basename(diaryPath));
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

`normalizeDiaryPath` accepted any `--dream-file` path via `path.resolve()` and later read it. That means an operator script or automation path could accidentally point dream promotion at files outside the intended diary/state area, including absolute paths like `/etc/passwd`.

This is defense-in-depth for CLI/automation input, not a remote code-execution style vulnerability: someone who can directly choose the CLI argument already has local/operator influence. The useful fix is still to bound the file read to expected local roots.

This PR adds two validations:

1. Reject explicit `..` path segments before resolving.
2. Require the resolved path to live under an allowed local root: home directory, `OPENCLAW_STATE_DIR`, `os.tmpdir()`, or `~/.libravdbd`.

Legitimate diary locations like `~/dreams/diary.md`, files under the configured state dir, or `/tmp/test-diary.md` remain valid.

Closes #122.

## Verification

- `pnpm run plugin:ci`
- `pnpm exec tsc -p tsconfig.tests.json`
- `node --test --test-name-pattern='dream promotion rejects traversal|dream promotion accepts explicit diary' .ts-build/test/unit/dream-promotion.test.js`

The test now calls `promoteDreamDiaryFile()` and asserts behavior for traversal, outside-root, and allowed-root paths instead of grepping source text.

– Vale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dream diary file path validation is now stricter, restricting files to the operator's home directory or configured state directory, and rejecting paths containing directory traversal components or located outside allowed root directories.

* **Documentation**
  * Updated example commands and configuration documentation to clarify dream diary file location requirements and path constraints.

* **Tests**
  * Expanded integration and unit test coverage for dream diary path validation, promotion behavior scenarios, and environment variable management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->