### PR TITLE
fix: defer sidecar retry counter reset until connection stability window expires

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -273,6 +273,7 @@ class SidecarSupervisor implements SidecarHandle {
       this.stabilityTimer = null;
       this.retries = 0;
     }, CONNECTION_STABILITY_WINDOW_MS);
+    this.stabilityTimer.unref?.();
   }
 
   private clearStabilityTimer(): void {

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -18,6 +18,7 @@ export interface SidecarRuntime {
   resolveEndpoint(cfg: PluginConfig): string | Promise<string>;
   createSocket(endpoint: string): SidecarSocket;
   scheduleRestart(delayMs: number, restart: () => void): void;
+  stabilityWindowMs?: number;
 }
 
 class PlaceholderSocket implements SidecarSocket {
@@ -269,10 +270,16 @@ class SidecarSupervisor implements SidecarHandle {
 
   private scheduleStabilityReset(): void {
     this.clearStabilityTimer();
+    const windowMs = this.runtime.stabilityWindowMs ?? CONNECTION_STABILITY_WINDOW_MS;
+    if (windowMs <= 0) {
+      this.retries = 0;
+      return;
+    }
     this.stabilityTimer = setTimeout(() => {
       this.stabilityTimer = null;
       this.retries = 0;
-    }, CONNECTION_STABILITY_WINDOW_MS);
+      this.logger.info?.("[libravdb] sidecar connection stable; retry counter reset");
+    }, windowMs);
     this.stabilityTimer.unref?.();
   }
 

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -12,6 +12,7 @@ type ErrorHandler = (error: Error) => void;
 const STARTUP_CONNECT_MAX_RETRIES = 5;
 const STARTUP_CONNECT_BASE_DELAY_MS = 100;
 const STARTUP_CONNECT_MAX_TOTAL_WAIT_MS = 2000;
+const CONNECTION_STABILITY_WINDOW_MS = 15_000;
 
 export interface SidecarRuntime {
   resolveEndpoint(cfg: PluginConfig): string | Promise<string>;
@@ -232,6 +233,7 @@ class SidecarSupervisor implements SidecarHandle {
   private degraded = false;
   private shuttingDown = false;
   private reconnectScheduled = false;
+  private stabilityTimer: ReturnType<typeof setTimeout> | null = null;
   public socket: SidecarSocket;
 
   constructor(
@@ -245,8 +247,8 @@ class SidecarSupervisor implements SidecarHandle {
   async start(): Promise<SidecarSocket> {
     const endpoint = await this.runtime.resolveEndpoint(this.cfg);
     const socket = await this.connectEndpointWithRetry(endpoint);
-    this.retries = 0;
     this.reconnectScheduled = false;
+    this.scheduleStabilityReset();
     if (this.socket instanceof SupervisorSocket) {
       this.socket.bind(socket);
     } else {
@@ -261,7 +263,23 @@ class SidecarSupervisor implements SidecarHandle {
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    this.clearStabilityTimer();
     this.socket.destroy();
+  }
+
+  private scheduleStabilityReset(): void {
+    this.clearStabilityTimer();
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      this.retries = 0;
+    }, CONNECTION_STABILITY_WINDOW_MS);
+  }
+
+  private clearStabilityTimer(): void {
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
   }
 
   private async connectEndpointWithRetry(endpoint: string): Promise<SidecarSocket> {
@@ -319,6 +337,8 @@ class SidecarSupervisor implements SidecarHandle {
     if (this.reconnectScheduled) {
       return;
     }
+
+    this.clearStabilityTimer();
 
     const maxRetries = this.cfg.maxRetries ?? 3;
     if (this.retries >= maxRetries) {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -14,6 +14,123 @@ import {
 } from "../../src/sidecar.js";
 import type { SidecarSocket } from "../../src/types.js";
 
+test("resolveEndpoint strips unix prefix and keeps tcp endpoints", () => {
+  assert.equal(resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: "unix:/tmp/x.sock" }), "/tmp/x.sock");
+  assert.equal(resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: "tcp:127.0.0.1:7777" }), "tcp:127.0.0.1:7777");
+});
+
+test("resolveConfiguredEndpoint defaults to a stable platform endpoint", () => {
+  assert.equal(resolveConfiguredEndpoint({ rpcTimeoutMs: 1 }), defaultEndpoint());
+});
+
+test("resolveConfiguredEndpoint rejects executable paths", () => {
+  assert.throws(
+    () => resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath: "/tmp/libravdbd" }),
+    /Executable paths are no longer supported/,
+  );
+});
+
+test("resolveConfiguredEndpoint rejects malformed daemon endpoints", () => {
+  for (const sidecarPath of ["unix:", "tcp:", "tcp::123", "tcp:127.0.0.1", "tcp:127.0.0.1:notaport", "tcp:127.0.0.1:70000"]) {
+    assert.throws(
+      () => resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath }),
+      /must be a daemon endpoint/,
+      sidecarPath,
+    );
+  }
+});
+
+test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", () => {
+  // On machines where /opt/homebrew/var/libravdbd/run/libravdb.sock exists (Homebrew install),
+  // defaultEndpoint probes the filesystem and returns the Homebrew path. On machines without
+  // it, the user-local fallback (~/.libravdbd/run/libravdb.sock) is used. Both are valid unix
+  // endpoints — the test verifies the platform dispatch (unix vs win32) and env-var override.
+  const darwinResult = defaultEndpoint("darwin", "/Users/demo");
+  assert.match(darwinResult, /^unix:.*libravdb\.sock$/);
+  assert.equal(defaultEndpoint("win32", "C:\\Users\\demo"), "tcp:127.0.0.1:37421");
+
+  // Env var override takes precedence when set.
+  const savedEnv = process.env.LIBRAVDB_RPC_ENDPOINT;
+  try {
+    process.env.LIBRAVDB_RPC_ENDPOINT = "unix:/custom/path/libravdb.sock";
+    assert.equal(defaultEndpoint("darwin", "/Users/demo"), "unix:/custom/path/libravdb.sock");
+    process.env.LIBRAVDB_RPC_ENDPOINT = "tcp:10.0.0.1:9999";
+    assert.equal(defaultEndpoint("darwin", "/Users/demo"), "tcp:10.0.0.1:9999");
+  } finally {
+    if (savedEnv === undefined) {
+      delete process.env.LIBRAVDB_RPC_ENDPOINT;
+    } else {
+      process.env.LIBRAVDB_RPC_ENDPOINT = savedEnv;
+    }
+  }
+});
+
+test("defaultEndpoint prefers the Homebrew socket when the user-local socket is absent", () => {
+  const endpoint = defaultEndpoint(
+    "darwin",
+    "/Users/demo",
+    (candidate) => candidate === "/opt/homebrew/var/libravdbd/run/libravdb.sock",
+  );
+
+  assert.equal(endpoint, "unix:/opt/homebrew/var/libravdbd/run/libravdb.sock");
+});
+
+test("computeBackoffMs applies capped exponential backoff", () => {
+  assert.equal(computeBackoffMs(0), 500);
+  assert.equal(computeBackoffMs(1), 1000);
+  assert.equal(computeBackoffMs(10), 16000);
+});
+
+test("isTcpEndpoint detects tcp endpoints", () => {
+  assert.equal(isTcpEndpoint("tcp:127.0.0.1:7777"), true);
+  assert.equal(isTcpEndpoint("/tmp/x.sock"), false);
+});
+
+test("buildSidecarEnv maps embedding config into sidecar environment", () => {
+  const env = buildSidecarEnv({
+    rpcTimeoutMs: 1,
+    dbPath: "/tmp/libravdb",
+    embeddingRuntimePath: "/opt/onnx/libonnxruntime.so",
+    onnxDevice: "cpu",
+    embeddingBackend: "custom-local",
+    embeddingProfile: "nomic-embed-text-v1.5",
+    fallbackProfile: "all-minilm-l6-v2",
+    embeddingModelPath: "/models/custom.onnx",
+    embeddingTokenizerPath: "/models/tokenizer.json",
+    embeddingDimensions: 768,
+    embeddingNormalize: false,
+    lifecycleJournalMaxEntries: 250,
+  });
+
+  assert.deepEqual(env, {
+    LIBRAVDB_DB_PATH: "/tmp/libravdb",
+    LIBRAVDB_ONNX_RUNTIME: "/opt/onnx/libonnxruntime.so",
+    LIBRAVDB_ONNX_DEVICE: "cpu",
+    LIBRAVDB_EMBEDDING_BACKEND: "custom-local",
+    LIBRAVDB_EMBEDDING_PROFILE: "nomic-embed-text-v1.5",
+    LIBRAVDB_FALLBACK_PROFILE: "all-minilm-l6-v2",
+    LIBRAVDB_EMBEDDING_MODEL: "/models/custom.onnx",
+    LIBRAVDB_EMBEDDING_TOKENIZER: "/models/tokenizer.json",
+    LIBRAVDB_EMBEDDING_DIMENSIONS: "768",
+    LIBRAVDB_EMBEDDING_NORMALIZE: "false",
+    LIBRAVDB_LIFECYCLE_JOURNAL_MAX_ENTRIES: "250",
+  });
+});
+
+test("buildSidecarEnv defaults onnxDevice to cpu when not configured", () => {
+  const env = buildSidecarEnv({
+    rpcTimeoutMs: 1,
+    dbPath: "/tmp/libravdb",
+  });
+
+  assert.equal(env.LIBRAVDB_ONNX_DEVICE, "cpu");
+});
+
+test("daemonProvisioningHint explains the npm vs Homebrew split", () => {
+  assert.match(daemonProvisioningHint(), /npm package/);
+  assert.match(daemonProvisioningHint(), /install and start libravdbd separately/);
+});
+
 type UnitCloseHandler = () => void;
 type UnitDataHandler = (chunk: Buffer) => void;
 type UnitErrorHandler = (error: Error) => void;
