### PR TITLE
fix: preserve sidecar retry budget across reconnects

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -245,7 +245,6 @@ class SidecarSupervisor implements SidecarHandle {
   async start(): Promise<SidecarSocket> {
     const endpoint = await this.runtime.resolveEndpoint(this.cfg);
     const socket = await this.connectEndpointWithRetry(endpoint);
-    this.retries = 0;
     this.reconnectScheduled = false;
     if (this.socket instanceof SupervisorSocket) {
       this.socket.bind(socket);


### PR DESCRIPTION
## Summary

`SidecarSupervisor.start()` was resetting `this.retries = 0` on every successful reconnect, which made the retry budget appear fresh after each crash/reconnect cycle. With `maxRetries: 1`, a sidecar could crash and reconnect indefinitely without ever entering degraded mode — the integration test for this scenario was failing on main.

The fix removes the `this.retries = 0` reset from `start()`. The retry budget is now cumulative over the supervisor's lifetime: once the supervisor has scheduled `maxRetries` reconnection attempts, further crashes immediately enter degraded mode regardless of whether earlier reconnects succeeded. `this.reconnectScheduled = false` is kept as it only guards against duplicate reconnect scheduling.

## Verification

```sh
pnpm run test:inspect
pnpm exec tsc -p tsconfig.tests.json
node --test .ts-build/test/integration/sidecar-lifecycle.test.js
node --test .ts-build/test/unit/sidecar.test.js
```

All 6 integration tests pass (including the previously failing "sidecar enters degraded mode after exhausting retry budget"), all 11 unit tests pass.

Fixes xDarkicex/openclaw-memory-libravdb#132

– Vale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection stability and recovery behavior by ensuring proper retry state management during reconnection attempts. The system now maintains consistent tracking of connection retry cycles, preventing unexpected counter resets and enhancing overall fault tolerance capabilities during temporary network interruptions, connectivity issues, or service unavailability scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->