### PR TITLE
fix: trim unix sidecar endpoint paths

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -411,12 +411,13 @@ export function resolveConfiguredEndpoint(cfg: PluginConfig): string {
   if (!value || value === "auto") {
     return defaultEndpoint();
   }
-  if (!isConfiguredEndpoint(value)) {
+  const endpoint = normalizeConfiguredEndpoint(value);
+  if (!endpoint) {
     throw new Error(
       `LibraVDB sidecarPath must be a daemon endpoint like unix:/path/to/libravdb.sock or tcp:127.0.0.1:37421. Executable paths are no longer supported.`,
     );
   }
-  return value;
+  return endpoint;
 }
 
 export function daemonProvisioningHint(): string {
@@ -429,8 +430,8 @@ export function defaultEndpoint(
   pathExists: (path: string) => boolean = fs.existsSync,
 ): string {
   // Honour the daemon's own env var first (set by Homebrew LaunchAgent / systemd unit).
-  const envEndpoint = process.env.LIBRAVDB_RPC_ENDPOINT?.trim();
-  if (envEndpoint && isConfiguredEndpoint(envEndpoint)) {
+  const envEndpoint = normalizeConfiguredEndpoint(process.env.LIBRAVDB_RPC_ENDPOINT);
+  if (envEndpoint) {
     return envEndpoint;
   }
 
@@ -604,6 +605,18 @@ function isConfiguredEndpoint(value?: string): boolean {
   const host = address.slice(0, separator).trim();
   const port = Number(address.slice(separator + 1));
   return host.length > 0 && Number.isInteger(port) && port > 0 && port <= 65535;
+}
+
+function normalizeConfiguredEndpoint(value?: string): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "auto") {
+    return null;
+  }
+  if (trimmed.startsWith("unix:")) {
+    const socketPath = trimmed.slice("unix:".length).trim();
+    return socketPath ? `unix:${socketPath}` : null;
+  }
+  return isConfiguredEndpoint(trimmed) ? trimmed : null;
 }
 
 export { PlaceholderSocket };

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -40,6 +40,17 @@ test("resolveConfiguredEndpoint rejects malformed daemon endpoints", () => {
   }
 });
 
+test("resolveConfiguredEndpoint normalizes incidental Unix path whitespace", () => {
+  assert.equal(
+    resolveConfiguredEndpoint({ rpcTimeoutMs: 1, sidecarPath: " unix: /tmp/libravdb.sock " }),
+    "unix:/tmp/libravdb.sock",
+  );
+  assert.equal(
+    resolveEndpoint({ rpcTimeoutMs: 1, sidecarPath: " unix: /tmp/libravdb.sock " }),
+    "/tmp/libravdb.sock",
+  );
+});
+
 test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", () => {
   // On machines where /opt/homebrew/var/libravdbd/run/libravdb.sock exists (Homebrew install),
   // defaultEndpoint probes the filesystem and returns the Homebrew path. On machines without
@@ -52,7 +63,7 @@ test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", (
   // Env var override takes precedence when set.
   const savedEnv = process.env.LIBRAVDB_RPC_ENDPOINT;
   try {
-    process.env.LIBRAVDB_RPC_ENDPOINT = "unix:/custom/path/libravdb.sock";
+    process.env.LIBRAVDB_RPC_ENDPOINT = "unix: /custom/path/libravdb.sock ";
     assert.equal(defaultEndpoint("darwin", "/Users/demo"), "unix:/custom/path/libravdb.sock");
     process.env.LIBRAVDB_RPC_ENDPOINT = "tcp:10.0.0.1:9999";
     assert.equal(defaultEndpoint("darwin", "/Users/demo"), "tcp:10.0.0.1:9999");


### PR DESCRIPTION
## Summary

- Fixes #165.
- Normalize configured Unix endpoints by trimming the socket path portion before returning the endpoint.
- Apply the same normalization to `LIBRAVDB_RPC_ENDPOINT` Unix overrides.
- Add unit coverage for incidental Unix endpoint whitespace.

## Contributor Checklist

- Lifecycle separation unchanged; no daemon lifecycle/bootstrap behavior added.
- No user-facing config contract changed; this makes an already-accepted endpoint form connect to the validated path.
- Validation was not weakened; new coverage is additive.

## Verification

- `pnpm exec tsc -p tsconfig.tests.json` — PASS
- `node --test .ts-build/test/unit/sidecar.test.js` — PASS
- `pnpm run check` — PASS
- `pnpm run test:integration` — FAIL: existing upstream failure in `sidecar enters degraded mode after exhausting retry budget` (`false !== true`), tracked by #132 and unrelated to Unix endpoint normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of whitespace in sidecar endpoint configuration paths—paths with leading/trailing spaces are now properly normalized.
  * Improved endpoint validation to reject invalid configurations more reliably.

* **Tests**
  * Added tests verifying proper normalization of Unix socket paths with incidental whitespace.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->