### PR TITLE
fix: require explicit markdown ingestion enable flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,10 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
 | `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
 
+Configured markdown roots are ignored unless the matching enable flag is set to
+`true`. Set `markdownIngestionEnabled: true` for generic roots and
+`markdownIngestionObsidianEnabled: true` for Obsidian vault roots.
+
 ## Dream promotion
 
 | Key | Type | Default | Notes |

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -151,7 +151,7 @@ export function createMarkdownIngestionHandle(
   }
 
   const obsidianRoots = normalizeMarkdownRoots(cfg.markdownIngestionObsidianRoots);
-  if (cfg.markdownIngestionObsidianEnabled !== false && obsidianRoots.length > 0) {
+  if (cfg.markdownIngestionObsidianEnabled === true && obsidianRoots.length > 0) {
     adapters.push(
       new DirectoryMarkdownSourceAdapter(
         "obsidian",
@@ -738,10 +738,7 @@ function resolveMarkdownSnapshotPath(kind: string, configuredPath?: string): str
 }
 
 function isMarkdownIngestionEnabled(cfg: PluginConfig, roots: string[]): boolean {
-  if (cfg.markdownIngestionEnabled === false) {
-    return false;
-  }
-  return roots.length > 0;
+  return cfg.markdownIngestionEnabled === true && roots.length > 0;
 }
 
 function createRealFsApi(): FsApi {

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -87,6 +87,61 @@ function snapshotPath(tempRoot: string, kind: "generic" | "obsidian" = "generic"
   return path.join(tempRoot, `${kind}-snapshot.json`);
 }
 
+test("markdown ingestion roots stay inert unless explicitly enabled", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-disabled-"));
+  const filePath = path.join(tempRoot, "MEMORY.md");
+  await fsp.writeFile(filePath, "# Memory\n\nThis root is configured but not enabled.");
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+    },
+    async () => rpc,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+  fsApi.triggerAll("change");
+  await delay(25);
+
+  assert.equal(rpc.calls.length, 0);
+  assert.equal(fsApi.callbacks.size, 0);
+
+  await handle.stop();
+});
+
+test("obsidian roots stay inert unless explicitly enabled", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-obsidian-disabled-"));
+  const filePath = path.join(tempRoot, "tagged.md");
+  await fsp.writeFile(filePath, "# Project #openclaw\n\nThis vault root is configured but not enabled.");
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: false,
+      markdownIngestionObsidianRoots: [tempRoot],
+      markdownIngestionObsidianDebounceMs: 0,
+    },
+    async () => rpc,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+  fsApi.triggerAll("change");
+  await delay(25);
+
+  assert.equal(rpc.calls.length, 0);
+  assert.equal(fsApi.callbacks.size, 0);
+
+  await handle.stop();
+});
+
 test("markdown ingestion forwards raw markdown to the go sidecar and stays hash-stable", async () => {
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-"));
   const nestedDir = path.join(tempRoot, "skills", "alpha");


### PR DESCRIPTION
## Summary

- Fixes #163.
- Require `markdownIngestionEnabled === true` before generic markdown roots are watched.
- Require `markdownIngestionObsidianEnabled === true` before Obsidian roots are watched.
- Add integration coverage proving configured roots stay inert when the corresponding enable flag is omitted.
- Clarify the config docs so roots and enable flags have the same contract as the runtime.

## Contributor Checklist

- Lifecycle separation unchanged; no daemon lifecycle/bootstrap behavior added.
- User-visible config behavior documented in `docs/configuration.md`.
- Validation was not weakened; new coverage is additive.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json` — PASS
- `node --test .ts-build/test/integration/markdown-ingest.test.js` — PASS
- `pnpm run check` — PASS after docs update
- `pnpm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 and unrelated to markdown ingestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that markdown ingestion roots remain inactive unless explicitly enabled through configuration settings.

* **Bug Fixes**
  * Corrected configuration flag validation to strictly require explicit enablement values for markdown ingestion activation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->