### PR TITLE
fix: send CLI user scope explicitly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,6 +80,13 @@ type CliCommand = {
 };
 
 type CliProgram = CliCommand;
+type CliMemoryOperationScope = {
+  displayName: string;
+  params: {
+    userId?: string;
+    namespace?: string;
+  };
+};
 
 export function registerMemoryCli(
   api: OpenClawPluginApi,
@@ -486,15 +493,15 @@ function resolveDefaultSearchMinScore(status: { gatingThreshold?: number } | und
 }
 
 async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
-  const namespace = resolveCliNamespace(opts);
-  if (!namespace) {
+  const scope = resolveCliMemoryOperationScope(opts);
+  if (!scope) {
     logger.error("LibraVDB flush requires --user-id <userId> or --session-key <sessionKey>.");
     process.exitCode = 1;
     return;
   }
 
   if (!opts?.yes) {
-    const confirmed = await confirm(`Delete durable memory namespace ${namespace}? [y/N] `);
+    const confirmed = await confirm(`Delete durable memory namespace ${scope.displayName}? [y/N] `);
     if (!confirmed) {
       console.log("Aborted.");
       return;
@@ -503,8 +510,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 
   try {
     const rpc = await runtime.getRpc();
-    await rpc.call("flush_namespace", { namespace });
-    console.log(`Deleted durable memory namespace ${namespace}.`);
+    await rpc.call("flush_namespace", scope.params);
+    console.log(`Deleted durable memory namespace ${scope.displayName}.`);
   } catch (error) {
     logger.error(`LibraVDB flush failed: ${formatError(error)}`);
     process.exitCode = 1;
@@ -512,8 +519,8 @@ async function runFlush(runtime: PluginRuntime, opts: CliOptionBag | undefined, 
 }
 
 async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined, logger: LoggerLike): Promise<void> {
-  const namespace = resolveCliNamespace(opts);
-  if (!namespace) {
+  const scope = resolveCliMemoryOperationScope(opts);
+  if (!scope) {
     logger.error("LibraVDB export requires a namespace. Provide --user-id or --session-key.");
     process.exitCode = 1;
     return;
@@ -521,9 +528,7 @@ async function runExport(runtime: PluginRuntime, opts: CliOptionBag | undefined,
 
   try {
     const rpc = await runtime.getRpc();
-    const result = await rpc.call<ExportResult>("export_memory", {
-      namespace,
-    });
+    const result = await rpc.call<ExportResult>("export_memory", scope.params);
     for (const record of result.records ?? []) {
       stdout.write(`${JSON.stringify(record)}\n`);
     }
@@ -652,6 +657,27 @@ function resolveCliNamespace(opts: CliOptionBag | undefined): string | undefined
     return undefined;
   }
   return resolveDurableNamespace({ userId, sessionKey, agentId });
+}
+
+function resolveCliMemoryOperationScope(opts: CliOptionBag | undefined): CliMemoryOperationScope | undefined {
+  const userId = opts?.userId?.trim();
+  if (userId) {
+    return {
+      displayName: `user:${userId}`,
+      params: { userId },
+    };
+  }
+
+  const sessionKey = opts?.sessionKey?.trim();
+  const agentId = opts?.agent?.trim();
+  if (!sessionKey && !agentId) {
+    return undefined;
+  }
+  const namespace = resolveDurableNamespace({ sessionKey, agentId });
+  return {
+    displayName: namespace,
+    params: { namespace },
+  };
 }
 
 type CliRegistrar = {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -5,6 +5,7 @@ import { registerMemoryCli } from "../../src/cli.js";
 import { registerMemoryCliMetadata } from "../../src/cli-descriptors.js";
 import { register } from "../../src/index.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
+import type { PluginConfig } from "../../src/types.js";
 
 type RegisteredCli = {
   builder: (ctx: { program: FakeCommand }) => void;
@@ -87,6 +88,27 @@ function createRuntime(): PluginRuntime {
   };
 }
 
+function buildMemoryCommand(runtime: PluginRuntime, cfg: PluginConfig = {}): FakeCommand {
+  let registered: RegisteredCli | null = null;
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(api as never, runtime, cfg);
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  assert.ok(memory);
+  return memory;
+}
+
 test("CLI metadata registers the memory descriptor only when LibraVDB owns the memory slot", () => {
   const registered: RegisteredCli[] = [];
   const api = {
@@ -162,6 +184,77 @@ test("full CLI registration exposes standard memory commands and LibraVDB operat
   assert.ok(dreamPromote);
   assert.ok(dreamPromote.requiredOptions.includes("--user-id <userId>"));
   assert.ok(dreamPromote.requiredOptions.includes("--dream-file <path>"));
+});
+
+test("flush command sends explicit user ids through the userId RPC field", async () => {
+  const rpcCalls: Array<{ method: string; params: unknown }> = [];
+  const memory = buildMemoryCommand({
+    async getRpc() {
+      return {
+        async call(method: string, params: unknown) {
+          rpcCalls.push({ method, params });
+          return {};
+        },
+      } as never;
+    },
+    getKernel: async () => null,
+    async emitLifecycleHint() {},
+    onShutdown() {},
+    async shutdown() {},
+  });
+
+  const flush = memory.commands.find((command) => command.name() === "flush");
+  assert.ok(flush?.handler);
+
+  const originalLog = console.log;
+  console.log = (() => undefined) as typeof console.log;
+  try {
+    await flush.handler?.({ userId: "  alice  ", yes: true });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(rpcCalls, [
+    {
+      method: "flush_namespace",
+      params: { userId: "alice" },
+    },
+  ]);
+});
+
+test("export command keeps user ids separate from derived namespaces", async () => {
+  const rpcCalls: Array<{ method: string; params: unknown }> = [];
+  const memory = buildMemoryCommand({
+    async getRpc() {
+      return {
+        async call(method: string, params: unknown) {
+          rpcCalls.push({ method, params });
+          return { records: [] };
+        },
+      } as never;
+    },
+    getKernel: async () => null,
+    async emitLifecycleHint() {},
+    onShutdown() {},
+    async shutdown() {},
+  });
+
+  const exportCmd = memory.commands.find((command) => command.name() === "export");
+  assert.ok(exportCmd?.handler);
+
+  await exportCmd.handler?.({ userId: "  alice  " });
+  await exportCmd.handler?.({ sessionKey: "  session-1  " });
+
+  assert.deepEqual(rpcCalls, [
+    {
+      method: "export_memory",
+      params: { userId: "alice" },
+    },
+    {
+      method: "export_memory",
+      params: { namespace: "session-key:session-1" },
+    },
+  ]);
 });
 
 test("status command shuts the plugin runtime down after printing status", async () => {


### PR DESCRIPTION
## Summary

- Fixes #154.
- Sends `userId` for `memory flush --user-id` and `memory export --user-id` instead of wrapping the value as a generic `namespace`.
- Keeps derived scopes like `--session-key` on the `namespace` field.

## Verification

- `pnpm run check` — PASS
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/cli.test.js` — PASS
- `npm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 / #134 and unrelated to this CLI user-scope change.

– Vale