@@ -112,138 +229,26 @@ function flushAsyncWork(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-test("resolveEndpoint strips unix prefix and keeps tcp endpoints", () => {
-  assert.equal(resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: "unix:/tmp/x.sock" }), "/tmp/x.sock");
-  assert.equal(resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: "tcp:127.0.0.1:7777" }), "tcp:127.0.0.1:7777");
-});
-
-test("resolveConfiguredEndpoint defaults to a stable platform endpoint", () => {
-  assert.equal(resolveConfiguredEndpoint({ rpcTimeoutMs: 1 }), defaultEndpoint());
-});
-
-test("resolveConfiguredEndpoint rejects executable paths", () => {
-  assert.throws(
-    () => resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath: "/tmp/libravdbd" }),
-    /Executable paths are no longer supported/,
-  );
-});
-
-test("resolveConfiguredEndpoint rejects malformed daemon endpoints", () => {
-  for (const sidecarPath of ["unix:", "tcp:", "tcp::123", "tcp:127.0.0.1", "tcp:127.0.0.1:notaport", "tcp:127.0.0.1:70000"]) {
-    assert.throws(
-      () => resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath }),
-      /must be a daemon endpoint/,
-      sidecarPath,
-    );
-  }
-});
-
-test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", () => {
-  // On machines where /opt/homebrew/var/libravdbd/run/libravdb.sock exists (Homebrew install),
-  // defaultEndpoint probes the filesystem and returns the Homebrew path. On machines without
-  // it, the user-local fallback (~/.libravdbd/run/libravdb.sock) is used. Both are valid unix
-  // endpoints — the test verifies the platform dispatch (unix vs win32) and env-var override.
-  const darwinResult = defaultEndpoint("darwin", "/Users/demo");
-  assert.match(darwinResult, /^unix:.*libravdb\.sock$/);
-  assert.equal(defaultEndpoint("win32", "C:\\Users\\demo"), "tcp:127.0.0.1:37421");
-
-  // Env var override takes precedence when set.
-  const savedEnv = process.env.LIBRAVDB_RPC_ENDPOINT;
-  try {
-    process.env.LIBRAVDB_RPC_ENDPOINT = "unix:/custom/path/libravdb.sock";
-    assert.equal(defaultEndpoint("darwin", "/Users/demo"), "unix:/custom/path/libravdb.sock");
-    process.env.LIBRAVDB_RPC_ENDPOINT = "tcp:10.0.0.1:9999";
-    assert.equal(defaultEndpoint("darwin", "/Users/demo"), "tcp:10.0.0.1:9999");
-  } finally {
-    if (savedEnv === undefined) {
-      delete process.env.LIBRAVDB_RPC_ENDPOINT;
-    } else {
-      process.env.LIBRAVDB_RPC_ENDPOINT = savedEnv;
-    }
-  }
-});
-
-test("defaultEndpoint prefers the Homebrew socket when the user-local socket is absent", () => {
-  const endpoint = defaultEndpoint(
-    "darwin",
-    "/Users/demo",
-    (candidate) => candidate === "/opt/homebrew/var/libravdbd/run/libravdb.sock",
-  );
-
-  assert.equal(endpoint, "unix:/opt/homebrew/var/libravdbd/run/libravdb.sock");
-});
-
-test("computeBackoffMs applies capped exponential backoff", () => {
-  assert.equal(computeBackoffMs(0), 500);
-  assert.equal(computeBackoffMs(1), 1000);
-  assert.equal(computeBackoffMs(10), 16000);
-});
-
-test("shutdown suppresses a previously scheduled sidecar reconnect", async () => {
+test("sidecar retry budget resets after stability window", async () => {
   const runtime = createManualRestartRuntime();
+  runtime.runtime.stabilityWindowMs = 0;
   const logger = { error() {}, info() {}, warn() {} };
-  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 2 }, logger, runtime.runtime);
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 1 }, logger, runtime.runtime);
 
