### PR TITLE
fix: trim runtime memory search inputs

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -225,7 +225,16 @@ function resolveSessionSearchCollection(cfg: PluginConfig, sessionId: string): s
 }
 
 function firstString(...values: Array<string | undefined>): string | undefined {
-  return values.find((value) => typeof value === "string" && value.length > 0);
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return undefined;
 }
 
 function toMemorySearchResult(item: SearchResult) {

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -181,12 +181,51 @@ test("memory runtime bridge respects disabled cross-session recall", async () =>
   assert.equal(result.length, 1);
 });
 
+test("memory runtime bridge treats whitespace-only structured queries as missing", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "   " });
+
+  assert.deepEqual(result, []);
+  assert.deepEqual(rpc.calls.map((call) => call.method), ["status"]);
+});
+
+test("memory runtime bridge trims query and scope strings before searching", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({
+    query: "  find prior context  ",
+    sessionId: "  s1  ",
+    userId: "  u1  ",
+  });
+
+  assert.ok(Array.isArray(result));
+  assert.equal(rpc.calls[1]?.method, "search_text_collections");
+  assert.deepEqual(rpc.calls[1]?.params.collections, ["session:s1", "user:u1", "global"]);
+  assert.equal(rpc.calls[1]?.params.text, "find prior context");
+});
+
 test("memory runtime bridge returns no results without a session when cross-session recall is disabled", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
   const { manager } = await runtime.getMemorySearchManager();
 
   const result = await manager.search({ query: "find prior context", userId: "u1" });
+
+  assert.deepEqual(result, []);
+  assert.equal(rpc.calls.length, 1, "only the initial status check should run");
+});
+
+test("memory runtime bridge ignores whitespace-only session ids when cross-session recall is disabled", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "find prior context", userId: "u1", sessionId: "   " });
 
   assert.deepEqual(result, []);
   assert.equal(rpc.calls.length, 1, "only the initial status check should run");


### PR DESCRIPTION
## Summary

- Trim runtime memory search query and scope strings at the bridge boundary.
- Treat whitespace-only structured queries as missing instead of sending blank vector searches.
- Treat whitespace-only session IDs as absent, preventing malformed `session:   ` collection lookups when cross-session recall is disabled.
- Add unit coverage for blank queries, trimmed query/scope values, and blank session IDs.

Closes #139.

## Verification

- `pnpm run test:inspect` — PASS
- `pnpm exec tsc -p tsconfig.tests.json` — PASS
- `node --test .ts-build/test/unit/memory-runtime.test.js` — PASS
- `pnpm run check` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget`, reproduced unchanged on `main`; tracked by #132 / #134 and unrelated to this runtime search normalization change.

– Vale

Fixes #139