### PR TITLE
fix: validate gRPC TLS config before sidecar startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ gate threshold, and the loaded embedding profile.
 
 Runtime requirements:
 
-- OpenClaw `>= 2026.3.22`
+- OpenClaw `>= 2026.4.11`
 - Node.js `>= 22`
 - a separately installed `libravdbd` service
 
@@ -209,7 +209,7 @@ service checkout. For the full source workflow, read [Development](./docs/develo
 - npm package: `@xdarkicex/openclaw-memory-libravdb`
 - OpenClaw plugin id: `libravdb-memory`
 - plugin kind: `memory`, `context-engine`
-- minimum OpenClaw host version: `>= 2026.3.22`
+- minimum OpenClaw host version: `>= 2026.4.11`
 - default data path: `$HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb`
 - default macOS/Linux endpoint: `unix:$HOME/.libravdbd/run/libravdb.sock`
 - default Windows endpoint: `tcp:127.0.0.1:37421`

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -57,6 +57,7 @@
           "tls",
           "insecure"
         ],
+        "default": "auto",
         "description": "gRPC credential mode. auto (default): loopback and unix socket use plaintext, remote addresses use TLS. tls: always use TLS regardless of address. insecure: always use plaintext (use with service mesh or tunnel that handles TLS externally)."
       },
       "authoredHardBudgetFraction": {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -58,6 +58,7 @@ export function createPluginRuntime(
     }
     if (!started) {
       started = (async () => {
+        validateGrpcKernelConfig(cfg, logger);
         const sidecar = await startSidecar(cfg, logger);
         const rpc = new RpcClient(sidecar.socket, {
           timeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
@@ -77,25 +78,6 @@ export function createPluginRuntime(
         if (cfg.grpcEndpoint) {
           try {
             const secret = loadSecretFromEnv();
-            if (
-              cfg.grpcEndpointTlsMode !== undefined &&
-              !isTlsModeValid(cfg.grpcEndpointTlsMode)
-            ) {
-              throw new Error(
-                `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
-                `must be "auto", "tls", or "insecure"`,
-              );
-            }
-            if (
-              cfg.grpcEndpointTlsMode === "insecure" &&
-              cfg.grpcEndpointTlsCa
-            ) {
-              // logger is provided by the host and may not have all methods
-              logger.warn?.(
-                `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
-                `is "insecure" — the CA file will not be used`,
-              );
-            }
             kernel = new GrpcKernelClient({
               endpoint: cfg.grpcEndpoint,
               secret,
@@ -167,6 +149,30 @@ export function createPluginRuntime(
       }
     },
   };
+}
+
+export function validateGrpcKernelConfig(cfg: PluginConfig, logger: LoggerLike): void {
+  if (!cfg.grpcEndpoint) {
+    return;
+  }
+  if (
+    cfg.grpcEndpointTlsMode !== undefined &&
+    !isTlsModeValid(cfg.grpcEndpointTlsMode)
+  ) {
+    throw new Error(
+      `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
+      `must be "auto", "tls", or "insecure"`,
+    );
+  }
+  if (
+    cfg.grpcEndpointTlsMode === "insecure" &&
+    cfg.grpcEndpointTlsCa
+  ) {
+    logger.warn?.(
+      `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
+      `is "insecure" — the CA file will not be used`,
+    );
+  }
 }
 
 function loadSecretFromEnv(): string | undefined {

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { enrichStartupError, resolveStartupHealthTimeoutMs } from "../../src/plugin-runtime.js";
+import {
+  enrichStartupError,
+  resolveStartupHealthTimeoutMs,
+  validateGrpcKernelConfig,
+} from "../../src/plugin-runtime.js";
 
 test("enrichStartupError adds provisioning guidance for daemon startup failures", () => {
   const err = enrichStartupError("LibraVDB daemon failed health check", "embedder running in deterministic fallback mode");
@@ -21,43 +25,36 @@ test("resolveStartupHealthTimeoutMs uses the normal RPC timeout when it is highe
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 1000 }), 2000);
 });
 
-test("invalid grpcEndpointTlsMode throws with the bad value", async () => {
-  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-  const runtime = createPluginRuntime({
-    grpcEndpoint: "tcp:127.0.0.1:50051",
-    grpcEndpointTlsMode: "mtls" as any,
-  });
-  await assert.rejects(
-    () => runtime.getKernel(),
+test("invalid grpcEndpointTlsMode throws with the bad value", () => {
+  assert.throws(
+    () => validateGrpcKernelConfig({
+      grpcEndpoint: "tcp:127.0.0.1:50051",
+      grpcEndpointTlsMode: "mtls" as any,
+    }, console),
     /invalid grpcEndpointTlsMode.*mtls/,
   );
 });
 
-test("insecure mode with tlsCaPath logs warning about CA not being used", async () => {
+test("omitted grpcEndpointTlsMode is valid for auto credential selection", () => {
+  assert.doesNotThrow(() => validateGrpcKernelConfig({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+  }, console));
+});
+
+test("insecure mode with tlsCaPath logs warning about CA not being used", () => {
   const warnings: string[] = [];
-  const origWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    const msg = args.join(" ");
-    if (msg.includes("grpcEndpointTlsCa") || msg.includes("insecure")) {
-      warnings.push(msg);
-    }
+  const logger = {
+    error() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
   };
-  try {
-    const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-    const runtime = createPluginRuntime({
-      grpcEndpoint: "tcp:127.0.0.1:50051",
-      grpcEndpointTlsMode: "insecure",
-      grpcEndpointTlsCa: "/etc/certs/ca.pem",
-    });
-    try {
-      await runtime.getKernel();
-    } catch {
-      // gRPC init may fail — we only care about the warning
-    }
-    assert.equal(warnings.length, 1, "should have logged one CA/insecure warning");
-    assert.match(warnings[0], /grpcEndpointTlsCa/);
-    assert.match(warnings[0], /insecure/);
-  } finally {
-    console.warn = origWarn;
-  }
+  validateGrpcKernelConfig({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+    grpcEndpointTlsMode: "insecure",
+    grpcEndpointTlsCa: "/etc/certs/ca.pem",
+  }, logger);
+  assert.equal(warnings.length, 1, "should have logged one CA/insecure warning");
+  assert.match(warnings[0], /grpcEndpointTlsCa/);
+  assert.match(warnings[0], /insecure/);
 });


### PR DESCRIPTION
## Summary
- validate \`grpcEndpointTlsMode\` and the \`grpcEndpointTlsCa\`/\`insecure\` warning before sidecar startup
- test TLS config validation through a direct unit seam instead of requiring a daemon socket
- align the documented OpenClaw host requirement and schema default with the package install metadata

## Verification
- \`pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/plugin-runtime.test.js\`
- \`pnpm run check\`
- \`npm run test:integration\` currently fails on upstream \`main\` and this branch with existing \`host-flow.test.js\` assertions for assemble config mapping (\`undefined !== 0.002\`) and dynamic compaction target (\`undefined !== 800\`); not introduced by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum required OpenClaw host version from 2026.3.22 to 2026.4.11 in Quick Start and Runtime Facts sections.

* **Chores**
  * Added default "auto" configuration value for gRPC endpoint TLS mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->