### PR TITLE
docs: explain embedding store compatibility

### DIFF
--- a/docs/embedding-profiles.md
+++ b/docs/embedding-profiles.md
@@ -35,6 +35,34 @@ How it works:
 - The sidecar store persists an embedding fingerprint, so reopening an existing store with a different effective model profile will fail instead of silently mixing vector spaces.
 - `onnxDevice` is passed through as `LIBRAVDB_ONNX_DEVICE` for daemon versions that support execution-provider selection (`auto`, `cpu`, `cuda`, `coreml`, `directml`, `openvino`).
 
+## Store Compatibility and Upgrades
+
+The persisted embedding fingerprint is part of the database compatibility check.
+That is intentional: if a daemon opens a store with a different effective model
+profile, the safest outcome is to stop before mixing vector spaces.
+
+When updating `libravdbd`, keep the same effective embedding profile unless you
+intend to rebuild the store. The effective profile includes the profile family,
+dimensions, normalization setting, and any metadata supplied by the model
+manifest or daemon defaults.
+
+Legacy local setups can be more fragile than the current packaged profiles. For
+example, older `all-minilm-l6-v2` stores may fail to reopen after a daemon update
+if the daemon now computes different metadata for that local profile. This does
+not imply that current packaged `nomic-embed-text-v1.5` or
+`bge-small-en-v1.5` stores are incompatible; it means the old local profile must
+be treated as a separate vector space unless a migration path is provided.
+
+If a daemon update reports that the database format or embedding profile is
+incompatible:
+
+1. back up both the `.libravdb` file and its `.embedding.json` metadata file;
+2. either downgrade to the previous daemon that created the store, or move the
+   old store aside and let the new daemon initialize a fresh database;
+3. rebuild/reingest memories with the new effective embedding profile.
+
+Do not delete the old store until the replacement has been verified.
+
 Recommended usage:
 
 - `bundled` for the shipped default path, which uses `nomic-embed-text-v1.5`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -171,6 +171,30 @@ For foreground debugging:
 libravdbd serve
 ```
 
+### Incompatible database or embedding profile
+
+If the daemon exits with `database format is incompatible` or `database
+embedding profile is incompatible`, it is refusing to open a store whose saved
+format or embedding fingerprint differs from the current daemon settings. This
+fail-closed behavior protects the store from mixing incompatible vector spaces.
+
+Before changing anything, back up both files for the affected store:
+
+- the database file, such as `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
+- the adjacent `.embedding.json` metadata file
+
+Then choose one recovery path:
+
+- downgrade to the daemon version that created the store; or
+- move the old store aside, start the new daemon so it creates a fresh store,
+  and rebuild/reingest memories with the current embedding profile.
+
+This can affect legacy local profiles such as older `all-minilm-l6-v2` setups
+when daemon defaults or model metadata change across releases. It is not
+expected for stores that stay on the current packaged profiles and assets. See
+[Embedding Profiles](./embedding-profiles.md#store-compatibility-and-upgrades)
+for more detail.
+
 ### Hash mismatch
 
 Do not bypass a checksum mismatch. Delete the corrupt or stale asset and rerun


### PR DESCRIPTION
## Summary

Adds documentation for embedding-profile/store compatibility and recovery after daemon/profile changes.

## Scope

- Explains why embedding fingerprints affect whether an existing store can be opened.
- Adds troubleshooting guidance for incompatible database/profile startup failures.
- Calls out legacy local `all-minilm-l6-v2` stores separately from current packaged profiles.

## Audit Notes

- Docs-only change touching `docs/embedding-profiles.md` and `docs/installation.md`.
- The issue is recovery guidance, not a claim that all v1.4.62 stores break under v1.4.65.
- Keep the language careful: failing closed on incompatible embeddings is correct; the gap is user recovery guidance.

## Review Follow-up

- Add or verify a concrete cross-reference to the supported reindex/reingestion command before merge.
- Do not invent a version matrix unless the exact incompatible version ranges are verified. The safe wording is profile/fingerprint based.
- Keep the docs clear that fail-closed fingerprint rejection is correct behavior; recovery guidance is the missing piece.

## Verification

- `git diff --check`
- docs anchor smoke check
- `npm run plugin:ci`

Closes #180.

– Vale