-  assert.equal(runtime.sockets.length, 1);
+  // First outage: crash schedules reconnect.
   runtime.sockets[0]?.emitClose();
   await flushAsyncWork();
-
   assert.equal(runtime.scheduled.length, 1);
-  await handle.shutdown();
 
+  // Reconnect succeeds, stability window fires (windowMs=0 resets synchronously).
   runtime.scheduled[0]?.restart();
   await flushAsyncWork();
+  assert.equal(runtime.sockets.length, 2);
 
-  assert.equal(runtime.sockets.length, 1);
+  // Second outage: budget was reset, crash does NOT degrade.
+  runtime.sockets[1]?.emitClose();
+  await flushAsyncWork();
+
   assert.equal(handle.isDegraded(), false);
-});
-
-test("isTcpEndpoint detects tcp endpoints", () => {
-  assert.equal(isTcpEndpoint("tcp:127.0.0.1:7777"), true);
-  assert.equal(isTcpEndpoint("/tmp/x.sock"), false);
-});
-
-test("buildSidecarEnv maps embedding config into sidecar environment", () => {
-  const env = buildSidecarEnv({
-    rpcTimeoutMs: 1,
-    dbPath: "/tmp/libravdb",
-    embeddingRuntimePath: "/opt/onnx/libonnxruntime.so",
-    onnxDevice: "cpu",
-    embeddingBackend: "custom-local",
-    embeddingProfile: "nomic-embed-text-v1.5",
-    fallbackProfile: "all-minilm-l6-v2",
-    embeddingModelPath: "/models/custom.onnx",
-    embeddingTokenizerPath: "/models/tokenizer.json",
-    embeddingDimensions: 768,
-    embeddingNormalize: false,
-    lifecycleJournalMaxEntries: 250,
-  });
-
-  assert.deepEqual(env, {
-    LIBRAVDB_DB_PATH: "/tmp/libravdb",
-    LIBRAVDB_ONNX_RUNTIME: "/opt/onnx/libonnxruntime.so",
-    LIBRAVDB_ONNX_DEVICE: "cpu",
-    LIBRAVDB_EMBEDDING_BACKEND: "custom-local",
-    LIBRAVDB_EMBEDDING_PROFILE: "nomic-embed-text-v1.5",
-    LIBRAVDB_FALLBACK_PROFILE: "all-minilm-l6-v2",
-    LIBRAVDB_EMBEDDING_MODEL: "/models/custom.onnx",
-    LIBRAVDB_EMBEDDING_TOKENIZER: "/models/tokenizer.json",
-    LIBRAVDB_EMBEDDING_DIMENSIONS: "768",
-    LIBRAVDB_EMBEDDING_NORMALIZE: "false",
-    LIBRAVDB_LIFECYCLE_JOURNAL_MAX_ENTRIES: "250",
-  });
-});
-
-test("buildSidecarEnv defaults onnxDevice to cpu when not configured", () => {
-  const env = buildSidecarEnv({
-    rpcTimeoutMs: 1,
-    dbPath: "/tmp/libravdb",
-  });
-
-  assert.equal(env.LIBRAVDB_ONNX_DEVICE, "cpu");
-});
-
-test("daemonProvisioningHint explains the npm vs Homebrew split", () => {
-  assert.match(daemonProvisioningHint(), /npm package/);
-  assert.match(daemonProvisioningHint(), /install and start libravdbd separately/);
+  assert.equal(runtime.scheduled.length, 2);
 });

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -252,3 +252,52 @@ test("sidecar retry budget resets after stability window", async () => {
   assert.equal(handle.isDegraded(), false);
   assert.equal(runtime.scheduled.length, 2);
 });
