### PR TITLE
Remove OpenClaw from runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,6 @@
     "prepack": "npm run build",
     "build:daemon": "bash scripts/build-daemon.sh"
   },
-  "dependencies": {
-    "openclaw": "*"
-  },
   "devDependencies": {
     "@bufbuild/protobuf": "1.7.2",
     "@grpc/grpc-js": "^1.14.3",
@@ -75,6 +72,7 @@
     "@types/node": "^20.11.0",
     "@xdarkicex/libravdb-contracts": "^0.0.6",
     "esbuild": "^0.27.0",
+    "openclaw": "2026.4.11",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      openclaw:
-        specifier: '*'
-        version: 2026.4.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@napi-rs/canvas@0.1.97)(@types/express@5.0.6)(apache-arrow@18.1.0)(typescript@6.0.3)
     devDependencies:
       '@bufbuild/protobuf':
         specifier: 1.7.2
@@ -33,6 +29,9 @@ importers:
       esbuild:
         specifier: ^0.27.0
         version: 0.27.7
+      openclaw:
+        specifier: 2026.4.11
+        version: 2026.4.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@napi-rs/canvas@0.1.97)(@types/express@5.0.6)(apache-arrow@18.1.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- remove `openclaw` from published runtime dependencies so installing the plugin cannot install or replace a host OpenClaw package
- keep `openclaw@2026.4.11` as a dev dependency for local build/test tooling
- keep the existing OpenClaw peer dependency contract

## Tests
- `COREPACK_ENABLE_AUTO_PIN=0 PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm run plugin:ci`
- `COREPACK_ENABLE_AUTO_PIN=0 PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm run check`
- `COREPACK_ENABLE_AUTO_PIN=0 PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to optimize development environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->