### PR TITLE
Fix after-turn compaction for oversized payloads

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -419,6 +419,23 @@ function resolvePredictiveCompactionTokenCount(args: {
   );
 }
 
+function resolveAfterTurnPredictiveCompactionTokenCount(args: {
+  currentTokenCount?: number;
+  messages: OpenClawCompatibleMessage[];
+}): number | undefined {
+  const currentTokenCount = normalizeCurrentTokenCount(args.currentTokenCount);
+  const forwardedMessageTokens = normalizeCurrentTokenCount(
+    approximateMessagesTokens(args.messages),
+  );
+  if (currentTokenCount == null) {
+    return forwardedMessageTokens;
+  }
+  if (forwardedMessageTokens == null) {
+    return currentTokenCount;
+  }
+  return Math.max(currentTokenCount, forwardedMessageTokens);
+}
+
 export function normalizeKernelMessage(message: {
   role: string;
   content: unknown;
@@ -785,16 +802,21 @@ export function buildContextEngineFactory(
 
   async function performAfterTurnPredictiveCompaction(args: {
     sessionId: string;
+    messages: OpenClawCompatibleMessage[];
     tokenBudget?: number;
     currentTokenCount?: number;
   }): Promise<void> {
     const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
-    const predictiveTargetSize = resolvePredictiveCompactionTarget({
+    const currentContextTokens = resolveAfterTurnPredictiveCompactionTokenCount({
       currentTokenCount: args.currentTokenCount,
+      messages: args.messages,
+    });
+    const predictiveTargetSize = resolvePredictiveCompactionTarget({
+      currentTokenCount: currentContextTokens,
       threshold: dynamicCompactThreshold,
     });
     if (
-      args.currentTokenCount == null ||
+      currentContextTokens == null ||
       dynamicCompactThreshold == null ||
       predictiveTargetSize == null
     ) {
@@ -804,7 +826,7 @@ export function buildContextEngineFactory(
       logger,
       phase: "afterTurn",
       sessionId: args.sessionId,
-      currentTokenCount: args.currentTokenCount,
+      currentTokenCount: currentContextTokens,
       threshold: dynamicCompactThreshold,
       targetSize: predictiveTargetSize,
       tokenBudget: args.tokenBudget,
@@ -814,13 +836,13 @@ export function buildContextEngineFactory(
       targetSize: predictiveTargetSize,
       tokenBudget: args.tokenBudget,
       force: true,
-      currentTokenCount: args.currentTokenCount,
+      currentTokenCount: currentContextTokens,
     });
     logPredictiveCompactionOutcome({
       logger,
       phase: "afterTurn",
       sessionId: args.sessionId,
-      currentTokenCount: args.currentTokenCount,
+      currentTokenCount: currentContextTokens,
       threshold: dynamicCompactThreshold,
       targetSize: predictiveTargetSize,
       tokenBudget: args.tokenBudget,
@@ -1075,6 +1097,7 @@ export function buildContextEngineFactory(
           });
           await performAfterTurnPredictiveCompaction({
             sessionId,
+            messages,
             tokenBudget: args.tokenBudget,
             currentTokenCount,
           });
@@ -1090,6 +1113,7 @@ export function buildContextEngineFactory(
         });
         await performAfterTurnPredictiveCompaction({
           sessionId,
+          messages,
           tokenBudget: args.tokenBudget,
           currentTokenCount,
         });

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -585,3 +585,36 @@ test("afterTurn does not trigger predictive compaction without authoritative cur
   );
   assert.equal(rpc.getLastCall("compact_session"), null);
 });
+
+test("afterTurn triggers predictive compaction from oversized forwarded messages", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  const cfg: PluginConfig = {
+    rpcTimeoutMs: 1000,
+    compactionThresholdFraction: 0.8,
+  };
+
+  const context = buildContextEngineFactory(async () => rpc as never, cfg);
+
+  await context.afterTurn({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [
+      { role: "user", content: "please run the tool" },
+      { role: "assistant", content: "x".repeat(4000) },
+    ],
+    prePromptMessageCount: 1,
+    tokenBudget: 1000,
+    runtimeContext: { currentTokenCount: Number.NaN },
+  });
+
+  assert.deepEqual(
+    rpc.calls.map((call) => call.method),
+    ["after_turn_kernel", "compact_session"],
+  );
+
+  const compactParams = rpc.getLastCall("compact_session");
+  assert.ok(compactParams, "Expected compact_session to be called");
+  assert.ok(compactParams.currentTokenCount >= 800);
+  assert.equal(compactParams.targetSize, 799);
+});


### PR DESCRIPTION
## Summary
- Estimate forwarded after-turn message tokens when deciding whether predictive compaction should run
- Use the larger of runtime-reported tokens and forwarded-message estimate for the compaction request/logs
- Add a regression test for oversized post-prompt payloads with no authoritative runtime token count

## Validation
- Red check before fix: oversized afterTurn regression failed with no compact_session call
- COREPACK_ENABLE_AUTO_PIN=0 pnpm run test:integration
- COREPACK_ENABLE_AUTO_PIN=0 pnpm run build
- COREPACK_ENABLE_AUTO_PIN=0 pnpm run check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined token counting accuracy for large forwarded messages to ensure proper context management.
  * Enhanced context compaction logic to more reliably handle oversized conversation data.
  * Improved handling of edge cases in token count calculations.

* **Tests**
  * Added integration test coverage verifying predictive compaction behavior with oversized messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/173)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->