### PR TITLE
fix: suppress sidecar reconnect after shutdown

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -331,6 +331,10 @@ class SidecarSupervisor implements SidecarHandle {
     this.retries += 1;
     this.reconnectScheduled = true;
     this.runtime.scheduleRestart(backoffMs, () => {
+      if (this.shuttingDown) {
+        this.reconnectScheduled = false;
+        return;
+      }
       void this.start().catch((error) => {
         this.reconnectScheduled = false;
         const message = error instanceof Error ? error.message : String(error);

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -9,7 +9,108 @@ import {
   isTcpEndpoint,
   resolveConfiguredEndpoint,
   resolveEndpoint,
+  startSidecar,
+  type SidecarRuntime,
 } from "../../src/sidecar.js";
+import type { SidecarSocket } from "../../src/types.js";
+
+type UnitCloseHandler = () => void;
+type UnitDataHandler = (chunk: Buffer) => void;
+type UnitErrorHandler = (error: Error) => void;
+
+class ManualSidecarSocket implements SidecarSocket {
+  private readonly onData = new Set<UnitDataHandler>();
+  private readonly onClose = new Set<UnitCloseHandler>();
+  private readonly onError = new Set<UnitErrorHandler>();
+  private readonly connectOnce = new Set<UnitCloseHandler>();
+  private readonly errorOnce = new Set<UnitErrorHandler>();
+
+  constructor(readonly endpoint: string) {
+    queueMicrotask(() => this.emitConnect());
+  }
+
+  setEncoding(_encoding: string): void {}
+
+  on(event: "data" | "close" | "error", handler: UnitDataHandler | UnitCloseHandler | UnitErrorHandler): void {
+    if (event === "data") {
+      this.onData.add(handler as UnitDataHandler);
+      return;
+    }
+    if (event === "error") {
+      this.onError.add(handler as UnitErrorHandler);
+      return;
+    }
+    this.onClose.add(handler as UnitCloseHandler);
+  }
+
+  once(event: "connect" | "error", handler: UnitCloseHandler | UnitErrorHandler): void {
+    if (event === "connect") {
+      this.connectOnce.add(handler as UnitCloseHandler);
+      return;
+    }
+    this.errorOnce.add(handler as UnitErrorHandler);
+  }
+
+  off(event: "connect" | "error", handler: UnitCloseHandler | UnitErrorHandler): void {
+    if (event === "connect") {
+      this.connectOnce.delete(handler as UnitCloseHandler);
+      return;
+    }
+    this.errorOnce.delete(handler as UnitErrorHandler);
+  }
+
+  write(_chunk: Buffer | string): void {}
+
+  destroy(_err?: Error): void {
+    this.emitClose();
+  }
+
+  emitClose(): void {
+    for (const handler of this.onClose) {
+      handler();
+    }
+  }
+
+  emitError(error: Error): void {
+    for (const handler of this.onError) {
+      handler(error);
+    }
+    for (const handler of this.errorOnce) {
+      handler(error);
+    }
+    this.errorOnce.clear();
+  }
+
+  private emitConnect(): void {
+    for (const handler of this.connectOnce) {
+      handler();
+    }
+    this.connectOnce.clear();
+  }
+}
+
+function createManualRestartRuntime() {
+  const sockets: ManualSidecarSocket[] = [];
+  const scheduled: Array<{ delayMs: number; restart: () => void }> = [];
+
+  const runtime: SidecarRuntime = {
+    resolveEndpoint: () => "unix:/tmp/libravdb.sock",
+    createSocket(endpoint) {
+      const socket = new ManualSidecarSocket(endpoint);
+      sockets.push(socket);
+      return socket;
+    },
+    scheduleRestart(delayMs, restart) {
+      scheduled.push({ delayMs, restart });
+    },
+  };
+
+  return { runtime, sockets, scheduled };
+}
+
+function flushAsyncWork(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 test("resolveEndpoint strips unix prefix and keeps tcp endpoints", () => {
   assert.equal(resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: "unix:/tmp/x.sock" }), "/tmp/x.sock");
@@ -76,6 +177,25 @@ test("computeBackoffMs applies capped exponential backoff", () => {
   assert.equal(computeBackoffMs(0), 500);
   assert.equal(computeBackoffMs(1), 1000);
   assert.equal(computeBackoffMs(10), 16000);
+});
+
+test("shutdown suppresses a previously scheduled sidecar reconnect", async () => {
+  const runtime = createManualRestartRuntime();
+  const logger = { error() {}, info() {}, warn() {} };
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 2 }, logger, runtime.runtime);
+
+  assert.equal(runtime.sockets.length, 1);
+  runtime.sockets[0]?.emitClose();
+  await flushAsyncWork();
+
+  assert.equal(runtime.scheduled.length, 1);
+  await handle.shutdown();
+
+  runtime.scheduled[0]?.restart();
+  await flushAsyncWork();
+
+  assert.equal(runtime.sockets.length, 1);
+  assert.equal(handle.isDegraded(), false);
 });
 
 test("isTcpEndpoint detects tcp endpoints", () => {


### PR DESCRIPTION
## Summary

Fixes #136.

If the sidecar crashed and scheduled a reconnect, then the plugin/runtime shut down before the scheduled callback fired, the callback still called `start()` and created a new socket after shutdown.

This PR guards the scheduled reconnect callback with `this.shuttingDown`, clears `reconnectScheduled`, and returns without reconnecting once shutdown has begun.

## Regression coverage

Adds a unit test that:

1. starts the sidecar supervisor with a manual restart runtime,
2. emits a close to schedule a reconnect,
3. calls `shutdown()` before the scheduled callback runs,
4. runs the scheduled callback,
5. asserts that no second socket was created.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/sidecar.test.js` — PASS
- `pnpm run check` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this shutdown-reconnect guard.

– Vale
