### PR TITLE
fix: pace markdown startup ingestion

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,11 +92,15 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionInclude` | string[] | — | Glob patterns to include |
 | `markdownIngestionExclude` | string[] | — | Glob patterns to exclude |
 | `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
+| `markdownIngestionMaxFilesPerScan` | number | `4` | Maximum changed/new files to ingest per scan; `0` disables the cap |
+| `markdownIngestionBatchDelayMs` | number | `1000` | Delay before continuing a scan with deferred files |
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |
 | `markdownIngestionObsidianInclude` | string[] | — | Obsidian glob include patterns |
 | `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
 | `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
+| `markdownIngestionObsidianMaxFilesPerScan` | number | `4` | Maximum changed/new Obsidian files to ingest per scan; `0` disables the cap |
+| `markdownIngestionObsidianBatchDelayMs` | number | `1000` | Delay before continuing an Obsidian scan with deferred files |
 
 Configured markdown roots are ignored unless the matching enable flag is set to
 `true`. Set `markdownIngestionEnabled: true` for generic roots and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionExclude` | string[] | — | Glob patterns to exclude |
 | `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
 | `markdownIngestionMaxFilesPerScan` | number | `4` | Maximum changed/new files to ingest per scan; `0` disables the cap |
+| `markdownIngestionMaxBytesPerScan` | number | `1048576` | Maximum changed/new bytes to read and ingest per scan; `0` disables the cap; one oversized file is still allowed per scan |
 | `markdownIngestionBatchDelayMs` | number | `1000` | Delay before continuing a scan with deferred files |
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |
@@ -100,6 +101,7 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
 | `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
 | `markdownIngestionObsidianMaxFilesPerScan` | number | `4` | Maximum changed/new Obsidian files to ingest per scan; `0` disables the cap |
+| `markdownIngestionObsidianMaxBytesPerScan` | number | `1048576` | Maximum changed/new Obsidian bytes to read and ingest per scan; `0` disables the cap; falls back to `markdownIngestionMaxBytesPerScan` when unset |
 | `markdownIngestionObsidianBatchDelayMs` | number | `1000` | Delay before continuing an Obsidian scan with deferred files |
 
 Configured markdown roots are ignored unless the matching enable flag is set to

--- a/docs/features.md
+++ b/docs/features.md
@@ -55,11 +55,15 @@ Relevant config fields:
 | `markdownIngestionInclude` | Optional include globs for generic roots. |
 | `markdownIngestionExclude` | Optional exclude globs for generic roots. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
+| `markdownIngestionMaxFilesPerScan` | Caps changed/new generic files per scan, default `4`; `0` disables the cap. |
+| `markdownIngestionBatchDelayMs` | Delay before continuing deferred generic scans, default `1000`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
 | `markdownIngestionObsidianInclude` | Optional include globs for Obsidian roots. |
 | `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots. |
 | `markdownIngestionObsidianDebounceMs` | Obsidian watch debounce window, default `150`. |
+| `markdownIngestionObsidianMaxFilesPerScan` | Caps changed/new Obsidian files per scan, default `4`; `0` disables the cap. |
+| `markdownIngestionObsidianBatchDelayMs` | Delay before continuing deferred Obsidian scans, default `1000`. |
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,
 using frontmatter tags or inline tags such as `#project`. The stock OpenClaw

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,6 +56,7 @@ Relevant config fields:
 | `markdownIngestionExclude` | Optional exclude globs for generic roots. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
 | `markdownIngestionMaxFilesPerScan` | Caps changed/new generic files per scan, default `4`; `0` disables the cap. |
+| `markdownIngestionMaxBytesPerScan` | Caps changed/new generic bytes read and ingested per scan, default `1048576`; `0` disables the cap; one oversized file is still allowed per scan. |
 | `markdownIngestionBatchDelayMs` | Delay before continuing deferred generic scans, default `1000`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
