### PR TITLE
fix: preserve latest afterTurn message at prompt boundary

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -178,6 +178,14 @@ function selectAfterTurnMessages<T>(
   }
   const start = Math.floor(prePromptMessageCount);
   if (start >= messages.length) {
+    if (messages.length > 0) {
+      logger?.warn?.(
+        `LibraVDB afterTurn prePromptMessageCount consumed all messages; ` +
+        `forwarding latest message for compatibility ` +
+        `prePromptMessageCount=${prePromptMessageCount} start=${start} totalMessages=${messages.length}`,
+      );
+      return messages.slice(-1);
+    }
     logger?.warn?.(
       `LibraVDB afterTurn prePromptMessageCount produced zero forwarded messages ` +
       `prePromptMessageCount=${prePromptMessageCount} start=${start} totalMessages=${messages.length}`,

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -465,6 +465,35 @@ test("afterTurn forwards only post-prompt messages and strips prePromptMessageCo
   assert.deepEqual(params.messages, [mockMessages[1]]);
 });
 
+test("afterTurn forwards latest message when prePromptMessageCount consumes all messages", async () => {
+  const rpc = new StaticContractRpc();
+  const cfg: PluginConfig = { rpcTimeoutMs: 1000 };
+  const logger = createMemoryLogger();
+
+  const context = buildContextEngineFactory(async () => rpc as never, cfg, logger);
+
+  const mockMessages = [
+    { role: "assistant", content: "final answer that should still persist" },
+  ];
+
+  await context.afterTurn({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: mockMessages,
+    prePromptMessageCount: 1,
+    isHeartbeat: false,
+  });
+
+  const params = rpc.getLastCall("after_turn_kernel");
+  assert.ok(params, "Expected after_turn_kernel to be called");
+  assert.equal("prePromptMessageCount" in params, false, "prePromptMessageCount must not leak to daemon");
+  assert.deepEqual(params.messages, mockMessages);
+  assert.ok(
+    logger.warns.some((message) => /forwarding latest message for compatibility/.test(message)),
+    "boundary fallback should emit an operator warning",
+  );
+});
+
 test("afterTurn forwards all messages when prePromptMessageCount is absent", async () => {
   const rpc = new StaticContractRpc();
   const cfg: PluginConfig = { rpcTimeoutMs: 1000 };


### PR DESCRIPTION
## Summary

- Preserve the latest message when `prePromptMessageCount` consumes the entire message array.
- Keep the existing behavior for genuinely empty message arrays.
- Add an integration boundary test proving `after_turn_kernel` receives the latest completed turn and that `prePromptMessageCount` is still stripped from the daemon request.

Fixes #146.

Related: #108.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test --test-name-pattern='afterTurn forwards latest message when prePromptMessageCount consumes all messages' .ts-build/test/integration/host-flow.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this afterTurn boundary fix.

– Vale
