### PR TITLE
fix: use TLS for remote gRPC targets

### DIFF
--- a/src/grpc-client.ts
+++ b/src/grpc-client.ts
@@ -20,6 +20,38 @@ export function resolveGrpcTarget(endpoint: string): string {
   return endpoint.startsWith("tcp:") ? endpoint.substring(4) : endpoint;
 }
 
+export function resolveGrpcCredentialMode(endpoint: string): "insecure" | "tls" {
+  const target = resolveGrpcTarget(endpoint).trim();
+  if (target.startsWith("unix:")) {
+    return "insecure";
+  }
+
+  const host = extractGrpcHost(target);
+  return isLoopbackHost(host) ? "insecure" : "tls";
+}
+
+function resolveGrpcCredentials(endpoint: string): grpc.ChannelCredentials {
+  return resolveGrpcCredentialMode(endpoint) === "insecure"
+    ? grpc.credentials.createInsecure()
+    : grpc.credentials.createSsl();
+}
+
+function extractGrpcHost(target: string): string {
+  const withoutDnsPrefix = target.startsWith("dns:///") ? target.slice("dns:///".length) : target;
+  if (withoutDnsPrefix.startsWith("[")) {
+    const closeBracket = withoutDnsPrefix.indexOf("]");
+    return closeBracket > 0 ? withoutDnsPrefix.slice(1, closeBracket) : withoutDnsPrefix;
+  }
+
+  const portSeparator = withoutDnsPrefix.lastIndexOf(":");
+  return portSeparator > 0 ? withoutDnsPrefix.slice(0, portSeparator) : withoutDnsPrefix;
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
 export class GrpcKernelClient {
   private client: any;
   private readonly secret: string | undefined;
@@ -43,7 +75,7 @@ export class GrpcKernelClient {
 
     const target = resolveGrpcTarget(options.endpoint);
 
-    this.client = new kernelService(target, grpc.credentials.createInsecure());
+    this.client = new kernelService(target, resolveGrpcCredentials(options.endpoint));
   }
 
   private getMetadata(signed = true): grpc.Metadata {

--- a/test/unit/grpc-client.test.ts
+++ b/test/unit/grpc-client.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveGrpcTarget } from "../../src/grpc-client.js";
+import { resolveGrpcCredentialMode, resolveGrpcTarget } from "../../src/grpc-client.js";
 
 test("resolveGrpcTarget strips tcp prefix for grpc-js host targets", () => {
   assert.equal(resolveGrpcTarget("tcp:127.0.0.1:37421"), "127.0.0.1:37421");
@@ -16,4 +16,17 @@ test("resolveGrpcTarget preserves unix scheme for grpc-js UDS resolver", () => {
 
 test("resolveGrpcTarget leaves ordinary grpc targets unchanged", () => {
   assert.equal(resolveGrpcTarget("localhost:37421"), "localhost:37421");
+});
+
+test("resolveGrpcCredentialMode keeps local daemon transports insecure", () => {
+  assert.equal(resolveGrpcCredentialMode("unix:/home/user/.clawdb/run/libravdb.sock"), "insecure");
+  assert.equal(resolveGrpcCredentialMode("tcp:127.0.0.1:37421"), "insecure");
+  assert.equal(resolveGrpcCredentialMode("tcp:localhost:37421"), "insecure");
+  assert.equal(resolveGrpcCredentialMode("[::1]:37421"), "insecure");
+});
+
+test("resolveGrpcCredentialMode uses TLS for non-local grpc targets", () => {
+  assert.equal(resolveGrpcCredentialMode("tcp:192.0.2.10:37421"), "tls");
+  assert.equal(resolveGrpcCredentialMode("libravdb.example.com:443"), "tls");
+  assert.equal(resolveGrpcCredentialMode("dns:///libravdb.example.com:443"), "tls");
 });


### PR DESCRIPTION
## Summary

Fixes #120.

The gRPC kernel client always used `grpc.credentials.createInsecure()`, so non-local `grpcEndpoint` targets were contacted over plaintext. This PR keeps local development transports unchanged while switching remote endpoints to TLS:

- Unix socket targets remain insecure/local.
- Loopback TCP targets (`localhost`, `127.0.0.1`, `[::1]`) remain insecure/local.
- Non-local TCP/DNS targets use `grpc.credentials.createSsl()`.

## Compatibility note

This intentionally changes remote gRPC behavior. Remote plaintext endpoints should either terminate TLS or be accessed through an explicit local tunnel/loopback endpoint. Local daemon setups are unaffected.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/grpc-client.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this gRPC credential-mode change.

– Vale
