### PR TITLE
fix: preserve user turn in assembled context

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -164,6 +164,12 @@ function approximateMessagesTokens(messages: OpenClawCompatibleMessage[]): numbe
   return messages.reduce((sum, message) => sum + approximateMessageTokens(message), 0);
 }
 
+function hasReplaySafeUserTurn(messages: OpenClawCompatibleMessage[]): boolean {
+  return messages.some(
+    (message) => message.role === "user" && normalizeKernelContent(message.content).trim().length > 0,
+  );
+}
+
 function selectAfterTurnMessages<T>(
   messages: T[],
   prePromptMessageCount: number | undefined,
@@ -517,11 +523,9 @@ function ensureReplaySafeUserTurn(
   assembled: OpenClawCompatibleAssembleResult,
   sourceMessages: OpenClawCompatibleMessage[],
   logger?: LoggerLike,
+  tokenBudget?: number,
 ): OpenClawCompatibleAssembleResult {
-  const hasUserTurn = assembled.messages.some(
-    (message) => message.role === "user" && normalizeKernelContent(message.content).trim().length > 0,
-  );
-  if (hasUserTurn) {
+  if (hasReplaySafeUserTurn(assembled.messages)) {
     return assembled;
   }
 
@@ -533,12 +537,48 @@ function ensureReplaySafeUserTurn(
   logger?.warn?.(
     "LibraVDB assemble produced no replay-safe user turn; reinjecting the latest user message for provider compatibility.",
   );
-  const messages = [fallbackUser, ...assembled.messages];
   const baseEstimatedTokens = Math.max(
     0,
     assembled.estimatedTokens,
     approximateMessagesTokens(assembled.messages),
   );
+
+  if (typeof tokenBudget === "number" && Number.isFinite(tokenBudget) && tokenBudget > 0) {
+    const effectiveBudget = resolveEffectiveAssembleBudget(tokenBudget);
+    const fallbackCost = approximateMessageTokens(fallbackUser);
+    const fullMessages = [fallbackUser, ...assembled.messages];
+    const fullApproxTokens = fallbackCost + approximateMessagesTokens(assembled.messages);
+    if (baseEstimatedTokens + fallbackCost <= effectiveBudget && fullApproxTokens <= effectiveBudget) {
+      return {
+        ...assembled,
+        messages: fullMessages,
+        estimatedTokens: baseEstimatedTokens + fallbackCost,
+      };
+    }
+
+    if (fallbackCost >= effectiveBudget) {
+      const truncated = truncateContentToTokenBudget(fallbackUser.content, Math.max(1, effectiveBudget - 8));
+      return {
+        ...assembled,
+        messages: truncated ? [{ ...fallbackUser, content: truncated }] : [],
+        estimatedTokens: Math.min(
+          effectiveBudget,
+          truncated ? approximateMessageTokens({ ...fallbackUser, content: truncated }) : 0,
+        ),
+      };
+    }
+
+    const remainingBudget = Math.max(0, effectiveBudget - fallbackCost);
+    const trimmedMessages = trimMessagesToBudget(assembled.messages, remainingBudget);
+    const messages = [fallbackUser, ...trimmedMessages];
+    return {
+      ...assembled,
+      messages,
+      estimatedTokens: Math.min(effectiveBudget, fallbackCost + approximateMessagesTokens(trimmedMessages)),
+    };
+  }
+
+  const messages = [fallbackUser, ...assembled.messages];
   return {
     ...assembled,
     messages,
@@ -978,27 +1018,28 @@ export function buildContextEngineFactory(
       const kernel = await getKernelOrNull("assemble");
       if (kernel) {
         try {
-          const assembled = ensureReplaySafeUserTurn(
-            normalizeAssembleResult(await kernel.assembleContext({
-              sessionId: args.sessionId,
-              sessionKey: args.sessionKey,
-              userId,
-              queryText: args.prompt ?? "",
-              visibleMessages: messages,
-              tokenBudget: args.tokenBudget,
-              config: buildAssemblyConfig(args.tokenBudget),
-              emitDebug: true,
-            })),
+          const assembled = normalizeAssembleResult(await kernel.assembleContext({
+            sessionId: args.sessionId,
+            sessionKey: args.sessionKey,
+            userId,
+            queryText: args.prompt ?? "",
+            visibleMessages: messages,
+            tokenBudget: args.tokenBudget,
+            config: buildAssemblyConfig(args.tokenBudget),
+            emitDebug: true,
+          }));
+          return ensureReplaySafeUserTurn(
+            enforceTokenBudgetInvariant(
+              await augmentWithExactRecall(assembled, {
+                queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
+                userId,
+                sessionId: args.sessionId,
+                tokenBudget: args.tokenBudget,
+              }),
+              args.tokenBudget,
+            ),
             args.messages,
             logger,
-          );
-          return enforceTokenBudgetInvariant(
-            await augmentWithExactRecall(assembled, {
-              queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
-              userId,
-              sessionId: args.sessionId,
-              tokenBudget: args.tokenBudget,
-            }),
             args.tokenBudget,
           );
         } catch (error) {
@@ -1022,18 +1063,19 @@ export function buildContextEngineFactory(
           emitDebug: true,
           config: buildAssemblyConfig(args.tokenBudget),
         });
-        const assembled = ensureReplaySafeUserTurn(
-          normalizeAssembleResult(resp),
+        const assembled = normalizeAssembleResult(resp);
+        return ensureReplaySafeUserTurn(
+          enforceTokenBudgetInvariant(
+            await augmentWithExactRecall(assembled, {
+              queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
+              userId,
+              sessionId: args.sessionId,
+              tokenBudget: args.tokenBudget,
+            }),
+            args.tokenBudget,
+          ),
           args.messages,
           logger,
-        );
-        return enforceTokenBudgetInvariant(
-          await augmentWithExactRecall(assembled, {
-            queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
-            userId,
-            sessionId: args.sessionId,
-            tokenBudget: args.tokenBudget,
-          }),
           args.tokenBudget,
         );
       } catch (error) {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -492,6 +492,55 @@ function appendSystemPromptAddition(existing: string, addition: string): string 
   return `${trimmedExisting}\n\n${addition}`;
 }
 
+function findLastReplaySafeUserMessage(
+  messages: OpenClawCompatibleMessage[],
+): OpenClawCompatibleMessage | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const candidate = messages[index]!;
+    if (candidate.role !== "user") {
+      continue;
+    }
+    const content = normalizeKernelContent(candidate.content);
+    if (content.trim().length === 0) {
+      continue;
+    }
+    return {
+      role: "user",
+      content,
+      ...(typeof candidate.id === "string" ? { id: candidate.id } : {}),
+    };
+  }
+  return null;
+}
+
+function ensureReplaySafeUserTurn(
+  assembled: OpenClawCompatibleAssembleResult,
+  sourceMessages: OpenClawCompatibleMessage[],
+  logger?: LoggerLike,
+): OpenClawCompatibleAssembleResult {
+  const hasUserTurn = assembled.messages.some(
+    (message) => message.role === "user" && normalizeKernelContent(message.content).trim().length > 0,
+  );
+  if (hasUserTurn) {
+    return assembled;
+  }
+
+  const fallbackUser = findLastReplaySafeUserMessage(sourceMessages);
+  if (!fallbackUser) {
+    return assembled;
+  }
+
+  logger?.warn?.(
+    "LibraVDB assemble produced no replay-safe user turn; reinjecting the latest user message for provider compatibility.",
+  );
+  const messages = [fallbackUser, ...assembled.messages];
+  return {
+    ...assembled,
+    messages,
+    estimatedTokens: Math.max(assembled.estimatedTokens, approximateMessagesTokens(messages)),
+  };
+}
+
 export function normalizeAssembleResult(result: {
   messages?: Array<{ role: string; content?: unknown; id?: string }>;
   estimatedTokens?: number;
@@ -924,16 +973,20 @@ export function buildContextEngineFactory(
       const kernel = await getKernelOrNull("assemble");
       if (kernel) {
         try {
-          const assembled = normalizeAssembleResult(await kernel.assembleContext({
-            sessionId: args.sessionId,
-            sessionKey: args.sessionKey,
-            userId,
-            queryText: args.prompt ?? "",
-            visibleMessages: messages,
-            tokenBudget: args.tokenBudget,
-            config: buildAssemblyConfig(args.tokenBudget),
-            emitDebug: true,
-          }));
+          const assembled = ensureReplaySafeUserTurn(
+            normalizeAssembleResult(await kernel.assembleContext({
+              sessionId: args.sessionId,
+              sessionKey: args.sessionKey,
+              userId,
+              queryText: args.prompt ?? "",
+              visibleMessages: messages,
+              tokenBudget: args.tokenBudget,
+              config: buildAssemblyConfig(args.tokenBudget),
+              emitDebug: true,
+            })),
+            args.messages,
+            logger,
+          );
           return enforceTokenBudgetInvariant(
             await augmentWithExactRecall(assembled, {
               queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
@@ -964,7 +1017,11 @@ export function buildContextEngineFactory(
           emitDebug: true,
           config: buildAssemblyConfig(args.tokenBudget),
         });
-        const assembled = normalizeAssembleResult(resp);
+        const assembled = ensureReplaySafeUserTurn(
+          normalizeAssembleResult(resp),
+          args.messages,
+          logger,
+        );
         return enforceTokenBudgetInvariant(
           await augmentWithExactRecall(assembled, {
             queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -303,6 +303,14 @@ function truncateContentToTokenBudget(content: unknown, tokenBudget: number): st
   return normalized.slice(normalized.length - maxChars);
 }
 
+function truncateSystemPromptAdditionToTokenBudget(value: string, tokenBudget: number): string {
+  if (tokenBudget <= 0) return "";
+  const maxChars = Math.max(1, tokenBudget * APPROX_CHARS_PER_TOKEN);
+  if (value.length <= maxChars) return value;
+  // System additions are head-structured: preserve XML/preamble/instructions.
+  return value.slice(0, maxChars);
+}
+
 function trimMessagesToBudget(
   messages: OpenClawCompatibleMessage[],
   tokenBudget: number,
@@ -546,13 +554,14 @@ function ensureReplaySafeUserTurn(
   if (typeof tokenBudget === "number" && Number.isFinite(tokenBudget) && tokenBudget > 0) {
     const effectiveBudget = resolveEffectiveAssembleBudget(tokenBudget);
     const fallbackCost = approximateMessageTokens(fallbackUser);
+    const systemPromptTokens = approximateTokenCount(assembled.systemPromptAddition);
     const fullMessages = [fallbackUser, ...assembled.messages];
-    const fullApproxTokens = fallbackCost + approximateMessagesTokens(assembled.messages);
+    const fullApproxTokens = systemPromptTokens + fallbackCost + approximateMessagesTokens(assembled.messages);
     if (baseEstimatedTokens + fallbackCost <= effectiveBudget && fullApproxTokens <= effectiveBudget) {
       return {
         ...assembled,
         messages: fullMessages,
-        estimatedTokens: baseEstimatedTokens + fallbackCost,
+        estimatedTokens: Math.max(baseEstimatedTokens + fallbackCost, fullApproxTokens),
       };
     }
 
@@ -560,6 +569,7 @@ function ensureReplaySafeUserTurn(
       const truncated = truncateContentToTokenBudget(fallbackUser.content, Math.max(1, effectiveBudget - 8));
       return {
         ...assembled,
+        systemPromptAddition: "",
         messages: truncated ? [{ ...fallbackUser, content: truncated }] : [],
         estimatedTokens: Math.min(
           effectiveBudget,
@@ -568,13 +578,23 @@ function ensureReplaySafeUserTurn(
       };
     }
 
-    const remainingBudget = Math.max(0, effectiveBudget - fallbackCost);
-    const trimmedMessages = trimMessagesToBudget(assembled.messages, remainingBudget);
+    const remainingBudget = effectiveBudget - fallbackCost;
+    const systemPromptAddition =
+      systemPromptTokens > remainingBudget
+        ? truncateSystemPromptAdditionToTokenBudget(assembled.systemPromptAddition, remainingBudget)
+        : assembled.systemPromptAddition;
+    const trimmedSystemPromptTokens = approximateTokenCount(systemPromptAddition);
+    const messageBudget = Math.max(0, remainingBudget - trimmedSystemPromptTokens);
+    const trimmedMessages = trimMessagesToBudget(assembled.messages, messageBudget);
     const messages = [fallbackUser, ...trimmedMessages];
     return {
       ...assembled,
+      systemPromptAddition,
       messages,
-      estimatedTokens: Math.min(effectiveBudget, fallbackCost + approximateMessagesTokens(trimmedMessages)),
+      estimatedTokens: Math.min(
+        effectiveBudget,
+        fallbackCost + trimmedSystemPromptTokens + approximateMessagesTokens(trimmedMessages),
+      ),
     };
   }
 

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -534,10 +534,15 @@ function ensureReplaySafeUserTurn(
     "LibraVDB assemble produced no replay-safe user turn; reinjecting the latest user message for provider compatibility.",
   );
   const messages = [fallbackUser, ...assembled.messages];
+  const baseEstimatedTokens = Math.max(
+    0,
+    assembled.estimatedTokens,
+    approximateMessagesTokens(assembled.messages),
+  );
   return {
     ...assembled,
     messages,
-    estimatedTokens: Math.max(assembled.estimatedTokens, approximateMessagesTokens(messages)),
+    estimatedTokens: baseEstimatedTokens + approximateMessageTokens(fallbackUser),
   };
 }
 

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -160,9 +160,12 @@ test("assemble passes correct configuration mapping and returns expected payload
   assert.equal(params.emitDebug, true);
 
   // Verify inbound response handling
-  assert.equal(assembled.estimatedTokens, 150);
+  assert.equal(assembled.estimatedTokens, 164);
   assert.equal(assembled.systemPromptAddition, "<recalled_memories>static memory data</recalled_memories>");
-  assert.deepEqual(assembled.messages, [{ role: "assistant", content: "Mocked recalled context" }]);
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "what do you remember?" },
+    { role: "assistant", content: "Mocked recalled context" },
+  ]);
   assert.equal(assembled.debug?.recoveryTriggerFired, true);
 });
 

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -192,7 +192,8 @@ test("assemble clamps oversized daemon context to token budget", async () => {
   });
 
   assert.ok(assembled.estimatedTokens <= 256);
-  assert.ok(assembled.messages.length <= 1);
+  assert.ok(assembled.messages.length <= 2);
+  assert.equal(assembled.messages[0]?.role, "user");
 });
 
 test("assemble fail-closed on sidecar errors with budget-clamped fallback", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -375,6 +375,32 @@ test("context engine assemble reinjects a user turn when daemon output is assist
   );
 });
 
+test("context engine assemble preserves reinjected user turn during budget clamp", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [{ role: "assistant", content: "x".repeat(100) }],
+    estimatedTokens: 999,
+    systemPromptAddition: "",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn() {},
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "current user query")],
+    prompt: "current user query",
+    tokenBudget: 300,
+  });
+
+  assert.equal(assembled.messages[0]?.role, "user");
+  assert.equal(assembled.messages[0]?.content, "current user query");
+  assert.ok(assembled.estimatedTokens <= 44);
+});
+
 test("context engine assemble injects exact factual recall for marker tokens", async () => {
   const rpc = new FakeRpc();
   const marker = "CROSS_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -401,6 +401,37 @@ test("context engine assemble preserves reinjected user turn during budget clamp
   assert.ok(assembled.estimatedTokens <= 44);
 });
 
+test("context engine assemble budgets system prompt when preserving reinjected user turn", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [{ role: "assistant", content: "x".repeat(100) }],
+    estimatedTokens: 999,
+    systemPromptAddition: `<context>\n${"s".repeat(500)}`,
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn() {},
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "current user query")],
+    prompt: "current user query",
+    tokenBudget: 300,
+  });
+
+  const approxPromptTokens = Math.ceil(assembled.systemPromptAddition.length / 4);
+  const approxUserTokens = Math.ceil(String(assembled.messages[0]?.content ?? "").length / 4) + 8;
+
+  assert.equal(assembled.messages.length, 1);
+  assert.equal(assembled.messages[0]?.role, "user");
+  assert.equal(assembled.messages[0]?.content, "current user query");
+  assert.ok(approxPromptTokens + approxUserTokens <= 44);
+  assert.ok(assembled.estimatedTokens <= 44);
+});
+
 test("context engine assemble injects exact factual recall for marker tokens", async () => {
   const rpc = new FakeRpc();
   const marker = "CROSS_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -251,7 +251,10 @@ test("context engine uses gRPC kernel on cold assemble without falling back to R
   assert.equal(params.sessionId, "s1");
   assert.equal(params.sessionKey, "sk1");
   assert.equal(params.userId, "fixed-user");
-  assert.deepEqual(assembled.messages, [{ role: "assistant", content: "kernel context" }]);
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "kernel context" },
+  ]);
 });
 
 function makeMessage(role: string, content: string, id?: string) {
@@ -334,6 +337,41 @@ test("context engine assemble resolves config userId and passes it to daemon", a
   assert.equal(call.params.sessionId, "s1");
   assert.equal(call.params.sessionKey, "sk1");
   assert.equal(call.params.userId, "fixed-user");
+});
+
+test("context engine assemble reinjects a user turn when daemon output is assistant-only", async () => {
+  const rpc = new FakeRpc();
+  rpc.assembleResponse = {
+    messages: [{ role: "assistant", content: "recalled memory block" }],
+    estimatedTokens: 24,
+    systemPromptAddition: "",
+  };
+  const warnings: string[] = [];
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "fixed-user" }, {
+    error() {},
+    info() {},
+    warn(message: string) { warnings.push(message); },
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("assistant", "previous context"),
+      makeMessage("user", "current user query"),
+    ],
+    prompt: "current user query",
+    tokenBudget: 4000,
+  });
+
+  assert.equal(assembled.messages[0]?.role, "user");
+  assert.equal(assembled.messages[0]?.content, "current user query");
+  assert.equal(assembled.messages[1]?.role, "assistant");
+  assert.equal(assembled.messages[1]?.content, "recalled memory block");
+  assert.equal(
+    warnings.some((message) => /reinjecting the latest user message/.test(message)),
+    true,
+  );
 });
 
 test("context engine assemble injects exact factual recall for marker tokens", async () => {
@@ -451,7 +489,10 @@ test("context engine exact recall skips additions that would exceed the token bu
 
   assert.equal(assembled.systemPromptAddition, "");
   assert.equal(assembled.estimatedTokens, 43);
-  assert.match(warnings[0] ?? "", /addition exceeds token budget/);
+  assert.equal(
+    warnings.some((message) => /addition exceeds token budget/.test(message)),
+    true,
+  );
 });
 
 test("context engine assemble keeps daemon result when exact recall RPC acquisition fails", async () => {
@@ -489,9 +530,15 @@ test("context engine assemble keeps daemon result when exact recall RPC acquisit
     tokenBudget: 4000,
   });
 
-  assert.deepEqual(assembled.messages, [{ role: "assistant", content: "base recalled context" }]);
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: `What does ${marker} mean?` },
+    { role: "assistant", content: "base recalled context" },
+  ]);
   assert.equal(getRpcCalls, 2);
