### PR TITLE
fix: remove conversation-gated agent_end hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,21 +162,9 @@ export function register(api: OpenClawPluginApi) {
 
   api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
   api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
-  api.on("agent_end", async (event: unknown) => {
-    const e = asRecord(event) ?? {};
-    logger.info?.(
-      `LibraVDB agent_end success=${e.success ?? 'unknown'} ` +
-      `durationMs=${e.durationMs ?? "?"} ` +
-      `error=${typeof e.error === "string" ? e.error : "none"}`,
-    );
-  });
   api.on("gateway_stop", async () => {
     await runtime.shutdown();
   });
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
 }
 
 export default definePluginEntry({

--- a/src/lifecycle-hooks.ts
+++ b/src/lifecycle-hooks.ts
@@ -52,13 +52,21 @@ export function createSessionEndHook(runtime: PluginRuntime, logger: LoggerLike 
   return async (event: unknown, ctx: unknown): Promise<void> => {
     const typedEvent = asSessionEndEvent(event);
     const typedCtx = asAgentContext(ctx);
+    const sessionId = typedEvent.sessionId ?? typedCtx.sessionId;
+    const sessionKey = typedEvent.sessionKey ?? typedCtx.sessionKey;
     try {
+      logger.info?.(
+        `LibraVDB session_end sessionId=${sessionId ?? "(unknown)"} ` +
+        `messageCount=${typedEvent.messageCount ?? "?"} ` +
+        `durationMs=${typedEvent.durationMs ?? "?"} ` +
+        `reason=${typedEvent.reason ?? "unknown"}`,
+      );
       await runtime.emitLifecycleHint({
         hook: "session_end",
         reason: typedEvent.reason,
         sessionFile: typedEvent.sessionFile,
-        sessionId: typedEvent.sessionId ?? typedCtx.sessionId,
-        sessionKey: typedEvent.sessionKey ?? typedCtx.sessionKey,
+        sessionId,
+        sessionKey,
         agentId: typedCtx.agentId,
         workspaceDir: typedCtx.workspaceDir,
         messageCount: typedEvent.messageCount,

--- a/test/unit/lifecycle-hooks.test.ts
+++ b/test/unit/lifecycle-hooks.test.ts
@@ -54,7 +54,14 @@ test("before_reset hook forwards advisory reset context to the runtime", async (
 
 test("session_end hook forwards advisory end metadata to the runtime", async () => {
   const { runtime, hints } = createRuntimeRecorder();
-  const hook = createSessionEndHook(runtime);
+  const infos: string[] = [];
+  const hook = createSessionEndHook(runtime, {
+    error() {},
+    info(message: string) {
+      infos.push(message);
+    },
+    warn() {},
+  });
 
   await hook(
     {
@@ -90,4 +97,7 @@ test("session_end hook forwards advisory end metadata to the runtime", async () 
       nextSessionKey: "session-key-3",
     },
   ]);
+  assert.match(infos[0] ?? "", /LibraVDB session_end/);
+  assert.match(infos[0] ?? "", /sessionId=session-2/);
+  assert.match(infos[0] ?? "", /durationMs=4200/);
 });


### PR DESCRIPTION
## Summary

Fixes #130.

LibraVDB registered `agent_end` only to log turn-completion metadata. In current OpenClaw builds, `agent_end` is conversation-access gated for non-bundled plugins, so registering it can be blocked unless users configure `allowConversationAccess`.

This PR removes the `agent_end` registration and keeps observability on the existing `session_end` hook, which is not conversation-gated and already carries non-sensitive lifecycle metadata.

## Changes

- Remove `api.on("agent_end", ...)` from plugin registration.
- Remove the now-unused `asRecord` helper in `src/index.ts`.
- Add `session_end` metadata logging in `createSessionEndHook`.
- Extend lifecycle hook unit coverage for the new session-end log line.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/lifecycle-hooks.test.js .ts-build/test/integration/checklist-validation.test.js` — PASS
- `pnpm run check` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this hook-registration change.

– Vale
