### PR TITLE
fix: default-exclude generated markdown dirs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |
 | `markdownIngestionObsidianInclude` | string[] | — | Obsidian glob include patterns |
-| `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
+| `markdownIngestionObsidianExclude` | string[] | common dependency/build dirs | Obsidian glob exclude patterns; merged with the same default excludes as generic markdown ingestion |
 | `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
 
 ## Dream promotion

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionEnabled` | boolean | `false` | Watch markdown roots for changes |
 | `markdownIngestionRoots` | string[] | — | Directories to watch |
 | `markdownIngestionInclude` | string[] | — | Glob patterns to include |
-| `markdownIngestionExclude` | string[] | — | Glob patterns to exclude |
+| `markdownIngestionExclude` | string[] | common dependency/build dirs | Glob patterns to exclude; merged with default excludes such as `node_modules/**`, `.git/**`, `dist/**`, and `build/**` |
 | `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionEnabled` | boolean | `false` | Watch markdown roots for changes |
 | `markdownIngestionRoots` | string[] | — | Directories to watch |
 | `markdownIngestionInclude` | string[] | — | Glob patterns to include |
-| `markdownIngestionExclude` | string[] | common dependency/build dirs | Glob patterns to exclude; merged with default excludes such as `node_modules/**`, `.git/**`, `dist/**`, and `build/**` |
+| `markdownIngestionExclude` | string[] | common dependency/build dirs | Glob patterns to exclude; merged with default excludes such as `node_modules/**`, `**/node_modules/**`, `.git/**`, `dist/**`, and `build/**` |
 | `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,7 +53,7 @@ Relevant config fields:
 | `markdownIngestionEnabled` | Enables or disables generic markdown ingestion. |
 | `markdownIngestionRoots` | Generic markdown roots to watch. |
 | `markdownIngestionInclude` | Optional include globs for generic roots. |
-| `markdownIngestionExclude` | Optional exclude globs for generic roots; merged with default excludes for dependency/build dirs such as `node_modules/**`, `.git/**`, `dist/**`, and `build/**`. |
+| `markdownIngestionExclude` | Optional exclude globs for generic roots; merged with default excludes for dependency/build dirs such as `node_modules/**`, `**/node_modules/**`, `.git/**`, `dist/**`, and `build/**`. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
@@ -63,7 +63,7 @@ Relevant config fields:
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,
 using frontmatter tags or inline tags such as `#project`. The stock OpenClaw
-`MEMORY.md` file is always eligible through the generic adapter path. Generic markdown ingestion skips common generated or dependency directories by default so workspace-level roots do not crawl package changelogs, build outputs, or VCS internals.
+`MEMORY.md` file is always eligible through the generic adapter path. Generic markdown ingestion skips common generated or dependency directories at any depth by default so workspace-level roots do not crawl package changelogs, build outputs, or VCS internals.
 
 ## Dream Promotion
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -58,7 +58,7 @@ Relevant config fields:
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
 | `markdownIngestionObsidianInclude` | Optional include globs for Obsidian roots. |
-| `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots. |
+| `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots; merged with the same default excludes as generic markdown ingestion. |
 | `markdownIngestionObsidianDebounceMs` | Obsidian watch debounce window, default `150`. |
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,7 +53,7 @@ Relevant config fields:
 | `markdownIngestionEnabled` | Enables or disables generic markdown ingestion. |
 | `markdownIngestionRoots` | Generic markdown roots to watch. |
 | `markdownIngestionInclude` | Optional include globs for generic roots. |
-| `markdownIngestionExclude` | Optional exclude globs for generic roots. |
+| `markdownIngestionExclude` | Optional exclude globs for generic roots; merged with default excludes for dependency/build dirs such as `node_modules/**`, `.git/**`, `dist/**`, and `build/**`. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
@@ -63,7 +63,7 @@ Relevant config fields:
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,
 using frontmatter tags or inline tags such as `#project`. The stock OpenClaw
-`MEMORY.md` file is always eligible through the generic adapter path.
+`MEMORY.md` file is always eligible through the generic adapter path. Generic markdown ingestion skips common generated or dependency directories by default so workspace-level roots do not crawl package changelogs, build outputs, or VCS internals.
 
 ## Dream Promotion
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -198,6 +198,21 @@
       },
       "markdownIngestionExclude": {
         "type": "array",
+        "default": [
+          "node_modules/**",
+          ".git/**",
+          "dist/**",
+          "build/**",
+          "coverage/**",
+          ".next/**",
+          ".nuxt/**",
+          ".svelte-kit/**",
+          ".turbo/**",
+          ".cache/**",
+          ".venv/**",
+          "venv/**",
+          "__pycache__/**"
+        ],
         "items": {
           "type": "string"
         }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -182,6 +182,34 @@
       },
       "markdownIngestionObsidianExclude": {
         "type": "array",
+        "default": [
+          "node_modules/**",
+          "**/node_modules/**",
+          ".git/**",
+          "**/.git/**",
+          "dist/**",
+          "**/dist/**",
+          "build/**",
+          "**/build/**",
+          "coverage/**",
+          "**/coverage/**",
+          ".next/**",
+          "**/.next/**",
+          ".nuxt/**",
+          "**/.nuxt/**",
+          ".svelte-kit/**",
+          "**/.svelte-kit/**",
+          ".turbo/**",
+          "**/.turbo/**",
+          ".cache/**",
+          "**/.cache/**",
+          ".venv/**",
+          "**/.venv/**",
+          "venv/**",
+          "**/venv/**",
+          "__pycache__/**",
+          "**/__pycache__/**"
+        ],
         "items": {
           "type": "string"
         }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -200,18 +200,31 @@
         "type": "array",
         "default": [
           "node_modules/**",
+          "**/node_modules/**",
           ".git/**",
+          "**/.git/**",
           "dist/**",
+          "**/dist/**",
           "build/**",
+          "**/build/**",
           "coverage/**",
+          "**/coverage/**",
           ".next/**",
+          "**/.next/**",
           ".nuxt/**",
+          "**/.nuxt/**",
           ".svelte-kit/**",
+          "**/.svelte-kit/**",
           ".turbo/**",
+          "**/.turbo/**",
           ".cache/**",
+          "**/.cache/**",
           ".venv/**",
+          "**/.venv/**",
           "venv/**",
-          "__pycache__/**"
+          "**/venv/**",
+          "__pycache__/**",
+          "**/__pycache__/**"
         ],
         "items": {
           "type": "string"

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -13,18 +13,31 @@ const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
 const DEFAULT_MARKDOWN_INGEST_EXCLUDES = [
   "node_modules/**",
+  "**/node_modules/**",
   ".git/**",
+  "**/.git/**",
   "dist/**",
+  "**/dist/**",
   "build/**",
+  "**/build/**",
   "coverage/**",
+  "**/coverage/**",
   ".next/**",
+  "**/.next/**",
   ".nuxt/**",
+  "**/.nuxt/**",
   ".svelte-kit/**",
+  "**/.svelte-kit/**",
   ".turbo/**",
+  "**/.turbo/**",
   ".cache/**",
+  "**/.cache/**",
   ".venv/**",
+  "**/.venv/**",
   "venv/**",
+  "**/venv/**",
   "__pycache__/**",
+  "**/__pycache__/**",
 ];
 type Disposable = { close(): void };
 

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -11,6 +11,21 @@ const DEFAULT_DEBOUNCE_MS = 150;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
+const DEFAULT_MARKDOWN_INGEST_EXCLUDES = [
+  "node_modules/**",
+  ".git/**",
+  "dist/**",
+  "build/**",
+  "coverage/**",
+  ".next/**",
+  ".nuxt/**",
+  ".svelte-kit/**",
+  ".turbo/**",
+  ".cache/**",
+  ".venv/**",
+  "venv/**",
+  "__pycache__/**",
+];
 type Disposable = { close(): void };
 
 interface RpcLike {
@@ -206,7 +221,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.kind = kind;
     this.roots = config.roots;
     this.includePatterns = config.include?.length ? config.include : [];
-    this.excludePatterns = config.exclude?.length ? config.exclude : [];
+    this.excludePatterns = mergeDefaultMarkdownIngestionExcludes(config.exclude);
     this.debounceMs = config.debounceMs ?? DEFAULT_DEBOUNCE_MS;
     this.fsApi = fsApi;
     this.getRpc = getRpc;
@@ -350,6 +365,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       const child = path.join(dir, entry.name);
       if (entry.isDirectory()) {
+        if (this.shouldSkipDirectory(rootState.root, child)) {
+          continue;
+        }
         await this.walkDirectory(rootState, child, currentFiles);
         continue;
       }
@@ -388,6 +406,20 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     } catch (error) {
       this.logger.warn?.(`[markdown-ingest] watch unavailable for ${dir}: ${formatError(error)}`);
     }
+  }
+
+  private shouldSkipDirectory(root: string, dirPath: string): boolean {
+    const relative = toPosixPath(path.relative(root, dirPath));
+    if (!relative) {
+      return false;
+    }
+    const directoryPath = `${relative}/`;
+    for (const pattern of this.excludePatterns) {
+      if (matchesGlob(directoryPath, pattern) || matchesGlob(relative, pattern)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private shouldIncludeFile(root: string, filePath: string): boolean {
@@ -546,6 +578,17 @@ function toPosixPath(value: string): string {
 }
 
 const textDecoder = new TextDecoder();
+
+function mergeDefaultMarkdownIngestionExcludes(exclude?: string[]): string[] {
+  const merged = new Set(DEFAULT_MARKDOWN_INGEST_EXCLUDES);
+  for (const pattern of exclude ?? []) {
+    const trimmed = pattern.trim();
+    if (trimmed) {
+      merged.add(trimmed);
+    }
+  }
+  return [...merged];
+}
 
 function normalizeMarkdownRoots(roots?: string[]): string[] {
   if (!roots?.length) {

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -162,6 +162,46 @@ test("markdown ingestion forwards raw markdown to the go sidecar and stays hash-
   await handle.stop();
 });
 
+test("markdown ingestion default-excludes dependency and build directories", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-default-exclude-"));
+  const keepPath = path.join(tempRoot, "docs", "guide.md");
+  const nodeModulesPath = path.join(tempRoot, "node_modules", "pkg", "CHANGELOG.md");
+  const gitPath = path.join(tempRoot, ".git", "README.md");
+  const distPath = path.join(tempRoot, "dist", "README.md");
+  await fsp.mkdir(path.dirname(keepPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nodeModulesPath), { recursive: true });
+  await fsp.mkdir(path.dirname(gitPath), { recursive: true });
+  await fsp.mkdir(path.dirname(distPath), { recursive: true });
+  await fsp.writeFile(keepPath, "# Keep\n\nThis user-authored doc should ingest.");
+  await fsp.writeFile(nodeModulesPath, "# Changelog\n\nDependency docs should not ingest.");
+  await fsp.writeFile(gitPath, "# Git internals\n\nThis should not ingest.");
+  await fsp.writeFile(distPath, "# Build output\n\nThis should not ingest.");
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+    },
+    async () => rpc,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 1);
+  assert.equal(rpc.documents.has(keepPath), true);
+  assert.equal(rpc.documents.has(nodeModulesPath), false);
+  assert.equal(rpc.documents.has(gitPath), false);
+  assert.equal(rpc.documents.has(distPath), false);
+  assert.equal(fsApi.callbacks.has(path.join(tempRoot, "node_modules")), false, "excluded directories should not be watched");
+
+  await handle.stop();
+});
+
 test("obsidian markdown ingestion flips source kind while reusing the same rpc path", async () => {
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-obsidian-"));
   const filePath = path.join(tempRoot, "memory.md");

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -168,14 +168,20 @@ test("markdown ingestion default-excludes dependency and build directories", asy
   const nodeModulesPath = path.join(tempRoot, "node_modules", "pkg", "CHANGELOG.md");
   const gitPath = path.join(tempRoot, ".git", "README.md");
   const distPath = path.join(tempRoot, "dist", "README.md");
+  const nestedNodeModulesPath = path.join(tempRoot, "packages", "app", "node_modules", "pkg", "README.md");
+  const nestedBuildPath = path.join(tempRoot, "packages", "app", "build", "README.md");
   await fsp.mkdir(path.dirname(keepPath), { recursive: true });
   await fsp.mkdir(path.dirname(nodeModulesPath), { recursive: true });
   await fsp.mkdir(path.dirname(gitPath), { recursive: true });
   await fsp.mkdir(path.dirname(distPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nestedNodeModulesPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nestedBuildPath), { recursive: true });
   await fsp.writeFile(keepPath, "# Keep\n\nThis user-authored doc should ingest.");
   await fsp.writeFile(nodeModulesPath, "# Changelog\n\nDependency docs should not ingest.");
   await fsp.writeFile(gitPath, "# Git internals\n\nThis should not ingest.");
   await fsp.writeFile(distPath, "# Build output\n\nThis should not ingest.");
+  await fsp.writeFile(nestedNodeModulesPath, "# Nested dependency docs\n\nThis should not ingest.");
+  await fsp.writeFile(nestedBuildPath, "# Nested build output\n\nThis should not ingest.");
 
   const rpc = new FakeRpcClient();
   const fsApi = new FakeFsApi();
@@ -197,7 +203,10 @@ test("markdown ingestion default-excludes dependency and build directories", asy
   assert.equal(rpc.documents.has(nodeModulesPath), false);
   assert.equal(rpc.documents.has(gitPath), false);
   assert.equal(rpc.documents.has(distPath), false);
+  assert.equal(rpc.documents.has(nestedNodeModulesPath), false);
+  assert.equal(rpc.documents.has(nestedBuildPath), false);
   assert.equal(fsApi.callbacks.has(path.join(tempRoot, "node_modules")), false, "excluded directories should not be watched");
+  assert.equal(fsApi.callbacks.has(path.join(tempRoot, "packages", "app", "node_modules")), false, "nested excluded directories should not be watched");
 
   await handle.stop();
 });


### PR DESCRIPTION
## Summary

Adds default markdown ingestion excludes for dependency, VCS, cache, virtualenv, and build-output directories.

## Scope

- Adds default exclude patterns to plugin config/schema/docs.
- Skips excluded directories during traversal before attaching watchers.
- Adds markdown-ingest integration coverage for default excludes.

## Dependencies

- Must merge after #111. This PR depends on recursive glob patterns such as `**/node_modules/**` working correctly.
- Current merge state is `DIRTY`; rebase is required before review.

## Audit Notes

- This reduces the practical workspace-footgun from generated/dependency directories.
- It does not add a hard parent-boundary policy for arbitrary configured roots; #121 remains separate.
- After rebase, verify the default excludes still match the glob semantics introduced by #111.

## Review Follow-up

- Branch is `DIRTY`; rebase after #111 before review.
- Decide whether default excludes are intentionally non-removable. If users need to ingest `.cache` or similar dirs, add an opt-out/negation design separately.
- Manifest defaults duplicate the runtime default list; acceptable for now, but keep both in sync.
- Root-level and `**/` pattern pairs are partly redundant but harmless; simplify only if tests still cover top-level and nested dirs.
- A direct `shouldSkipDirectory` unit test would be useful, though current integration coverage proves the main behavior.

## Verification

- `pnpm run check`
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/markdown-ingest.test.js`
- `npm run test:integration` was previously blocked by an unrelated degraded-sidecar test failure; markdown-ingest cases passed.

Closes #118.
Depends on #111.

– Vale