### PR TITLE
fix: send cli user targets as user ids

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,11 @@ type CliOptionBag = {
   collections?: string;
 };
 
+type CliMemoryTarget = {
+  label: string;
+  params: { userId: string } | { namespace: string };
+};
+
 type JournalResult = {
   results?: Array<{
     id: string;
@@ -486,15 +491,15 @@ function resolveDefaultSearchMinScore(status: { gatingThreshold?: number } | und
 }
 
 async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
-  const namespace = resolveCliNamespace(opts);
-  if (!namespace) {
+  const target = resolveCliMemoryTarget(opts);
+  if (!target) {
     logger.error("LibraVDB flush requires --user-id <userId> or --session-key <sessionKey>.");
     process.exitCode = 1;
     return;
   }
 
   if (!opts?.yes) {
-    const confirmed = await confirm(`Delete durable memory namespace ${namespace}? [y/N] `);
+    const confirmed = await confirm(`Delete durable memory namespace ${target.label}? [y/N] `);
     if (!confirmed) {
       console.log("Aborted.");
       return;
@@ -503,8 +508,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 
   try {
     const rpc = await runtime.getRpc();
-    await rpc.call("flush_namespace", { namespace });
-    console.log(`Deleted durable memory namespace ${namespace}.`);
+    await rpc.call("flush_namespace", target.params);
+    console.log(`Deleted durable memory namespace ${target.label}.`);
   } catch (error) {
     logger.error(`LibraVDB flush failed: ${formatError(error)}`);
     process.exitCode = 1;
@@ -512,8 +517,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 }
 
 async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
-  const namespace = resolveCliNamespace(opts);
-  if (!namespace) {
+  const target = resolveCliMemoryTarget(opts);
+  if (!target) {
     logger.error("LibraVDB export requires a namespace. Provide --user-id or --session-key.");
     process.exitCode = 1;
     return;
@@ -521,9 +526,7 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
 
   try {
     const rpc = await runtime.getRpc();
-    const result = await rpc.call<ExportResult>("export_memory", {
-      namespace,
-    });
+    const result = await rpc.call<ExportResult>("export_memory", target.params);
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);
     }
@@ -652,6 +655,27 @@ function resolveCliNamespace(opts: CliOptionBag | undefined): string | undefined
     return undefined;
   }
   return resolveDurableNamespace({ userId, sessionKey, agentId });
+}
+
+function resolveCliMemoryTarget(opts: CliOptionBag | undefined): CliMemoryTarget | undefined {
+  const userId = opts?.userId?.trim();
+  if (userId) {
+    return {
+      label: `user:${userId}`,
+      params: { userId },
+    };
+  }
+
+  const sessionKey = opts?.sessionKey?.trim();
+  const agentId = opts?.agent?.trim();
+  if (!sessionKey && !agentId) {
+    return undefined;
+  }
+  const namespace = resolveDurableNamespace({ sessionKey, agentId });
+  return {
+    label: namespace,
+    params: { namespace },
+  };
 }
 
 type CliRegistrar = {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -227,6 +227,75 @@ test("status command shuts the plugin runtime down after printing status", async
   assert.equal(shutdownCalls, 1);
 });
 
+test("flush and export send userId for user targets and namespace for session keys", async () => {
+  let registered: RegisteredCli | null = null;
+  let shutdownCalls = 0;
+  const rpcCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>) {
+            rpcCalls.push({ method, params });
+            if (method === "flush_namespace") {
+              return { ok: true };
+            }
+            if (method === "export_memory") {
+              return { records: [] };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      async getKernel() {
+        return null;
+      },
+      async emitLifecycleHint() {},
+      onShutdown() {},
+      async shutdown() {
+        shutdownCalls += 1;
+      },
+    },
+    {},
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const flush = memory?.commands.find((command) => command.name() === "flush");
+  const exportCmd = memory?.commands.find((command) => command.name() === "export");
+  assert.ok(flush?.handler);
+  assert.ok(exportCmd?.handler);
+
+  const originalLog = console.log;
+  console.log = (() => undefined) as typeof console.log;
+  try {
+    await flush.handler({ userId: "  test-user  ", yes: true });
+    await exportCmd.handler({ userId: "  test-user  " });
+    await flush.handler({ sessionKey: "  session-1  ", yes: true });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(rpcCalls, [
+    { method: "flush_namespace", params: { userId: "test-user" } },
+    { method: "export_memory", params: { userId: "test-user" } },
+    { method: "flush_namespace", params: { namespace: "session-key:session-1" } },
+  ]);
+  assert.equal(shutdownCalls, 3);
+});
+
 
 test("search command applies the status gate threshold by default", async () => {
   let registered: RegisteredCli | null = null;


### PR DESCRIPTION
## Summary
- route `memory flush --user-id` and `memory export --user-id` through the RPC `userId` field
- keep derived scopes like `--session-key` on the RPC `namespace` field
- cover the CLI payload shape for both user and session-key targets

Fixes #154.

## Verification
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/cli.test.js`
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory flush and export commands to correctly process both user-based and namespace-based targets when sending remote procedure calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->