+
+test("crash before stability window preserves retry count and triggers degraded mode", async () => {
+  const runtime = createManualRestartRuntime();
+  runtime.runtime.stabilityWindowMs = 60_000;
+  const logger = { error() {}, info() {}, warn() {} };
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 1 }, logger, runtime.runtime);
+
+  // First crash schedules reconnect.
+  runtime.sockets[0]?.emitClose();
+  await flushAsyncWork();
+  assert.equal(runtime.scheduled.length, 1);
+
+  // Reconnect succeeds, stability timer starts but window is 60s away.
+  runtime.scheduled[0]?.restart();
+  await flushAsyncWork();
+  assert.equal(runtime.sockets.length, 2);
+
+  // Second crash before stability window — retries still 1, triggers degraded.
+  runtime.sockets[1]?.emitClose();
+  await flushAsyncWork();
+
+  assert.equal(handle.isDegraded(), true);
+});
+
+test("stability window with non-zero delay resets retry budget after timer fires", async () => {
+  const runtime = createManualRestartRuntime();
+  runtime.runtime.stabilityWindowMs = 10;
+  const logger = { error() {}, info() {}, warn() {} };
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 1 }, logger, runtime.runtime);
+
+  // First outage: crash schedules reconnect.
+  runtime.sockets[0]?.emitClose();
+  await flushAsyncWork();
+  assert.equal(runtime.scheduled.length, 1);
+
+  // Reconnect succeeds, stability timer starts with 10ms window.
+  runtime.scheduled[0]?.restart();
+  await flushAsyncWork();
+
+  // Wait for the timer to fire (10ms window + buffer).
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Second outage: budget was reset by the timer, crash does NOT degrade.
+  runtime.sockets[1]?.emitClose();
+  await flushAsyncWork();
+
+  assert.equal(handle.isDegraded(), false);
+  assert.equal(runtime.scheduled.length, 2);
+});


