### PR TITLE
fix: validate user memory collections

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { MEMORY_CLI_DESCRIPTOR, isMemorySlotSelected } from "./cli-descriptors.js";
-import { resolveDurableNamespace } from "./memory-scopes.js";
+import { resolveDurableNamespace, resolveUserCollection } from "./memory-scopes.js";
 import { resolveIdentity } from "./identity.js";
 import { formatError } from "./format-error.js";
 import { promoteDreamDiaryFile } from "./dream-promotion.js";
@@ -324,11 +324,21 @@ async function runDeepStatusProbe(
     identityPath: cfg.identityPath,
     noAutoPersist: true,
   });
-  const durableCollections = [`user:${userId}`, "global"] as const;
-
-  const allCollections = [...AUTHORED_STATUS_COLLECTIONS, ...durableCollections] as const;
-
   const probes: DeepStatusProbe[] = [];
+  let userCollection: string | null = null;
+  try {
+    userCollection = resolveUserCollection(userId);
+  } catch (error) {
+    probes.push({
+      ok: false,
+      collection: "user:<invalid>",
+      error: formatError(error),
+    });
+  }
+
+  const durableCollections = userCollection ? [userCollection, "global"] : ["global"];
+  const allCollections = [...AUTHORED_STATUS_COLLECTIONS, ...durableCollections];
+
   for (const collection of allCollections) {
     try {
       const result = await rpc.call<{ results?: unknown[] }>("search_text", {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -13,6 +13,7 @@ import {
   CompactSessionResponse,
 } from "@xdarkicex/libravdb-contracts";
 import { resolveIdentity, type ResolvedIdentity } from "./identity.js";
+import { resolveUserCollection } from "./memory-scopes.js";
 
 type KernelCompatibleMessage = {
   role: string;
@@ -693,7 +694,7 @@ export function buildContextEngineFactory(
     for (const token of missingTokens) {
       try {
         const result = await rpc.call<{ results: SearchResult[] }>("search_text_collections", {
-          collections: [`user:${args.userId}`, "global"],
+          collections: [resolveUserCollection(args.userId), "global"],
           text: token,
           k: Math.max(EXACT_RECALL_SEARCH_K, cfg.topK ?? 0),
           excludeByCollection: {},

--- a/src/dream-routing.ts
+++ b/src/dream-routing.ts
@@ -1,3 +1,5 @@
+import { validateNamespace } from "./memory-scopes.js";
+
 const DREAM_COLLECTION_PREFIX = "dream:";
 
 const DREAM_PATTERN_RULES: Array<{ label: string; patterns: RegExp[] }> = [
@@ -58,5 +60,6 @@ export function detectDreamQuerySignal(queryText: string): DreamQuerySignal {
 }
 
 export function resolveDreamCollection(userId: string): string {
-  return `${DREAM_COLLECTION_PREFIX}${userId.trim()}`;
+  const namespace = validateNamespace(userId.trim());
+  return validateNamespace(`${DREAM_COLLECTION_PREFIX}${namespace}`);
 }

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -1,5 +1,5 @@
 import type { RpcGetter } from "./plugin-runtime.js";
-import { resolveDurableNamespace } from "./memory-scopes.js";
+import { resolveDurableNamespace, resolveUserCollection } from "./memory-scopes.js";
 import { resolveIdentity } from "./identity.js";
 import { detectDreamQuerySignal, resolveDreamCollection } from "./dream-routing.js";
 import type { PluginConfig, LoggerLike, SearchResult } from "./types.js";
@@ -205,7 +205,7 @@ function resolveSearchCollections(cfg: PluginConfig, userId: string, sessionId?:
     return sessionId ? [resolveSessionSearchCollection(cfg, sessionId)] : [];
   }
 
-  const collections = [`user:${userId}`, "global"];
+  const collections = [resolveUserCollection(userId), "global"];
   if (!sessionId) {
     return collections;
   }

--- a/src/memory-scopes.ts
+++ b/src/memory-scopes.ts
@@ -1,5 +1,6 @@
 const SESSION_KEY_NAMESPACE_PREFIX = "session-key:";
 const AGENT_ID_NAMESPACE_PREFIX = "agent-id:";
+const USER_COLLECTION_PREFIX = "user:";
 
 /** Valid collection names: alphanumeric, underscores, hyphens, dots, colons, at-signs, hashes.
  *  Must start with a letter. Max 128 characters. */
@@ -47,6 +48,15 @@ export function resolveDurableNamespace(params: {
   return "default";
 }
 
+export function resolveUserCollection(userId: string): string {
+  const namespace = firstNonEmpty(userId);
+  if (!namespace) {
+    throw new Error("Invalid user collection namespace: userId must be non-empty");
+  }
+  validateNamespace(namespace);
+  return validateNamespace(`${USER_COLLECTION_PREFIX}${namespace}`);
+}
+
 export function resolveScopes(params: {
   userId: string;
   sessionId?: string;
@@ -54,7 +64,7 @@ export function resolveScopes(params: {
 }): RetrievalScopes {
   return {
     session: params.sessionId ? `session:${params.sessionId}` : "session:default",
-    user: params.crossSessionRecall !== false ? `user:${params.userId}` : null,
+    user: params.crossSessionRecall !== false ? resolveUserCollection(params.userId) : null,
     global: "global",
   };
 }

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -454,6 +454,75 @@ test("status --deep probes authored collection search health", async () => {
   assert.equal(shutdownCalls, 1);
 });
 
+test("status --deep reports invalid user collection without probing it", async () => {
+  let registered: RegisteredCli | null = null;
+  const rpcCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const api = {
+    config: selectedConfig,
+    registerCli(builder: unknown, opts: RegisteredCli["opts"]) {
+      registered = { builder: builder as RegisteredCli["builder"], opts };
+    },
+  };
+
+  registerMemoryCli(
+    api as never,
+    {
+      async getRpc() {
+        return {
+          async call(method: string, params: Record<string, unknown>) {
+            rpcCalls.push({ method, params });
+            if (method === "status") {
+              return { ok: true, message: "ok", embeddingProfile: "all-minilm-l6-v2" };
+            }
+            if (method === "search_text") {
+              return { results: [] };
+            }
+            throw new Error(`unexpected rpc method: ${method}`);
+          },
+        } as never;
+      },
+      getKernel: async () => null,
+      async emitLifecycleHint() {},
+      onShutdown: async () => {},
+      async shutdown() {},
+    },
+    { userId: "bad user" },
+  );
+
+  assert.ok(registered);
+  const cli = registered as RegisteredCli;
+  const program = new FakeCommand("openclaw");
+  cli.builder({ program });
+
+  const memory = program.commands.find((command) => command.name() === "memory");
+  const status = memory?.commands.find((command) => command.name() === "status");
+  assert.ok(status?.handler);
+
+  const originalLog = console.log;
+  const previousExitCode = process.exitCode;
+  const logs: string[] = [];
+  let observedExitCode: string | number | undefined;
+  console.log = ((message?: unknown) => { logs.push(String(message)); }) as typeof console.log;
+  process.exitCode = undefined;
+  try {
+    await status.handler?.({ deep: true, json: true });
+    observedExitCode = process.exitCode;
+  } finally {
+    console.log = originalLog;
+    process.exitCode = previousExitCode;
+  }
+
+  const payload = JSON.parse(logs[0] ?? "{}");
+  assert.equal(payload.deep.ok, false);
+  assert.equal(payload.deep.probes[0]?.collection, "user:<invalid>");
+  assert.match(payload.deep.probes[0]?.error ?? "", /Invalid collection namespace/);
+  assert.deepEqual(
+    rpcCalls.filter((call) => call.method === "search_text").map((call) => call.params.collection),
+    ["authored:hard", "authored:soft", "authored:variant", "global"],
+  );
+  assert.equal(observedExitCode, 1);
+});
+
 test("status --deep includes authored probe rows in table output", async () => {
   let registered: RegisteredCli | null = null;
   const api = {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -579,6 +579,38 @@ test("context engine assemble keeps daemon result when exact recall RPC acquisit
   assert.match(warnings[0] ?? "", /exact recall skipped/);
 });
 
+test("context engine exact recall rejects invalid user collections before probing", async () => {
+  const rpc = new FakeRpc();
+  const marker = "INVALID_USER_COLLECTION_MARKER_1234567890";
+  rpc.assembleResponse = {
+    messages: [{ role: "assistant", content: "base recalled context" }],
+    estimatedTokens: 24,
+    systemPromptAddition: "",
+  };
+  const warnings: string[] = [];
+  const engine = buildContextEngineFactory(fakeRuntime(rpc), { userId: "bad user" }, {
+    error() {},
+    info() {},
+    warn(message: string) { warnings.push(message); },
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", `What does ${marker} mean?`)],
+    prompt: `What does ${marker} mean?`,
+    tokenBudget: 4000,
+  });
+
+  assert.deepEqual(assembled.messages, [{ role: "assistant", content: "base recalled context" }]);
+  assert.equal(
+    rpc.calls.some((call) => call.method === "search_text_collections"),
+    false,
+    "invalid user collection should not be sent to the daemon",
+  );
+  assert.match(warnings[0] ?? "", /Invalid collection namespace/);
+});
+
 test("context engine exact recall skips empty-text search results", async () => {
   const rpc = new FakeRpc();
   const marker = "BROKEN_SESSION_MEMORY_MARKER_1234567890";

--- a/test/unit/dream-routing.test.ts
+++ b/test/unit/dream-routing.test.ts
@@ -50,4 +50,7 @@ test("dream routing ignores ordinary memory queries", () => {
 test("dream routing resolves the dedicated dream collection name", () => {
   assert.equal(resolveDreamCollection("u1"), "dream:u1");
   assert.equal(resolveDreamCollection("  session-key:abc  "), "dream:session-key:abc");
+  assert.throws(() => resolveDreamCollection(""), /Invalid collection namespace/);
+  assert.throws(() => resolveDreamCollection("has spaces"), /Invalid collection namespace/);
+  assert.throws(() => resolveDreamCollection("a".repeat(123)), /Invalid collection namespace/);
 });

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -104,6 +104,25 @@ test("memory runtime bridge routes dream queries to the dream collection when cr
   }
 });
 
+test("memory runtime bridge rejects invalid dream collections before daemon search", async () => {
+  const rpc = new FakeRpc();
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  await assert.rejects(
+    manager.search({
+      query: "tell me about your dreams from last week",
+      userId: "a".repeat(123),
+    }),
+    /Invalid collection namespace/,
+  );
+  assert.equal(
+    rpc.calls.some((call) => call.method === "search_text"),
+    false,
+    "invalid dream collection should not be sent to the daemon",
+  );
+});
+
 test("memory runtime bridge treats dream queries as session-scoped searches when cross-session recall is disabled", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, { crossSessionRecall: false });

--- a/test/unit/memory-scopes.test.ts
+++ b/test/unit/memory-scopes.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveDurableNamespace, validateNamespace } from "../../src/memory-scopes.js";
+import { resolveDurableNamespace, resolveUserCollection, validateNamespace } from "../../src/memory-scopes.js";
 
 test("resolveDurableNamespace trims inputs and prefers sessionKey over agentId", () => {
   assert.equal(
@@ -37,4 +37,14 @@ test("validateNamespace rejects invalid collection names", () => {
   assert.throws(() => validateNamespace("1starts-with-number"), /Invalid collection namespace/);
   assert.throws(() => validateNamespace("has spaces"), /Invalid collection namespace/);
   assert.throws(() => validateNamespace("has\nnewline"), /Invalid collection namespace/);
+});
+
+test("resolveUserCollection validates the full prefixed collection name", () => {
+  assert.equal(resolveUserCollection("u1"), "user:u1");
+  assert.equal(resolveUserCollection("  session-key:abc  "), "user:session-key:abc");
+
+  assert.throws(() => resolveUserCollection(""), /userId must be non-empty/);
+  assert.throws(() => resolveUserCollection("1starts-with-number"), /Invalid collection namespace/);
+  assert.throws(() => resolveUserCollection("has spaces"), /Invalid collection namespace/);
+  assert.throws(() => resolveUserCollection("a".repeat(124)), /Invalid collection namespace/);
 });


### PR DESCRIPTION
## Summary

Validate user-scoped memory collection names through a shared helper before sending probe/search calls to the daemon.

PR #129 added validation for `resolveDurableNamespace()`. A few follow-up paths still built `user:${userId}` directly, which meant malformed config/framework/identity user IDs could still become daemon collection names outside that helper.

## Root cause

The validation existed in one namespace-resolution path, but user-scoped collection construction was duplicated in other paths:

- exact recall probes in the context engine
- memory runtime user/global searches
- `memory status --deep` health probes

Those paths were simple and easy to miss because the happy-path value is the same string shape: `user:<id>`.

## What changed

- Add `resolveUserCollection()` in `memory-scopes`.
- Validate both the raw user namespace and the final `user:<id>` collection name.
- Use the helper for exact recall probes before calling `search_text_collections`.
- Use the helper for memory runtime user/global searches.
- Use the helper for `memory status --deep`.
- When `status --deep` sees an invalid user collection, report that probe as failed and skip only that user collection instead of sending it to the daemon.
- Add focused unit coverage for invalid user IDs in the shared helper, context engine, and CLI deep status path.

## Why this is safe

- Valid existing user IDs continue to produce the same `user:<id>` collection names.
- Invalid user-scoped collection names fail before daemon calls.
- `status --deep` still checks authored collections and `global` even when the configured user ID is invalid.
- The change reuses the same namespace rules introduced by #129.
- No daemon protocol, dependency, network, install, or persisted data format changes.

## Tests

- `.\node_modules\.bin\tsc.CMD -p tsconfig.tests.json`
- `node --test .ts-build\test\unit\memory-scopes.test.js`
- `node --test .ts-build\test\unit\context-engine.test.js`
- `node --test .ts-build\test\unit\cli.test.js`
- `node --test .ts-build\test\unit\memory-runtime.test.js`

## Not run

- Daemon/integration tests, because this is plugin-side validation and unit coverage exercises the affected RPC call boundaries.

## Notes

- Full unit suite on the current `main` baseline still has the known unrelated Windows `defaultEndpoint` sidecar failure fixed separately by #175.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for user collection names; invalid namespaces are now reported and excluded from searches, with fallback to global collections.

* **Refactor**
  * Collection resolution and cross-session recall now use normalized/validated user collection names for more consistent lookup behavior.

* **Tests**
  * Added unit tests covering invalid namespace handling, error reporting, and the updated collection-resolution/search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/176)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->