### PR TITLE
fix: skip sidecar reconnect after shutdown

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -331,6 +331,11 @@ class SidecarSupervisor implements SidecarHandle {
     this.retries += 1;
     this.reconnectScheduled = true;
     this.runtime.scheduleRestart(backoffMs, () => {
+      if (this.shuttingDown) {
+        this.reconnectScheduled = false;
+        return;
+      }
+
       void this.start().catch((error) => {
         this.reconnectScheduled = false;
         const message = error instanceof Error ? error.message : String(error);

--- a/test/integration/sidecar-lifecycle.test.ts
+++ b/test/integration/sidecar-lifecycle.test.ts
@@ -161,6 +161,24 @@ test("sidecar crash mid-session reconnects within the restart window", async () 
   assert.equal(handle.isDegraded(), false);
 });
 
+test("sidecar does not reconnect from a scheduled restart after shutdown", async () => {
+  const runtime = createRuntime({});
+  const logger = createMemoryLogger();
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 2 }, logger, runtime.runtime);
+
+  runtime.sockets[0]?.emitClose();
+  await flushAsyncWork();
+
+  assert.equal(runtime.scheduled.length, 1);
+
+  await handle.shutdown();
+  runtime.scheduled[0]?.restart();
+  await flushAsyncWork();
+
+  assert.equal(runtime.sockets.length, 1);
+  assert.equal(handle.isDegraded(), false);
+});
+
 test("sidecar runtime socket errors reject pending RPCs and recover after restart", async () => {
   const runtime = createRuntime({});
   const logger = createMemoryLogger();


### PR DESCRIPTION
## Summary

Adds a shutdown guard to the scheduled SidecarSupervisor reconnect callback so a pending restart does not call `start()` after `shutdown()` has begun. Also adds an integration lifecycle regression test that schedules a reconnect, shuts the supervisor down, then verifies the scheduled callback does not create a new socket.

Fixes xDarkicex/openclaw-memory-libravdb#136

## Verification

- `pnpm run test:inspect` — PASS
- `pnpm exec tsc -p tsconfig.tests.json` — PASS
- `node --test --test-name-pattern="sidecar does not reconnect from a scheduled restart after shutdown" .ts-build/test/integration/sidecar-lifecycle.test.js` — PASS
- `node --test .ts-build/test/unit/*.test.js` — PASS (116 tests)
- `pnpm check` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), reproduced unchanged on `origin/main`; appears covered by open PR #134 and this PR avoids touching that retry-budget fix.

– Vale
