### PR TITLE
fix: strictly parse dream promotion metadata numbers

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -445,11 +445,15 @@ function parseTrailingMetadata(body: string): { bodyStart: number; score: number
   };
 }
 
+const DECIMAL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+
 function parseNumber(value: string | undefined): number | null {
-  if (!value) {
+  const trimmed = value?.trim();
+  if (!trimmed || !DECIMAL_NUMBER_PATTERN.test(trimmed)) {
     return null;
   }
-  const parsed = Number.parseFloat(value);
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
     return null;
   }
@@ -457,11 +461,12 @@ function parseNumber(value: string | undefined): number | null {
 }
 
 function parseInteger(value: string | undefined): number | null {
-  if (!value) {
+  const trimmed = value?.trim();
+  if (!trimmed || !INTEGER_PATTERN.test(trimmed)) {
     return null;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) {
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
     return null;
   }
   return parsed;

--- a/test/unit/dream-promotion.test.ts
+++ b/test/unit/dream-promotion.test.ts
@@ -32,6 +32,24 @@ test("dream promotion parser only accepts explicit deep-sleep candidate bullets"
   assert.equal(candidates[1]?.text, "too weak to promote");
 });
 
+test("dream promotion parser rejects partially parsed numeric metadata", () => {
+  const candidates = parseDreamPromotionCandidates(
+    [
+      "## Deep Sleep",
+      "- malformed score {score=0.82junk recall=3 unique=2}",
+      "- malformed recall count {score=0.82 recall=3x unique=2}",
+      "- malformed unique query count {score=0.82 recall=3 unique=2y}",
+      "- valid metadata {score=8.2e-1 recall=3 unique=2}",
+    ].join("\n"),
+  );
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.text, "valid metadata");
+  assert.equal(candidates[0]?.score, 0.82);
+  assert.equal(candidates[0]?.recallCount, 3);
+  assert.equal(candidates[0]?.uniqueQueries, 2);
+});
+
 test("disabled dream promotion does not validate unused diary paths", () => {
   assert.doesNotThrow(() => {
     createDreamPromotionHandle(


### PR DESCRIPTION
## Summary

- Fixes #149.
- Rejects dream promotion metadata numbers unless the entire token is a valid decimal or integer.
- Adds regression coverage for malformed suffixes like `score=0.82junk`, `recall=3x`, and `unique=2y`.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/dream-promotion.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this dream metadata parser change.

– Vale
