### PR TITLE
fix: extend index rebuild RPC timeout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,8 @@ type JournalResult = {
   }>;
 };
 
+const INDEX_REBUILD_TIMEOUT_MS = 5 * 60 * 1000;
+
 type CliCommand = {
   commands?: CliCommand[];
   command(name: string): CliCommand;
@@ -367,7 +369,7 @@ function formatDeepStatusTableRows(deep: DeepStatusResult): Record<string, strin
 
 async function runIndex(
   runtime: PluginRuntime,
-  _cfg: PluginConfig,
+  cfg: PluginConfig,
   opts: CliOptionBag | undefined,
   logger: LoggerLike,
   params: { quiet?: boolean } = {},
@@ -394,6 +396,8 @@ async function runIndex(
     }>("rebuild_index", {
       namespace: namespace ?? "",
       ...(collections?.length ? { collections } : {}),
+    }, {
+      timeoutMs: resolveIndexRebuildTimeoutMs(cfg),
     });
 
     if (!params.quiet) {
@@ -416,6 +420,10 @@ async function runIndex(
     logger.error(`LibraVDB index rebuild failed: ${formatError(error)}`);
     process.exitCode = 1;
   }
+}
+
+function resolveIndexRebuildTimeoutMs(cfg: PluginConfig): number {
+  return Math.max(INDEX_REBUILD_TIMEOUT_MS, cfg.rpcTimeoutMs ?? 0);
 }
 
 async function runSearch(

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -525,6 +525,73 @@ test("status --deep includes authored probe rows in table output", async () => {
   assert.equal(tables[0]?.["Probe global"], "ok (1 hits)");
 });
 
+test("index command uses an extended timeout for rebuild_index", async () => {
+  let registered: RegisteredCli | null = null;
+  let shutdownCalls = 0;
+  const rpcCalls: Array<{
+    method: string;
+    params: Record<string, unknown>;
+    options?: { timeoutMs?: number };
+  }> = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>, options?: { timeoutMs?: number }) {
+            rpcCalls.push({ method, params, options });
+            if (method === "rebuild_index") {
+              return {
+                collectionsProcessed: 1,
+                recordsReindexed: 2,
+                collectionsRecreated: 0,
+                errors: [],
+              };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel: async () => null,
+      async emitLifecycleHint() {},
+      onShutdown: async () => {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const index = memory?.commands.find((command) => command.name() === "index");
+  assert.ok(index?.handler);
+
+  const originalLog = console.log;
+  console.log = (() => {}) as typeof console.log;
+  try {
+    await index.handler?.({ force: true });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(rpcCalls.length, 1);
+  assert.equal(rpcCalls[0]?.method, "rebuild_index");
+  assert.equal(rpcCalls[0]?.options?.timeoutMs, 300000);
+  assert.equal(shutdownCalls, 1);
+});
+
 test("non-full CLI registration exposes command structure without action handlers", () => {
   let registered: RegisteredCli | null = null;
   const api = {


### PR DESCRIPTION
## Summary

Fixes #135.

`memory index --force` calls the long-running `rebuild_index` RPC with the default 30s timeout. A rebuild can legitimately take longer than status/search calls because it may re-embed stored records and recreate collections.

This PR gives `rebuild_index` an explicit 5-minute RPC timeout while still respecting larger user-configured `rpcTimeoutMs` values.

## Changes

- Add `INDEX_REBUILD_TIMEOUT_MS = 5 * 60 * 1000`.
- Pass `{ timeoutMs: resolveIndexRebuildTimeoutMs(cfg) }` to `rpc.call("rebuild_index", ...)`.
- Add CLI regression coverage verifying the extended timeout reaches the RPC layer.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/cli.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this index timeout change.

– Vale
