### PR TITLE
fix: validate collection namespace names

### DIFF
--- a/src/memory-scopes.ts
+++ b/src/memory-scopes.ts
@@ -1,6 +1,21 @@
 const SESSION_KEY_NAMESPACE_PREFIX = "session-key:";
 const AGENT_ID_NAMESPACE_PREFIX = "agent-id:";
 
+/** Valid collection names: alphanumeric, underscores, hyphens, dots, colons, at-signs.
+ *  Must start with a letter. Max 128 characters. */
+const COLLECTION_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.:@-]{0,127}$/;
+
+/** Validate and return a collection-safe namespace.
+ *  Throws on invalid characters or length. */
+export function validateNamespace(name: string): string {
+  if (!COLLECTION_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid collection namespace: "${name}". Must match ${COLLECTION_NAME_RE.source}`,
+    );
+  }
+  return name;
+}
+
 export type RetrievalScopes = {
   /** Always queried — fresh context bound to this session. */
   session: string;
@@ -18,15 +33,18 @@ export function resolveDurableNamespace(params: {
   fallback?: string;
 }): string {
   const explicitUserId = firstNonEmpty(params.userId);
-  if (explicitUserId) return explicitUserId;
+  if (explicitUserId) return validateNamespace(explicitUserId);
 
   const sessionKey = firstNonEmpty(params.sessionKey);
-  if (sessionKey) return `${SESSION_KEY_NAMESPACE_PREFIX}${sessionKey}`;
+  if (sessionKey) return validateNamespace(`${SESSION_KEY_NAMESPACE_PREFIX}${sessionKey}`);
 
   const agentId = firstNonEmpty(params.agentId);
-  if (agentId) return `${AGENT_ID_NAMESPACE_PREFIX}${agentId}`;
+  if (agentId) return validateNamespace(`${AGENT_ID_NAMESPACE_PREFIX}${agentId}`);
 
-  return firstNonEmpty(params.fallback) ?? "default";
+  const fallback = firstNonEmpty(params.fallback);
+  if (fallback) return validateNamespace(fallback);
+
+  return "default";
 }
 
 export function resolveScopes(params: {

--- a/src/memory-scopes.ts
+++ b/src/memory-scopes.ts
@@ -1,9 +1,9 @@
 const SESSION_KEY_NAMESPACE_PREFIX = "session-key:";
 const AGENT_ID_NAMESPACE_PREFIX = "agent-id:";
 
-/** Valid collection names: alphanumeric, underscores, hyphens, dots, colons, at-signs.
+/** Valid collection names: alphanumeric, underscores, hyphens, dots, colons, at-signs, hashes.
  *  Must start with a letter. Max 128 characters. */
-const COLLECTION_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.:@-]{0,127}$/;
+const COLLECTION_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.:@#-]{0,127}$/;
 
 /** Validate and return a collection-safe namespace.
  *  Throws on invalid characters or length. */

--- a/test/unit/memory-scopes.test.ts
+++ b/test/unit/memory-scopes.test.ts
@@ -28,6 +28,7 @@ test("validateNamespace rejects invalid collection names", () => {
   assert.equal(validateNamespace("user-1"), "user-1");
   assert.equal(validateNamespace("session-key:abc"), "session-key:abc");
   assert.equal(validateNamespace("agent-id:my-agent"), "agent-id:my-agent");
+  assert.equal(validateNamespace("computment@COMPUTMENT#1fb3bb24"), "computment@COMPUTMENT#1fb3bb24");
   assert.equal(validateNamespace("a"), "a");
 
   // Invalid names

--- a/test/unit/memory-scopes.test.ts
+++ b/test/unit/memory-scopes.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveDurableNamespace } from "../../src/memory-scopes.js";
+import { resolveDurableNamespace, validateNamespace } from "../../src/memory-scopes.js";
 
 test("resolveDurableNamespace trims inputs and prefers sessionKey over agentId", () => {
   assert.equal(
@@ -21,4 +21,19 @@ test("resolveDurableNamespace trims inputs and prefers sessionKey over agentId",
 test("resolveDurableNamespace trims fallback values and rejects blank fallback strings", () => {
   assert.equal(resolveDurableNamespace({ fallback: "  custom-fallback  " }), "custom-fallback");
   assert.equal(resolveDurableNamespace({ fallback: "   " }), "default");
+});
+
+test("validateNamespace rejects invalid collection names", () => {
+  // Valid names
+  assert.equal(validateNamespace("user-1"), "user-1");
+  assert.equal(validateNamespace("session-key:abc"), "session-key:abc");
+  assert.equal(validateNamespace("agent-id:my-agent"), "agent-id:my-agent");
+  assert.equal(validateNamespace("a"), "a");
+
+  // Invalid names
+  assert.throws(() => validateNamespace(""), /Invalid collection namespace/);
+  assert.throws(() => validateNamespace("../etc/passwd"), /Invalid collection namespace/);
+  assert.throws(() => validateNamespace("1starts-with-number"), /Invalid collection namespace/);
+  assert.throws(() => validateNamespace("has spaces"), /Invalid collection namespace/);
+  assert.throws(() => validateNamespace("has\nnewline"), /Invalid collection namespace/);
 });


### PR DESCRIPTION
## Summary

`resolveDurableNamespace` accepted arbitrary `userId` / fallback namespace strings and passed them through as RPC collection names. That can create confusing or unsafe namespace names (`../x`, embedded control characters, spaces, null bytes) and push validation ambiguity downstream into the daemon.

This is mostly hygiene/misconfiguration hardening, not a strong untrusted-input exploit path: the values are operator/config/session-derived. Still, validating collection names at the plugin boundary gives clearer failures and avoids malformed collection identifiers.

This PR adds `validateNamespace()` with:

```ts
/^[a-zA-Z][a-zA-Z0-9_.:@#-]{0,127}$/
```

That allows common identifiers (`user-1`, `session-key:abc`, `agent-id:my-agent`) while rejecting traversal-ish names, whitespace, null bytes, and other awkward characters.

`resolveDurableNamespace` now validates every returned namespace.

Closes #124.

## Compatibility note

This is a behavior change: fallback namespace values that previously worked despite spaces, leading digits, or other disallowed characters will now throw a descriptive error. That is intentional, but it should be treated as a config validation tightening rather than invisible behavior preservation.

## Verification

- Namespace validation unit tests cover accepted and rejected names.
- Existing `resolveDurableNamespace` tests cover the integration path.

– Vale

Closes #124