### PR TITLE
fix: gate memory readFile paths to search results

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -67,6 +67,7 @@ function createMemorySearchManager(
 ) {
   let cachedStatus = initialStatus;
   let cachedIdentityUserId: string | null = null;
+  const returnedSearchPaths = new Set<string>();
 
   function getResolvedUserId(sessionKey: string | undefined): string {
     if (cachedIdentityUserId !== null) return cachedIdentityUserId;
@@ -133,9 +134,16 @@ function createMemorySearchManager(
       if (legacyCall) {
         return { results: legacyResults };
       }
-      return filteredResults.map(toMemorySearchResult);
+      const memoryResults = filteredResults.map(toMemorySearchResult);
+      for (const item of memoryResults) {
+        returnedSearchPaths.add(item.path);
+      }
+      return memoryResults;
     },
     async readFile(params: { relPath: string; from?: number; lines?: number }) {
+      if (!returnedSearchPaths.has(params.relPath)) {
+        throw new Error("LibraVDB memory path was not returned by this search manager");
+      }
       const located = await loadSearchResultText(getRpc, params.relPath);
       const fromLine = Math.max(1, params.from ?? 1);
       const lineCount = Math.max(1, params.lines ?? 200);

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -164,6 +164,24 @@ test("memory runtime bridge keeps the legacy string search shape", async () => {
   assert.equal(result.results[0]?.content, "remembered item");
 });
 
+test("memory runtime bridge does not authorize hidden paths from legacy search results", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  await manager.search("find prior context", { userId: "u1" });
+  await assert.rejects(
+    manager.readFile({ relPath: "user%3Au1::m1", from: 1, lines: 1 }),
+    /not returned by this search manager/,
+  );
+
+  assert.equal(
+    rpc.calls.some((call) => call.method === "list_collection"),
+    false,
+    "legacy searches should not authorize paths they did not return",
+  );
+});
+
 test("memory runtime bridge respects disabled cross-session recall", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {
@@ -241,6 +259,24 @@ test("memory runtime bridge round-trips encoded collection names in result paths
   assert.equal(typeof path, "string");
   const loaded = await manager.readFile({ relPath: path ?? "", from: 1, lines: 1 });
   assert.equal(loaded.text, "remembered item");
+});
+
+test("memory runtime bridge rejects readFile paths not returned by search", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  await manager.search({ query: "find prior context", userId: "u1" });
+  await assert.rejects(
+    manager.readFile({ relPath: "global::m1", from: 1, lines: 1 }),
+    /not returned by this search manager/,
+  );
+
+  assert.equal(
+    rpc.calls.some((call) => call.method === "list_collection"),
+    false,
+    "crafted paths should be rejected before collection listing",
+  );
 });
 
 test("memory runtime bridge exposes cached status and keeps legacy helpers delegated", async () => {


### PR DESCRIPTION
## Summary

Tighten the memory runtime bridge so `readFile()` only opens memory paths that were returned by the same search manager's structured `search()` results.

The normal search path already scopes collections before returning results. The follow-up read path was looser: it decoded the caller-provided `collection::id` path and called `list_collection` for that decoded collection without checking whether that path came from a prior structured search result.

## Root cause

`readFile({ relPath })` treated the encoded path as authority. That meant a caller could provide a crafted memory path shape and make the bridge ask the daemon for that decoded collection. The daemon still decides what exists, but the bridge was not preserving the search result boundary it had just established.

## What changed

- Track paths returned by structured `search()` results per search manager.
- Reject `readFile()` calls when the path was not returned by that manager.
- Keep legacy string search behavior unchanged.
- Avoid granting hidden read access from legacy search results, since those do not return structured paths.
- Add regression coverage for crafted paths and legacy hidden paths.

## Why this is safe

- Existing structured search results still round-trip through `readFile()`.
- Crafted paths are rejected before any `list_collection` call is made.
- The change is local to the memory runtime bridge and tests.
- No daemon protocol, dependency, network, or configuration behavior changes.

## Tests

- `node_modules/.bin/tsc.CMD -p tsconfig.tests.json`
- `node --test .ts-build/test/unit/memory-runtime.test.js`

Also checked:

- `node --test .ts-build/test/unit/*.test.js`
  - 131/132 passed
  - Existing unrelated Windows path expectation failed in `test/unit/sidecar.test.ts`: `defaultEndpoint prefers the Homebrew socket when the user-local socket is absent`

## Not run

- `npm run test:integration`, because the integration tests require a daemon/prepared daemon binary.
