### PR TITLE
fix: reject malformed dream metadata numbers

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -13,6 +13,8 @@ const DEFAULT_MIN_RECALL_COUNT = 2;
 const DEFAULT_MIN_UNIQUE_QUERIES = 2;
 const DREAM_PROMOTION_VERSION = 1;
 const DREAM_SOURCE_KIND = "dream";
+const STRICT_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;
+const STRICT_INTEGER_PATTERN = /^[+-]?\d+$/;
 
 type Disposable = { close(): void };
 
@@ -449,7 +451,11 @@ function parseNumber(value: string | undefined): number | null {
   if (!value) {
     return null;
   }
-  const parsed = Number.parseFloat(value);
+  const trimmed = value.trim();
+  if (!STRICT_NUMBER_PATTERN.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
     return null;
   }
@@ -460,8 +466,12 @@ function parseInteger(value: string | undefined): number | null {
   if (!value) {
     return null;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) {
+  const trimmed = value.trim();
+  if (!STRICT_INTEGER_PATTERN.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
     return null;
   }
   return parsed;

--- a/test/unit/dream-promotion.test.ts
+++ b/test/unit/dream-promotion.test.ts
@@ -32,6 +32,25 @@ test("dream promotion parser only accepts explicit deep-sleep candidate bullets"
   assert.equal(candidates[1]?.text, "too weak to promote");
 });
 
+test("dream promotion parser rejects malformed numeric metadata", () => {
+  const candidates = parseDreamPromotionCandidates(
+    [
+      "## Deep Sleep",
+      "- Keep a valid candidate {score=0.82 recall=3 unique=2}",
+      "- Reject a malformed score {score=0.82abc recall=3 unique=2}",
+      "- Reject a malformed recall count {score=0.82 recall=3abc unique=2}",
+      "- Reject a fractional unique count {score=0.82 recall=3 unique=2.5}",
+      "- Keep an exponent score {score=8.2e-1 recall=3 unique=2}",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.text),
+    ["Keep a valid candidate", "Keep an exponent score"],
+  );
+  assert.equal(candidates[1]?.score, 0.82);
+});
+
 test("disabled dream promotion does not validate unused diary paths", () => {
   assert.doesNotThrow(() => {
     createDreamPromotionHandle(


### PR DESCRIPTION
## Summary
- require complete numeric tokens for dream promotion score metadata
- require complete safe integer tokens for recall/unique count metadata
- add parser coverage for malformed numeric metadata

Fixes #150.

## Verification
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/dream-promotion.test.js`
- `pnpm check`