### PR TITLE
fix: require force for status index rebuild

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ type CliOptionBag = {
   yes?: boolean;
   json?: boolean;
   deep?: boolean;
+  index?: boolean;
   fix?: boolean;
   force?: boolean;
   verbose?: boolean;
@@ -119,7 +120,8 @@ export function registerMemoryCli(
         .option("--agent <id>", "Agent id")
         .option("--json", "Print JSON")
         .option("--deep", "Probe authored collection search health")
-        .option("--index", "Refresh delegated index state before printing status")
+        .option("--index", "Rebuild the index before printing status")
+        .option("--force", "Required with --index: confirm index rebuild")
         .option("--fix", "Accepted for OpenClaw memory CLI compatibility")
         .option("--verbose", "Verbose logging")
         .action(async (opts) => {
@@ -250,6 +252,18 @@ async function runStatus(
   logger: LoggerLike,
   opts: CliOptionBag = {},
 ): Promise<void> {
+  if (opts.index) {
+    if (!opts.force) {
+      logger.error("LibraVDB status --index performs an index rebuild. Re-run with --force to continue.");
+      process.exitCode = 1;
+      return;
+    }
+    const ok = await runIndex(runtime, cfg, { ...opts, verbose: false }, logger, { quiet: true });
+    if (!ok) {
+      return;
+    }
+  }
+
   try {
     const rpc = await runtime.getRpc();
     const status = await rpc.call<StatusResult>("status", {});
@@ -371,11 +385,11 @@ async function runIndex(
   opts: CliOptionBag | undefined,
   logger: LoggerLike,
   params: { quiet?: boolean } = {},
-): Promise<void> {
+): Promise<boolean> {
   if (!opts?.force) {
     logger.error("LibraVDB index rebuild requires --force. This re-embeds all stored documents with the current model and may be slow.");
     process.exitCode = 1;
-    return;
+    return false;
   }
 
   const namespace = resolveCliNamespace(opts);
@@ -411,10 +425,13 @@ async function runIndex(
     if ((result.errors?.length ?? 0) > 0 && (result.recordsReindexed ?? 0) === 0) {
       logger.error("LibraVDB index rebuild completed with errors and no records reindexed.");
       process.exitCode = 1;
+      return false;
     }
+    return true;
   } catch (error) {
     logger.error(`LibraVDB index rebuild failed: ${formatError(error)}`);
     process.exitCode = 1;
+    return false;
   }
 }
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -144,6 +144,8 @@ test("full CLI registration exposes standard memory commands and LibraVDB operat
   assert.ok(status);
   assert.ok(status.options.includes("--json"));
   assert.ok(status.options.includes("--agent <id>"));
+  assert.ok(status.options.includes("--index"));
+  assert.ok(status.options.includes("--force"));
 
   const search = memory.commands.find((command) => command.name() === "search");
   assert.ok(search);
@@ -224,6 +226,141 @@ test("status command shuts the plugin runtime down after printing status", async
     console.table = originalTable;
   }
 
+  assert.equal(shutdownCalls, 1);
+});
+
+test("status --index requires --force before rebuilding", async () => {
+  let registered: RegisteredCli | null = null;
+  let shutdownCalls = 0;
+  let getRpcCalls = 0;
+  const errors: string[] = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        getRpcCalls += 1;
+        throw new Error("status --index without --force should not start RPC");
+      },
+      async getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      onShutdown() {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+    {
+      error(message: string) {
+        errors.push(message);
+      },
+    },
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const status = memory?.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    await status.handler?.({ index: true });
+    assert.equal(process.exitCode, 1);
+  } finally {
+    process.exitCode = previousExitCode;
+  }
+
+  assert.equal(getRpcCalls, 0);
+  assert.equal(shutdownCalls, 1);
+  assert.match(errors[0] ?? "", /--force/);
+});
+
+test("status --index --force rebuilds before printing status", async () => {
+  let registered: RegisteredCli | null = null;
+  let shutdownCalls = 0;
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>) {
+            calls.push({ method, params });
+            if (method === "rebuild_index") {
+              return {
+                collectionsProcessed: 1,
+                recordsReindexed: 2,
+                collectionsRecreated: 0,
+                errors: [],
+              };
+            }
+            if (method === "status") {
+              return {
+                ok: true,
+                turnCount: 3,
+                memoryCount: 3,
+                lifecycleHintCount: 1,
+                gatingThreshold: 0.35,
+                abstractiveReady: true,
+                embeddingProfile: "all-minilm-l6-v2",
+                message: "ok",
+              };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      async getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      onShutdown() {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const status = memory?.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const originalTable = console.table;
+  console.table = (() => undefined) as typeof console.table;
+  try {
+    await status.handler?.({ index: true, force: true });
+  } finally {
+    console.table = originalTable;
+  }
+
+  assert.deepEqual(calls.map((call) => call.method), ["rebuild_index", "status"]);
+  assert.deepEqual(calls[0]?.params, { namespace: "" });
   assert.equal(shutdownCalls, 1);
 });
 


### PR DESCRIPTION
## Summary

- Make `memory status --index` an explicit rebuild path instead of a silent no-op.
- Require `--force` when `--index` is used from `status`, matching the safety contract of `memory index --force`.
- Return early when the rebuild guard or rebuild itself fails, and only print status after a successful rebuild.
- Add CLI regression coverage for both the missing-force guard and the `rebuild_index` then `status` RPC order.

Closes #137.

## Verification

- `pnpm run test:inspect` — PASS
- `pnpm exec tsc -p tsconfig.tests.json` — PASS
- `node --test .ts-build/test/unit/cli.test.js` — PASS
- `pnpm run check` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget`, reproduced unchanged on `main`; tracked by #132 / #134 and unrelated to this CLI change.

– Vale

Fixes #137