### PR TITLE
fix: build unix endpoint paths with posix separators

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -439,10 +439,11 @@ export function defaultEndpoint(
     return "tcp:127.0.0.1:37421";
   }
 
+  const joinSocketPath = path.posix.join;
   const sockName = "libravdb.sock";
   const candidateDirs = [
     // User-local (npm plugin convention)
-    homeDir?.trim() ? path.join(homeDir, ".libravdbd", "run") : null,
+    homeDir?.trim() ? joinSocketPath(homeDir, ".libravdbd", "run") : null,
     // Homebrew (Apple Silicon) — matches the Homebrew formula LaunchAgent
     "/opt/homebrew/var/libravdbd/run",
     // Homebrew (Intel Mac) / manual Linux installs
@@ -450,7 +451,7 @@ export function defaultEndpoint(
   ].filter((d): d is string => d !== null);
 
   for (const dir of candidateDirs) {
-    const sockPath = path.join(dir, sockName);
+    const sockPath = joinSocketPath(dir, sockName);
     try {
       if (pathExists(sockPath)) {
         return `unix:${sockPath}`;
@@ -462,9 +463,9 @@ export function defaultEndpoint(
 
   // Fallback to the original user-local path so error messages stay familiar.
   const baseDir = homeDir?.trim()
-    ? path.join(homeDir, ".libravdbd", "run")
-    : path.join(".", ".libravdbd", "run");
-  return `unix:${path.join(baseDir, sockName)}`;
+    ? joinSocketPath(homeDir, ".libravdbd", "run")
+    : joinSocketPath(".", ".libravdbd", "run");
+  return `unix:${joinSocketPath(baseDir, sockName)}`;
 }
 
 export function buildSidecarEnv(cfg: PluginConfig): Record<string, string> {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -76,6 +76,12 @@ test("defaultEndpoint uses unix sockets on unix and localhost TCP on windows", (
   }
 });
 
+test("defaultEndpoint builds unix fallback paths with POSIX separators", () => {
+  const endpoint = defaultEndpoint("darwin", "/Users/demo", () => false);
+
+  assert.equal(endpoint, "unix:/Users/demo/.libravdbd/run/libravdb.sock");
+});
+
 test("defaultEndpoint prefers the Homebrew socket when the user-local socket is absent", () => {
   const endpoint = defaultEndpoint(
     "darwin",


### PR DESCRIPTION
## Summary

Make `defaultEndpoint()` build Unix socket paths with POSIX separators after the requested platform has already been classified as non-Windows.

This keeps the Windows TCP endpoint unchanged, while making simulated macOS/Linux endpoint discovery host-independent in the unit suite.

## Root cause

`defaultEndpoint(platform, homeDir, pathExists)` accepts an explicit platform argument, so tests can simulate Darwin behavior on another host OS. The implementation still used the host `path.join()` for Unix socket candidates. When the test suite runs on Windows and asks for `platform === "darwin"`, that produced backslash paths such as `\Users\demo\.libravdbd\run\libravdb.sock`, so the Homebrew socket candidate check could not match the expected POSIX path.

## What changed

- Keep the existing Windows branch returning `tcp:127.0.0.1:37421`.
- Use POSIX path joining for non-Windows Unix socket candidates and fallback paths.
- Add a regression test for Darwin fallback path formatting on a Windows-hosted test run.

## Why this is safe

- Runtime Windows behavior is unchanged.
- POSIX hosts already expect `/` separators for Unix sockets, so the produced endpoint shape stays correct.
- The change only affects local endpoint string construction.
- No daemon lifecycle, install, network, or config contract behavior changes.

## Tests

- `.\node_modules\.bin\tsc.CMD -p tsconfig.tests.json`
- `node --test .ts-build\test\unit\sidecar.test.js`
- `node --test .ts-build\test\unit\*.test.js`

## Not run

- Daemon/integration tests, because this is a path-string unit fix and does not start or talk to a daemon.

## Notes

- Full unit suite passes on Windows: 132/132.