@@ -63,6 +64,7 @@ Relevant config fields:
 | `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots. |
 | `markdownIngestionObsidianDebounceMs` | Obsidian watch debounce window, default `150`. |
 | `markdownIngestionObsidianMaxFilesPerScan` | Caps changed/new Obsidian files per scan, default `4`; `0` disables the cap. |
+| `markdownIngestionObsidianMaxBytesPerScan` | Caps changed/new Obsidian bytes read and ingested per scan, default `1048576`; `0` disables the cap; falls back to `markdownIngestionMaxBytesPerScan` when unset. |
 | `markdownIngestionObsidianBatchDelayMs` | Delay before continuing deferred Obsidian scans, default `1000`. |
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -218,6 +218,12 @@
         "default": 4,
         "description": "Maximum changed/new generic markdown files to ingest per scan. Set 0 for unlimited."
       },
+      "markdownIngestionMaxBytesPerScan": {
+        "type": "number",
+        "minimum": 0,
+        "default": 1048576,
+        "description": "Maximum changed/new generic markdown bytes to read and ingest per scan. Set 0 for unlimited; one oversized file is still allowed per scan."
+      },
       "markdownIngestionBatchDelayMs": {
         "type": "number",
         "minimum": 0,
@@ -229,6 +235,12 @@
         "minimum": 0,
         "default": 4,
         "description": "Maximum changed/new Obsidian markdown files to ingest per scan. Set 0 for unlimited."
+      },
+      "markdownIngestionObsidianMaxBytesPerScan": {
+        "type": "number",
+        "minimum": 0,
+        "default": 1048576,
+        "description": "Maximum changed/new Obsidian markdown bytes to read and ingest per scan. Falls back to markdownIngestionMaxBytesPerScan when unset. Set 0 for unlimited; one oversized file is still allowed per scan."
       },
       "markdownIngestionObsidianBatchDelayMs": {
         "type": "number",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -212,6 +212,30 @@
       "markdownIngestionObsidianSnapshotPath": {
         "type": "string"
       },
+      "markdownIngestionMaxFilesPerScan": {
+        "type": "number",
+        "minimum": 0,
+        "default": 4,
+        "description": "Maximum changed/new generic markdown files to ingest per scan. Set 0 for unlimited."
+      },
+      "markdownIngestionBatchDelayMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 1000,
+        "description": "Delay before continuing a generic markdown scan when files were deferred by markdownIngestionMaxFilesPerScan."
+      },
+      "markdownIngestionObsidianMaxFilesPerScan": {
+        "type": "number",
+        "minimum": 0,
+        "default": 4,
+        "description": "Maximum changed/new Obsidian markdown files to ingest per scan. Set 0 for unlimited."
+      },
+      "markdownIngestionObsidianBatchDelayMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 1000,
+        "description": "Delay before continuing an Obsidian scan when files were deferred by markdownIngestionObsidianMaxFilesPerScan."
+      },
       "dreamPromotionEnabled": {
         "type": "boolean",
         "default": false

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -533,6 +533,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) {
       return "unchanged";
     }
+    if (!consumeIngestBudget(ingestBudget)) {
+      return "deferred";
+    }
 
     const bytes = await this.safeReadFile(filePath);
     if (!bytes) {
@@ -561,9 +564,6 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       this.fileStates.delete(sourceDoc);
       this.snapshotDirty = true;
       return "skipped";
-    }
-    if (!consumeIngestBudget(ingestBudget)) {
-      return "deferred";
     }
     await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, stat.mtimeMs);
     this.setFileState(sourceDoc, {

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -10,6 +10,7 @@ import { IngestQueue } from "./ingest-queue.js";
 
 const DEFAULT_DEBOUNCE_MS = 150;
 const DEFAULT_MAX_FILES_PER_SCAN = 4;
+const DEFAULT_MAX_BYTES_PER_SCAN = 1024 * 1024;
 const DEFAULT_BATCH_DELAY_MS = 1000;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
@@ -82,6 +83,7 @@ interface GenericMarkdownSourceConfig {
   debounceMs?: number;
   snapshotPath?: string;
   maxFilesPerScan?: number;
+  maxBytesPerScan?: number;
   batchDelayMs?: number;
 }
 
@@ -103,6 +105,8 @@ type SyncMarkdownResult = "ingested" | "unchanged" | "deferred" | "deleted" | "s
 interface IngestBudget {
   maxFiles: number;
   usedFiles: number;
+  maxBytes: number;
+  usedBytes: number;
 }
 
 interface MarkdownSnapshotFile {
@@ -153,6 +157,7 @@ export function createMarkdownIngestionHandle(
           debounceMs: cfg.markdownIngestionDebounceMs ?? DEFAULT_DEBOUNCE_MS,
           snapshotPath: resolveMarkdownSnapshotPath("generic", cfg.markdownIngestionSnapshotPath),
           maxFilesPerScan: cfg.markdownIngestionMaxFilesPerScan,
+          maxBytesPerScan: cfg.markdownIngestionMaxBytesPerScan,
           batchDelayMs: cfg.markdownIngestionBatchDelayMs,
         },
         getRpc,
@@ -174,6 +179,7 @@ export function createMarkdownIngestionHandle(
           debounceMs: cfg.markdownIngestionObsidianDebounceMs ?? cfg.markdownIngestionDebounceMs ?? DEFAULT_DEBOUNCE_MS,
           snapshotPath: resolveMarkdownSnapshotPath("obsidian", cfg.markdownIngestionObsidianSnapshotPath),
           maxFilesPerScan: cfg.markdownIngestionObsidianMaxFilesPerScan ?? cfg.markdownIngestionMaxFilesPerScan,
+          maxBytesPerScan: cfg.markdownIngestionObsidianMaxBytesPerScan ?? cfg.markdownIngestionMaxBytesPerScan,
           batchDelayMs: cfg.markdownIngestionObsidianBatchDelayMs ?? cfg.markdownIngestionBatchDelayMs,
         },
         getRpc,
@@ -234,6 +240,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly logger: LoggerLike;
   private readonly snapshotPath: string;
   private readonly maxFilesPerScan: number;
+  private readonly maxBytesPerScan: number;
   private readonly batchDelayMs: number;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
@@ -257,6 +264,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.logger = logger;
     this.snapshotPath = config.snapshotPath ?? resolveMarkdownSnapshotPath(kind);
     this.maxFilesPerScan = normalizeMarkdownMaxFilesPerScan(config.maxFilesPerScan);
+    this.maxBytesPerScan = normalizeMarkdownMaxBytesPerScan(config.maxBytesPerScan);
     this.batchDelayMs = normalizeMarkdownBatchDelayMs(config.batchDelayMs);
     this.tokenizerId = DEFAULT_TOKENIZER_ID;
     this.coreDoc = true;
@@ -337,7 +345,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     let scheduleContinuation = false;
     const scan = (async () => {
       const stats = createScanStats();
-      const ingestBudget = createIngestBudget(this.maxFilesPerScan);
+      const ingestBudget = createIngestBudget(this.maxFilesPerScan, this.maxBytesPerScan);
       const startedAt = Date.now();
       try {
         const currentFiles = new Set<string>();
@@ -533,7 +541,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) {
       return "unchanged";
     }
-    if (!consumeIngestBudget(ingestBudget)) {
+    if (!consumeIngestBudget(ingestBudget, stat.size)) {
       return "deferred";
     }
 
@@ -711,18 +719,20 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 }
 
-function createIngestBudget(maxFiles: number): IngestBudget {
-  return { maxFiles, usedFiles: 0 };
+function createIngestBudget(maxFiles: number, maxBytes: number): IngestBudget {
+  return { maxFiles, usedFiles: 0, maxBytes, usedBytes: 0 };
 }
 
-function consumeIngestBudget(budget: IngestBudget): boolean {
-  if (!Number.isFinite(budget.maxFiles)) {
-    return true;
+function consumeIngestBudget(budget: IngestBudget, fileSize: number): boolean {
+  const normalizedFileSize = Number.isFinite(fileSize) ? Math.max(0, Math.floor(fileSize)) : 0;
+  if (Number.isFinite(budget.maxFiles) && budget.usedFiles >= budget.maxFiles) {
+    return false;
   }
-  if (budget.usedFiles >= budget.maxFiles) {
+  if (Number.isFinite(budget.maxBytes) && budget.usedBytes > 0 && budget.usedBytes + normalizedFileSize > budget.maxBytes) {
     return false;
   }
   budget.usedFiles++;
+  budget.usedBytes += normalizedFileSize;
   return true;
 }
 
@@ -791,6 +801,19 @@ function normalizeMarkdownMaxFilesPerScan(value?: number): number {
   }
   if (!Number.isFinite(value) || value < 0) {
     return DEFAULT_MAX_FILES_PER_SCAN;
+  }
+  if (value === 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function normalizeMarkdownMaxBytesPerScan(value?: number): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_BYTES_PER_SCAN;
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_MAX_BYTES_PER_SCAN;
   }
   if (value === 0) {
     return Number.POSITIVE_INFINITY;

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -9,6 +9,8 @@ import { formatError } from "./format-error.js";
 import { IngestQueue } from "./ingest-queue.js";
 
 const DEFAULT_DEBOUNCE_MS = 150;
+const DEFAULT_MAX_FILES_PER_SCAN = 4;
+const DEFAULT_BATCH_DELAY_MS = 1000;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
@@ -79,6 +81,8 @@ interface GenericMarkdownSourceConfig {
   exclude?: string[];
   debounceMs?: number;
   snapshotPath?: string;
+  maxFilesPerScan?: number;
+  batchDelayMs?: number;
 }
 
 interface ScanStats {
@@ -89,11 +93,17 @@ interface ScanStats {
   filesSkipped: number;
   filesUnchanged: number;
   filesIngested: number;
+  filesDeferred: number;
   filesDeleted: number;
   syncErrors: number;
 }
 
-type SyncMarkdownResult = "ingested" | "unchanged" | "deleted" | "skipped";
+type SyncMarkdownResult = "ingested" | "unchanged" | "deferred" | "deleted" | "skipped";
+
+interface IngestBudget {
+  maxFiles: number;
+  usedFiles: number;
+}
 
 interface MarkdownSnapshotFile {
   version: number;
@@ -142,6 +152,8 @@ export function createMarkdownIngestionHandle(
           exclude: cfg.markdownIngestionExclude,
           debounceMs: cfg.markdownIngestionDebounceMs ?? DEFAULT_DEBOUNCE_MS,
           snapshotPath: resolveMarkdownSnapshotPath("generic", cfg.markdownIngestionSnapshotPath),
+          maxFilesPerScan: cfg.markdownIngestionMaxFilesPerScan,
+          batchDelayMs: cfg.markdownIngestionBatchDelayMs,
         },
         getRpc,
         logger,
@@ -161,6 +173,8 @@ export function createMarkdownIngestionHandle(
           exclude: cfg.markdownIngestionObsidianExclude,
           debounceMs: cfg.markdownIngestionObsidianDebounceMs ?? cfg.markdownIngestionDebounceMs ?? DEFAULT_DEBOUNCE_MS,
           snapshotPath: resolveMarkdownSnapshotPath("obsidian", cfg.markdownIngestionObsidianSnapshotPath),
+          maxFilesPerScan: cfg.markdownIngestionObsidianMaxFilesPerScan ?? cfg.markdownIngestionMaxFilesPerScan,
+          batchDelayMs: cfg.markdownIngestionObsidianBatchDelayMs ?? cfg.markdownIngestionBatchDelayMs,
         },
         getRpc,
         logger,
@@ -219,6 +233,8 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly getRpc: RpcGetterLike;
   private readonly logger: LoggerLike;
   private readonly snapshotPath: string;
+  private readonly maxFilesPerScan: number;
+  private readonly batchDelayMs: number;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
   private readonly activeScans = new Set<Promise<void>>();
@@ -240,6 +256,8 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.getRpc = getRpc;
     this.logger = logger;
     this.snapshotPath = config.snapshotPath ?? resolveMarkdownSnapshotPath(kind);
+    this.maxFilesPerScan = normalizeMarkdownMaxFilesPerScan(config.maxFilesPerScan);
+    this.batchDelayMs = normalizeMarkdownBatchDelayMs(config.batchDelayMs);
     this.tokenizerId = DEFAULT_TOKENIZER_ID;
     this.coreDoc = true;
   }
@@ -316,24 +334,27 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
 
     rootState.scanState.scanning = true;
+    let scheduleContinuation = false;
     const scan = (async () => {
       const stats = createScanStats();
+      const ingestBudget = createIngestBudget(this.maxFilesPerScan);
       const startedAt = Date.now();
       try {
         const currentFiles = new Set<string>();
-        await this.walkDirectory(rootState, rootState.root, currentFiles, stats);
+        await this.walkDirectory(rootState, rootState.root, currentFiles, stats, ingestBudget);
         if (!this.stopping) {
           await this.pruneDeletedFiles(rootState, currentFiles, stats);
           rootState.knownFiles = currentFiles;
           await this.saveSnapshotIfDirty();
           this.logScanStats(rootState.root, stats, Date.now() - startedAt);
+          scheduleContinuation = stats.filesDeferred > 0;
         }
       } finally {
         rootState.scanState.scanning = false;
-        if (rootState.scanState.dirty) {
+        if (rootState.scanState.dirty || scheduleContinuation) {
           rootState.scanState.dirty = false;
           if (!this.stopping) {
-            this.scheduleRootScan(rootState);
+            this.scheduleRootScan(rootState, scheduleContinuation ? this.batchDelayMs : undefined);
           }
         }
       }
@@ -347,7 +368,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
   }
 
-  private scheduleRootScan(rootState: RootState): void {
+  private scheduleRootScan(rootState: RootState, delayMs = this.debounceMs): void {
     if (!this.started || this.stopping) {
       return;
     }
@@ -363,10 +384,16 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       void this.scanRoot(rootState.root).catch((error) => {
         this.logger.warn?.(`[markdown-ingest] root scan failed for ${rootState.root}: ${formatError(error)}`);
       });
-    }, this.debounceMs);
+    }, delayMs);
   }
 
-  private async walkDirectory(rootState: RootState, dir: string, currentFiles: Set<string>, stats: ScanStats): Promise<void> {
+  private async walkDirectory(
+    rootState: RootState,
+    dir: string,
+    currentFiles: Set<string>,
+    stats: ScanStats,
+    ingestBudget: IngestBudget,
+  ): Promise<void> {
     if (this.shouldPruneDirectory(rootState.root, dir)) {
       stats.directoriesPruned++;
       return;
@@ -392,7 +419,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       const child = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await this.walkDirectory(rootState, child, currentFiles, stats);
+        await this.walkDirectory(rootState, child, currentFiles, stats, ingestBudget);
         continue;
       }
       if (!entry.isFile() || !isMarkdownFile(entry.name)) {
@@ -406,7 +433,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       stats.filesIncluded++;
       currentFiles.add(child);
       try {
-        const result = await this.syncMarkdownFile(rootState, child);
+        const result = await this.syncMarkdownFile(rootState, child, ingestBudget);
         recordSyncResult(stats, result);
       } catch (error) {
         stats.syncErrors++;
@@ -491,7 +518,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
   }
 
-  private async syncMarkdownFile(rootState: RootState, filePath: string): Promise<SyncMarkdownResult> {
+  private async syncMarkdownFile(rootState: RootState, filePath: string, ingestBudget: IngestBudget): Promise<SyncMarkdownResult> {
     const sourceDoc = filePath;
     const relativePath = toPosixPath(path.relative(rootState.root, filePath));
     const stat = await this.safeStat(filePath);
@@ -534,6 +561,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       this.fileStates.delete(sourceDoc);
       this.snapshotDirty = true;
       return "skipped";
+    }
+    if (!consumeIngestBudget(ingestBudget)) {
+      return "deferred";
     }
     await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, stat.mtimeMs);
     this.setFileState(sourceDoc, {
@@ -676,9 +706,24 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
 
   private logScanStats(root: string, stats: ScanStats, durationMs: number): void {
     this.logger.info?.(
-      `[markdown-ingest] ${this.kind} scan complete root=${root} dirs=${stats.directoriesScanned} prunedDirs=${stats.directoriesPruned} markdown=${stats.markdownFilesSeen} included=${stats.filesIncluded} skipped=${stats.filesSkipped} unchanged=${stats.filesUnchanged} ingested=${stats.filesIngested} deleted=${stats.filesDeleted} errors=${stats.syncErrors} durationMs=${durationMs}`,
+      `[markdown-ingest] ${this.kind} scan complete root=${root} dirs=${stats.directoriesScanned} prunedDirs=${stats.directoriesPruned} markdown=${stats.markdownFilesSeen} included=${stats.filesIncluded} skipped=${stats.filesSkipped} unchanged=${stats.filesUnchanged} ingested=${stats.filesIngested} deferred=${stats.filesDeferred} deleted=${stats.filesDeleted} errors=${stats.syncErrors} durationMs=${durationMs}`,
     );
   }
+}
+
+function createIngestBudget(maxFiles: number): IngestBudget {
+  return { maxFiles, usedFiles: 0 };
+}
+
+function consumeIngestBudget(budget: IngestBudget): boolean {
+  if (!Number.isFinite(budget.maxFiles)) {
+    return true;
+  }
+  if (budget.usedFiles >= budget.maxFiles) {
+    return false;
+  }
+  budget.usedFiles++;
+  return true;
 }
 
 function createScanStats(): ScanStats {
@@ -690,6 +735,7 @@ function createScanStats(): ScanStats {
     filesSkipped: 0,
     filesUnchanged: 0,
     filesIngested: 0,
+    filesDeferred: 0,
     filesDeleted: 0,
     syncErrors: 0,
   };
@@ -700,6 +746,8 @@ function recordSyncResult(stats: ScanStats, result: SyncMarkdownResult): void {
     stats.filesIngested++;
   } else if (result === "unchanged") {
     stats.filesUnchanged++;
+  } else if (result === "deferred") {
+    stats.filesDeferred++;
   } else if (result === "deleted") {
     stats.filesDeleted++;
   } else {
@@ -735,6 +783,29 @@ function resolveMarkdownSnapshotPath(kind: string, configuredPath?: string): str
   }
   const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
   return path.join(stateDir, `libravdb-markdown-ingest-${kind}.json`);
+}
+
+function normalizeMarkdownMaxFilesPerScan(value?: number): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_FILES_PER_SCAN;
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_MAX_FILES_PER_SCAN;
+  }
+  if (value === 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function normalizeMarkdownBatchDelayMs(value?: number): number {
+  if (value === undefined) {
+    return DEFAULT_BATCH_DELAY_MS;
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_BATCH_DELAY_MS;
+  }
+  return Math.floor(value);
 }
 
 function isMarkdownIngestionEnabled(cfg: PluginConfig, roots: string[]): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,8 +52,10 @@ export interface PluginConfig {
   markdownIngestionSnapshotPath?: string;
   markdownIngestionObsidianSnapshotPath?: string;
   markdownIngestionMaxFilesPerScan?: number;
+  markdownIngestionMaxBytesPerScan?: number;
   markdownIngestionBatchDelayMs?: number;
   markdownIngestionObsidianMaxFilesPerScan?: number;
+  markdownIngestionObsidianMaxBytesPerScan?: number;
   markdownIngestionObsidianBatchDelayMs?: number;
   dreamPromotionEnabled?: boolean;
   dreamPromotionDiaryPath?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,10 @@ export interface PluginConfig {
   markdownIngestionDebounceMs?: number;
   markdownIngestionSnapshotPath?: string;
   markdownIngestionObsidianSnapshotPath?: string;
+  markdownIngestionMaxFilesPerScan?: number;
+  markdownIngestionBatchDelayMs?: number;
+  markdownIngestionObsidianMaxFilesPerScan?: number;
+  markdownIngestionObsidianBatchDelayMs?: number;
   dreamPromotionEnabled?: boolean;
   dreamPromotionDiaryPath?: string;
   dreamPromotionUserId?: string;

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -591,7 +591,7 @@ test("markdown ingestion batches fresh files and resumes deferred scans", async 
       markdownIngestionDebounceMs: 0,
       markdownIngestionSnapshotPath: snapshotPath(tempRoot),
       markdownIngestionMaxFilesPerScan: 2,
-      markdownIngestionBatchDelayMs: 0,
+      markdownIngestionBatchDelayMs: 50,
     },
     async () => rpc,
     { error() {}, warn() {}, info: (message: string) => infoMessages.push(message) },
@@ -602,7 +602,7 @@ test("markdown ingestion batches fresh files and resumes deferred scans", async 
   assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 2);
   assert.equal(infoMessages.some((message) => message.includes("ingested=2") && message.includes("deferred=1")), true);
 
-  await delay(25);
+  await delay(75);
 
   assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 3);
   assert.equal(infoMessages.some((message) => message.includes("ingested=1") && message.includes("unchanged=2")), true);

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -574,3 +574,38 @@ test("markdown ingestion persists snapshots across adapter restarts", async () =
 
   await secondHandle.stop();
 });
+
+test("markdown ingestion batches fresh files and resumes deferred scans", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-batch-"));
+  const paths = ["alpha.md", "bravo.md", "charlie.md"].map((name) => path.join(tempRoot, name));
+  for (const filePath of paths) {
+    await fsp.writeFile(filePath, `# ${path.basename(filePath)}\n\nThis fresh file should be paced.`);
+  }
+
+  const rpc = new FakeRpcClient();
+  const infoMessages: string[] = [];
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+      markdownIngestionMaxFilesPerScan: 2,
+      markdownIngestionBatchDelayMs: 0,
+    },
+    async () => rpc,
+    { error() {}, warn() {}, info: (message: string) => infoMessages.push(message) },
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 2);
+  assert.equal(infoMessages.some((message) => message.includes("ingested=2") && message.includes("deferred=1")), true);
+
+  await delay(25);
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 3);
+  assert.equal(infoMessages.some((message) => message.includes("ingested=1") && message.includes("unchanged=2")), true);
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -615,3 +615,43 @@ test("markdown ingestion batches fresh files and resumes deferred scans", async 
 
   await handle.stop();
 });
