### PR TITLE
fix: skip memory hooks when slot is disabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,10 @@ export function register(api: OpenClawPluginApi) {
       );
     }
     if (memSlot === "none") {
-      logger.info?.("[libravdb-memory] plugins.slots.memory is \"none\"; skipping memory and context-engine hooks.");
+      logger.info?.(
+        "[libravdb-memory] plugins.slots.memory is \"none\"; " +
+        "skipping memory capability, context engine, embedding providers, services, and hooks.",
+      );
       registerMemoryCli(api, null, cfg, logger);
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,23 @@ export function register(api: OpenClawPluginApi) {
     `crossSessionRecall=${cfg.crossSessionRecall !== false}`,
   );
 
+  // Slot gating: reject conflicts and skip explicit opt-out BEFORE runtime
+  // creation, so no work is wasted when memory is disabled or misconfigured.
+  const memSlot = api.config?.plugins?.slots?.memory;
+  if (!isLightweight && !isDiscovery) {
+    if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {
+      throw new Error(
+        `[libravdb-memory] plugins.slots.memory is "${memSlot}". ` +
+          `Set it to "libravdb-memory" before enabling this plugin.`,
+      );
+    }
+    if (memSlot === "none") {
+      logger.info?.("[libravdb-memory] plugins.slots.memory is \"none\"; skipping memory and context-engine hooks.");
+      registerMemoryCli(api, null, cfg, logger);
+      return;
+    }
+  }
+
   // Runtime creation:
   // - Lightweight modes (cli-metadata, setup-only): no runtime, CLI structure only.
   // - Discovery mode: runtime for lazy CLI loading, but no context engine.
@@ -70,20 +87,6 @@ export function register(api: OpenClawPluginApi) {
   const runtime = runtimeOrNull;
   if (!runtime) return; // unreachable but satisfies the type checker
 
-  // Exclusive slot check: refuse to register if another plugin owns the memory slot.
-  // plugins.slots.memory is the only configurable slot; context engine exclusivity
-  // is enforced by the registry at runtime (no config surface for it).
-  const memSlot = api.config?.plugins?.slots?.memory;
-  if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {
-    throw new Error(
-      `[libravdb-memory] plugins.slots.memory is "${memSlot}". ` +
-        `Set it to "libravdb-memory" before enabling this plugin.`,
-    );
-  }
-  if (memSlot === "none") {
-    logger.info?.("[libravdb-memory] plugins.slots.memory is \"none\"; skipping memory and context-engine hooks.");
-    return;
-  }
   if (!memSlot) {
     logger.warn?.("[libravdb-memory] plugins.slots.memory is unset; set it to \"libravdb-memory\" for memory to work.");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,13 +73,20 @@ export function register(api: OpenClawPluginApi) {
   // Exclusive slot check: refuse to register if another plugin owns the memory slot.
   // plugins.slots.memory is the only configurable slot; context engine exclusivity
   // is enforced by the registry at runtime (no config surface for it).
-  // "none" means memory is disabled, not a conflict, allow registration.
+  // "none" or an unset slot means memory is disabled, not a conflict.
   const memSlot = api.config?.plugins?.slots?.memory;
   if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {
     throw new Error(
       `[libravdb-memory] plugins.slots.memory is "${memSlot}". ` +
         `Set it to "libravdb-memory" before enabling this plugin.`,
     );
+  }
+  if (memSlot !== MEMORY_ID) {
+    logger.info?.(
+      `[libravdb-memory] plugins.slots.memory is ${memSlot ?? "(unset)"}; ` +
+        `skipping memory and context-engine hooks.`,
+    );
+    return;
   }
 
   // Migrated from three legacy calls to a single registerMemoryCapability.

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,6 @@ export function register(api: OpenClawPluginApi) {
   // Exclusive slot check: refuse to register if another plugin owns the memory slot.
   // plugins.slots.memory is the only configurable slot; context engine exclusivity
   // is enforced by the registry at runtime (no config surface for it).
-  // "none" or an unset slot means memory is disabled, not a conflict.
   const memSlot = api.config?.plugins?.slots?.memory;
   if (memSlot && memSlot !== MEMORY_ID && memSlot !== "none") {
     throw new Error(
@@ -81,12 +80,12 @@ export function register(api: OpenClawPluginApi) {
         `Set it to "libravdb-memory" before enabling this plugin.`,
     );
   }
-  if (memSlot !== MEMORY_ID) {
-    logger.info?.(
-      `[libravdb-memory] plugins.slots.memory is ${memSlot ?? "(unset)"}; ` +
-        `skipping memory and context-engine hooks.`,
-    );
+  if (memSlot === "none") {
+    logger.info?.("[libravdb-memory] plugins.slots.memory is \"none\"; skipping memory and context-engine hooks.");
     return;
+  }
+  if (!memSlot) {
+    logger.warn?.("[libravdb-memory] plugins.slots.memory is unset; set it to \"libravdb-memory\" for memory to work.");
   }
 
   // Migrated from three legacy calls to a single registerMemoryCapability.

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -10,11 +10,30 @@ import {
 } from "../../src/index.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
+type InstrumentedApi = OpenClawPluginApi & {
+  registrations: {
+    memoryCapabilities: string[];
+    contextEngines: string[];
+    embeddingProviders: string[];
+    runtimeLifecycles: string[];
+    services: string[];
+    hooks: string[];
+  };
+};
+
 /** Builds a fake OpenClawPluginApi for register(). */
 function makeFakeApi(overrides: {
   registrationMode?: string;
   slotsMemory?: string;
-} = {}): OpenClawPluginApi {
+} = {}): InstrumentedApi {
+  const registrations: InstrumentedApi["registrations"] = {
+    memoryCapabilities: [],
+    contextEngines: [],
+    embeddingProviders: [],
+    runtimeLifecycles: [],
+    services: [],
+    hooks: [],
+  };
   return {
     id: "test-plugin",
     name: "Test",
@@ -34,16 +53,49 @@ function makeFakeApi(overrides: {
       warn(_msg: string) {},
       info(_msg: string) {},
     },
-    registerMemoryCapability(_id: string, _cap: unknown) {},
-    registerContextEngine(_id: string, _factory: () => unknown) {},
-    on(_event: string, _handler: unknown) {},
-  } as unknown as OpenClawPluginApi;
+    registerMemoryCapability(id: string, _cap: unknown) {
+      registrations.memoryCapabilities.push(id);
+    },
+    registerContextEngine(id: string, _factory: () => unknown) {
+      registrations.contextEngines.push(id);
+    },
+    registerMemoryEmbeddingProvider(provider: { id?: string }) {
+      registrations.embeddingProviders.push(provider.id ?? "");
+    },
+    registerRuntimeLifecycle(lifecycle: { id?: string }) {
+      registrations.runtimeLifecycles.push(lifecycle.id ?? "");
+    },
+    registerService(service: { id?: string }) {
+      registrations.services.push(service.id ?? "");
+    },
+    on(event: string, _handler: unknown) {
+      registrations.hooks.push(event);
+    },
+    registrations,
+  } as unknown as InstrumentedApi;
 }
 
 // slot: "libravdb-memory" — no conflict, should not throw
 test("slot check — ours: register succeeds", () => {
   const api = makeFakeApi({ slotsMemory: "libravdb-memory" });
   assert.doesNotThrow(() => register(api), "should not throw when slot is libravdb-memory");
+  assert.deepEqual(api.registrations.memoryCapabilities, [MEMORY_ID]);
+  assert.deepEqual(api.registrations.contextEngines, [MEMORY_ID]);
+  assert.deepEqual(api.registrations.embeddingProviders, [
+    "libravdb-bundled",
+    "libravdb-onnx",
+  ]);
+  assert.deepEqual(api.registrations.services, [
+    "libravdb-markdown-ingestion",
+    "libravdb-dream-promotion",
+  ]);
+  assert.deepEqual(api.registrations.runtimeLifecycles, ["libravdb-shutdown"]);
+  assert.deepEqual(api.registrations.hooks, [
+    "before_reset",
+    "session_end",
+    "agent_end",
+    "gateway_stop",
+  ]);
 });
 
 // slot: another plugin — should throw with slot name in message
@@ -65,12 +117,24 @@ test("slot check — other plugin: register throws", () => {
 test("slot check — unset: register succeeds", () => {
   const api = makeFakeApi({ slotsMemory: undefined });
   assert.doesNotThrow(() => register(api), "should not throw when slot is unset");
+  assert.deepEqual(api.registrations.memoryCapabilities, []);
+  assert.deepEqual(api.registrations.contextEngines, []);
+  assert.deepEqual(api.registrations.embeddingProviders, []);
+  assert.deepEqual(api.registrations.services, []);
+  assert.deepEqual(api.registrations.runtimeLifecycles, []);
+  assert.deepEqual(api.registrations.hooks, []);
 });
 
-// slot: "none" — memory disabled, should not throw
+// slot: "none" — memory disabled, should not throw or register hooks
 test("slot check — 'none': register succeeds", () => {
   const api = makeFakeApi({ slotsMemory: "none" });
   assert.doesNotThrow(() => register(api), "should not throw when slot is 'none'");
+  assert.deepEqual(api.registrations.memoryCapabilities, []);
+  assert.deepEqual(api.registrations.contextEngines, []);
+  assert.deepEqual(api.registrations.embeddingProviders, []);
+  assert.deepEqual(api.registrations.services, []);
+  assert.deepEqual(api.registrations.runtimeLifecycles, []);
+  assert.deepEqual(api.registrations.hooks, []);
 });
 
 // registrationMode: "full" — registration proceeds

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -113,16 +113,27 @@ test("slot check — other plugin: register throws", () => {
   );
 });
 
-// slot: undefined — nobody owns it, should not throw
-test("slot check — unset: register succeeds", () => {
+// slot: undefined — nobody owns it, should warn but still register
+test("slot check — unset: register succeeds with warning", () => {
   const api = makeFakeApi({ slotsMemory: undefined });
   assert.doesNotThrow(() => register(api), "should not throw when slot is unset");
-  assert.deepEqual(api.registrations.memoryCapabilities, []);
-  assert.deepEqual(api.registrations.contextEngines, []);
-  assert.deepEqual(api.registrations.embeddingProviders, []);
-  assert.deepEqual(api.registrations.services, []);
-  assert.deepEqual(api.registrations.runtimeLifecycles, []);
-  assert.deepEqual(api.registrations.hooks, []);
+  assert.deepEqual(api.registrations.memoryCapabilities, [MEMORY_ID]);
+  assert.deepEqual(api.registrations.contextEngines, [MEMORY_ID]);
+  assert.deepEqual(api.registrations.embeddingProviders, [
+    "libravdb-bundled",
+    "libravdb-onnx",
+  ]);
+  assert.deepEqual(api.registrations.services, [
+    "libravdb-markdown-ingestion",
+    "libravdb-dream-promotion",
+  ]);
+  assert.deepEqual(api.registrations.runtimeLifecycles, ["libravdb-shutdown"]);
+  assert.deepEqual(api.registrations.hooks, [
+    "before_reset",
+    "session_end",
+    "agent_end",
+    "gateway_stop",
+  ]);
 });
 
 // slot: "none" — memory disabled, should not throw or register hooks


### PR DESCRIPTION
## Summary

- Return early in full registration when `plugins.slots.memory` is unset or `"none"`, after preserving the existing conflict check for other plugin ids.
- Keep full memory/context registration active only when `plugins.slots.memory === "libravdb-memory"`.
- Expand slot registration tests to assert the enabled path registers memory/context services and the disabled paths register none of those hooks.

Fixes #169.

## Validation

- [x] `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/slot-conflict.test.js && git diff --check`
- [x] `pnpm run check`
- [ ] `pnpm run test:integration` - fails only on existing #132 (`sidecar enters degraded mode after exhausting retry budget`, assertion `false !== true`)

## Contributor checklist

- [x] Behavioral change has matching validation coverage.
- [x] No validation checks were weakened or bypassed.
- [x] Plugin lifecycle and daemon lifecycle remain separate.
- [x] No install-time daemon bootstrap or installer behavior changes.
- [x] No docs update required; existing install/uninstall docs already describe slot removal as disabling the plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration now respects a configurable memory slot: invalid values cause an error; "none" skips memory and context registrations (info logged); unset logs a warning but proceeds with memory enabled.

* **Tests**
  * Expanded tests to record and assert all registration actions.
  * Added scenarios verifying full registrations when unset and skipped registrations when "none".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/170)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->