-  assert.match(warnings[0] ?? "", /exact recall skipped/);
+  assert.equal(
+    warnings.some((message) => /exact recall skipped/.test(message)),
+    true,
+  );
 });
 
 test("context engine exact recall skips empty-text search results", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -368,6 +368,7 @@ test("context engine assemble reinjects a user turn when daemon output is assist
   assert.equal(assembled.messages[0]?.content, "current user query");
   assert.equal(assembled.messages[1]?.role, "assistant");
   assert.equal(assembled.messages[1]?.content, "recalled memory block");
+  assert.equal(assembled.estimatedTokens, 37);
   assert.equal(
     warnings.some((message) => /reinjecting the latest user message/.test(message)),
     true,
@@ -488,7 +489,8 @@ test("context engine exact recall skips additions that would exceed the token bu
   });
 
   assert.equal(assembled.systemPromptAddition, "");
-  assert.equal(assembled.estimatedTokens, 43);
+  assert.equal(assembled.messages[0]?.role, "user");
+  assert.ok(assembled.estimatedTokens <= 44);
   assert.equal(
     warnings.some((message) => /addition exceeds token budget/.test(message)),
     true,


### PR DESCRIPTION
## Summary

Ensures assembled context still contains a replay-safe user turn when daemon/kernel output would otherwise be assistant-only.

## Scope

- Reinserts the latest non-empty source user turn when normalized assembled output has no user message.
- Applies the guard to both gRPC kernel and sidecar RPC assemble paths.
- Accounts for the reinjected user turn in `estimatedTokens`.
- Preserves the reinjected user turn through budget clamping while reserving room for `systemPromptAddition`.

## Audit Notes

- Current merge state is `DIRTY`; this branch must be rebased before review.
- This is not the same as blindly appending stale user text. The source user turn must be current and budget-accounted.
- After rebase, rerun the focused context-engine and host-flow tests because this touches replay shape and token accounting.

## Review Follow-up

- Branch is `DIRTY`; rebase before review.
- The old #218/#221 merge-order concerns are obsolete because those PRs were closed.
- Still review the XML/system-prompt truncation path: character slicing can cut structured prompt additions mid-tag.
- Verify tool-call conversation shapes are not broken by prepending the preserved user turn.
- Prefer resilient token assertions where exact token counts are incidental.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js .ts-build/test/integration/host-flow.test.js`
- `pnpm run check`

Fixes #159.

– Vale