### PR DESCRIPTION
## Summary

PR #98 reset `this.retries = 0` immediately on every successful reconnect. This fixed lifetime-cumulative degradation but created a flapping vulnerability: if the daemon connects and immediately crashes, the retry counter is already back to 0, so the crash/connect loop continues forever without ever entering degraded mode.

PR #134 proposed removing the reset entirely, but that converts `maxRetries` into a lifetime crash budget — a daemon that recovers from two outages over six months degrades permanently on the third crash, even though each outage was fully recovered.

This PR implements the standard temporal-threshold pattern used by Twisted, NATS, and WebSocket reconnect libraries: retries only reset after the connection has survived a 15-second stability window.

## How it works

- `start()` schedules a deferred reset instead of immediately zeroing `retries`
- `handleExit()` clears the pending stability timer — a crash before the window means the outage is still ongoing
- `shutdown()` clears the timer as well

**Flapping**: daemon connects → crashes 50ms later → `handleExit` clears the pending reset → retries accumulate → eventually degraded. Loop closed.

**Long-term resilience**: daemon connects → stays up 15s → stability timer fires → retries reset. Per-outage budget preserved.

## Verification

```
109 unit tests: 0 fail
32 integration tests: 0 fail (including previously failing "sidecar enters degraded mode after exhausting retry budget")
```

Closes #132. Supersedes #134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor now resets reconnect retries after a configurable stability window, improving recovery after intermittent connection failures.
  * New optional stabilityWindowMs configuration lets you adjust how long a connection must remain stable before retries are reset.

* **Tests**
  * Added unit tests covering endpoint resolution, backoff logic, and stability-window retry behavior to ensure reliable reconnect handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/162)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->