### PR TITLE
fix: guard exact recall result text

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -444,7 +444,9 @@ function isQuestionShapedRecallCandidate(text: string): boolean {
 }
 
 function rankExactRecallCandidate(result: SearchResult, token: string): number {
-  if (!result.text.includes(token)) return Number.NEGATIVE_INFINITY;
+  if (typeof result.text !== "string" || !result.text.includes(token)) {
+    return Number.NEGATIVE_INFINITY;
+  }
   let rank = result.score;
   if (/\bmeans\b/i.test(result.text)) rank += 100;
   if (/\b(remember|durable|fact)\b/i.test(result.text)) rank += 10;
@@ -644,7 +646,7 @@ export function buildContextEngineFactory(
           excludeByCollection: {},
         });
         const hit = (result.results ?? [])
-          .filter((candidate) => isExactRecallFact(candidate.text, token))
+          .filter((candidate) => typeof candidate?.text === "string" && isExactRecallFact(candidate.text, token))
           .sort((a, b) => rankExactRecallCandidate(b, token) - rankExactRecallCandidate(a, token))[0];
         if (hit) {
           injectedFacts.push(buildExactRecallFact(hit, token));

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -529,6 +529,41 @@ test("context engine exact recall skips empty-text search results", async () => 
   assert.equal(warnings.some((message) => /exact recall failed/.test(message)), false);
 });
 
+test("context engine exact recall ignores malformed non-string search result text", async () => {
+  const rpc = new FakeRpc();
+  const marker = "MALFORMED_SESSION_MEMORY_MARKER_1234567890";
+  rpc.assembleResponse = {
+    messages: [{ role: "user", content: `What does ${marker} mean?` }],
+    estimatedTokens: 24,
+    systemPromptAddition: "",
+  };
+  rpc.searchResults = [
+    {
+      id: "bad-fact",
+      score: 0.9,
+      text: undefined as unknown as string,
+      metadata: { collection: "user:fixed-user" },
+    },
+  ];
+  const warnings: string[] = [];
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn(message: string) { warnings.push(message); },
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", `What does ${marker} mean?`)],
+    prompt: `What does ${marker} mean?`,
+    tokenBudget: 4000,
+  });
+
+  assert.equal(assembled.systemPromptAddition, "");
+  assert.equal(warnings.some((message) => /exact recall failed/.test(message)), false);
+});
+
 test("exact recall extracts quoted phrases from user queries", async () => {
   const rpc = new FakeRpc();
   const phrase = "blue lobster preference";


### PR DESCRIPTION
## Summary

- Ignore malformed exact-recall search hits whose `text` field is not a string.
- Add the same type guard inside `rankExactRecallCandidate` so future call sites cannot crash on `result.text.includes(...)`.
- Add regression coverage for a daemon result with `text: undefined`.

Fixes #109.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this exact-recall guard.

– Vale