+
+test("markdown ingestion byte budget defers reads for oversized batches", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-byte-batch-"));
+  const paths = ["alpha.md", "bravo.md", "charlie.md"].map((name) => path.join(tempRoot, name));
+  for (const filePath of paths) {
+    await fsp.writeFile(filePath, "123456789\n");
+  }
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const infoMessages: string[] = [];
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+      markdownIngestionMaxFilesPerScan: 0,
+      markdownIngestionMaxBytesPerScan: 20,
+      markdownIngestionBatchDelayMs: 50,
+    },
+    async () => rpc,
+    { error() {}, warn() {}, info: (message: string) => infoMessages.push(message) },
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 2);
+  assert.equal(fsApi.readFileCalls.length, 2);
+  assert.equal(infoMessages.some((message) => message.includes("ingested=2") && message.includes("deferred=1")), true);
+
+  await delay(75);
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 3);
+  assert.equal(fsApi.readFileCalls.length, 3);
+  assert.equal(infoMessages.some((message) => message.includes("ingested=1") && message.includes("unchanged=2")), true);
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -39,12 +39,14 @@ class FakeRpcClient {
 
 class FakeFsApi {
   callbacks = new Map<string, Array<(event: string, filename: string | Buffer | null) => void>>();
+  readFileCalls: string[] = [];
 
   async readdir(dir: string) {
     return await fsp.readdir(dir, { withFileTypes: true });
   }
 
   async readFile(file: string) {
+    this.readFileCalls.push(file);
     return await fsp.readFile(file);
   }
 
@@ -583,6 +585,7 @@ test("markdown ingestion batches fresh files and resumes deferred scans", async 
   }
 
   const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
   const infoMessages: string[] = [];
   const handle = createMarkdownIngestionHandle(
     {
@@ -595,16 +598,19 @@ test("markdown ingestion batches fresh files and resumes deferred scans", async 
     },
     async () => rpc,
     { error() {}, warn() {}, info: (message: string) => infoMessages.push(message) },
+    fsApi as never,
   );
 
   await handle.start();
 
   assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 2);
+  assert.equal(fsApi.readFileCalls.length, 2);
   assert.equal(infoMessages.some((message) => message.includes("ingested=2") && message.includes("deferred=1")), true);
 
   await delay(75);
 
   assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 3);
+  assert.equal(fsApi.readFileCalls.length, 3);
   assert.equal(infoMessages.some((message) => message.includes("ingested=1") && message.includes("unchanged=2")), true);
 
   await handle.stop();


### PR DESCRIPTION
## Summary

- pace startup markdown ingestion by limiting changed/new files processed per scan
- cap changed/new markdown bytes read and ingested per scan so large notes cannot bypass the file-count throttle
- continue deferred generic and Obsidian scans after a configurable delay
- add config/schema/docs for per-scan file caps, byte caps, and batch delays (`0` disables a cap)
- log deferred counts and cover continuation/read-deferral behavior with integration tests

## Context

Fresh markdown startup scans can saturate daemon CPU while embedding/tokenizing documents. This PR bounds both daemon ingest request rate and plugin-side read/hash/decode work during startup scans. Daemon-side CPU/thread/backpressure controls are tracked separately in #177.

## Tests

- `npm run test:integration -- --test-name-pattern="markdown ingestion"`
- `pnpm run check`
- `npm run test:integration`
- `npm run build`