### PR TITLE
Add gRPC mTLS client certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ All keys are optional. For the full reference, see [Configuration](./docs/config
 
 - New install: [Install](./docs/install.md), [Installation reference](./docs/installation.md)
 - Understand the design: [Problem](./docs/problem.md), [Architecture](./docs/architecture.md), [ADRs](./docs/architecture-decisions/README.md)
-- Configure: [Configuration](./docs/configuration.md), [TLS configuration](./docs/TLS_configuration.md), [Features](./docs/features.md), [Embedding profiles](./docs/embedding-profiles.md), [Models](./docs/models.md)
+- Configure: [Configuration](./docs/configuration.md), [TLS configuration](./docs/TLS_configuration.md), [mTLS configuration](./docs/mTLS_configuration.md), [Features](./docs/features.md), [Embedding profiles](./docs/embedding-profiles.md), [Models](./docs/models.md)
 - Operate safely: [Security](./docs/security.md), [Uninstall](./docs/uninstall.md)
 - Advanced operations: [Performance and tuning](./docs/performance-and-tuning.md)
 - Work from source: [Development](./docs/development.md), [Contributing](./docs/contributing.md)

--- a/docs/mTLS_configuration.md
+++ b/docs/mTLS_configuration.md
@@ -1,0 +1,78 @@
+# mTLS Configuration
+
+The plugin supports mutual TLS (mTLS) for gRPC connections to the Vector Service. In mTLS, both the client and the server present X.509 certificates, and each side verifies the other's certificate against a trusted CA. When the Vector Service is configured with a client CA, it will reject any client that does not present a valid certificate signed by that CA.
+
+## When mTLS is required
+
+The Vector Service operator enables mTLS by configuring a client CA on the service side. When this is enabled, the Vector Service requires every connecting client to present a certificate signed by that CA. If the plugin is configured to use TLS but does not present a client certificate, the TLS handshake will fail and the connection will be rejected.
+
+The plugin cannot detect whether the daemon requires mTLS — it must be configured explicitly. If connections fail with a "client did not provide a certificate" error, the plugin likely needs a client certificate configured.
+
+## Configuration fields
+
+| Field | Type | When to use |
+|---|---|---|
+| `grpcEndpointTlsClientCert` | string (file path) | Path to a PEM-encoded X.509 client certificate. Required when the Vector Service requires a client certificate. |
+| `grpcEndpointTlsClientKey` | string (file path) | Path to the PEM-encoded private key that corresponds to the certificate. Required when `grpcEndpointTlsClientCert` is set. |
+
+Both fields must be set together or not at all. Setting one without the other will cause a configuration error at startup.
+
+These fields only take effect when the connection uses TLS — that is, when `grpcEndpointTlsMode` is not `"insecure"` and the endpoint is not a loopback address or Unix socket. See [TLS configuration](./TLS_configuration.md) for the full TLS behavior reference.
+
+## Certificate requirements
+
+- **Format**: PEM-encoded X.509 certificate (-----BEGIN CERTIFICATE-----)
+- **Chain order**: Leaf certificate must be first in the file; intermediate certificates may follow in the same file
+- **Signing**: The certificate must be signed by the CA that the Vector Service operator configured as the client CA
+- **Key types accepted**:
+  - RSA (any key size)
+  - ECDSA (P-256, P-384, P-521)
+  - Ed25519
+- **Key file format**: PEM-encoded private key (-----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY----- etc.)
+- **Key/cert match**: The private key must correspond to the leaf certificate's public key
+- **Revocation**: The Vector Service does not perform revocation checking. Expired certificates are rejected (`NotAfter` boundary). Revoked but unexpired certificates are not detected. Keep certificate lifetimes short.
+
+## Example configuration
+
+```json
+{
+  "grpcEndpoint": "tcp:libravdb.internal:9090",
+  "grpcEndpointTlsCa": "/etc/certs/company-ca.pem",
+  "grpcEndpointTlsClientCert": "/etc/certs/plugin-client.crt",
+  "grpcEndpointTlsClientKey": "/etc/certs/plugin-client.key"
+}
+```
+
+This example shows all four gRPC TLS fields configured together for a remote Vector Service that uses a private CA and requires mTLS.
+
+## Generating a client certificate (quick reference)
+
+The following example shows OpenSSL commands to generate a client key, create a CSR, and sign it with a private CA. This is for illustration only — operators may use cert-manager, Vault, step, or other PKI tooling instead.
+
+**1. Create a client private key:**
+```bash
+openssl genpkey -algorithm ED25519 -out client.key
+```
+
+**2. Create a certificate signing request (CSR):**
+```bash
+openssl req -new -key client.key -out client.csr -subj "/CN=openclaw-plugin/O=LibraVDB"
+```
+
+**3. Sign the CSR with the private CA:**
+```bash
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key \
+  -CAcreateserial -out client.crt -days 365
+```
+
+Replace `ca.crt` and `ca.key` with the CA certificate and key that the daemon operator provided.
+
+## Error reference
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| `tls: client did not provide a certificate` | mTLS is required by the Vector Service, but no client certificate is configured in the plugin | Set `grpcEndpointTlsClientCert` and `grpcEndpointTlsClientKey` in the plugin config |
+| `tls: failed to verify client certificate: x509: certificate signed by unknown authority` | The client certificate is not signed by the Vector Service's client CA | Obtain a certificate signed by the CA the Vector Service operator configured as the client CA |
+| `LibraVDB: failed to load TLS client certificate from "...": ENOENT: no such file or directory` | The certificate file path does not exist or is not readable | Verify the path set in `grpcEndpointTlsClientCert` exists and has correct permissions |
+| `LibraVDB: failed to load TLS client key from "...": ENOENT: no such file or directory` | The key file path does not exist or is not readable | Verify the path set in `grpcEndpointTlsClientKey` exists and has correct permissions |
+| `LibraVDB: grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted` | Only one of the two fields is set | Set both fields or remove both from the configuration |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -50,6 +50,14 @@
         "type": "string",
         "description": "Path to a CA certificate PEM file for verifying the daemon's TLS certificate. Only needed for self-signed or private CA certificates. Not required when using a publicly trusted certificate (Let's Encrypt, cert-manager, etc)."
       },
+      "grpcEndpointTlsClientCert": {
+        "type": "string",
+        "description": "Path to a PEM-encoded X.509 client certificate for mTLS. Required when the daemon requires a client certificate. Must be paired with grpcEndpointTlsClientKey."
+      },
+      "grpcEndpointTlsClientKey": {
+        "type": "string",
+        "description": "Path to the client private key PEM file. Required when grpcEndpointTlsClientCert is set. Accepts RSA, ECDSA (P-256/P-384/P-521), Ed25519 keys."
+      },
       "grpcEndpointTlsMode": {
         "type": "string",
         "enum": [

--- a/src/grpc-client.ts
+++ b/src/grpc-client.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as fs from "fs";
+import fs from "node:fs";
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 
@@ -16,7 +16,9 @@ export interface GrpcClientOptions {
   secret?: string;
   timeoutMs?: number;
   tlsCaPath?: string;
-  tlsMode?: "auto" | "tls" | "insecure"; // exported type: use VALID_TLS_MODES from plugin-runtime for deriving new types
+  tlsMode?: "auto" | "tls" | "insecure";
+  tlsClientCertPath?: string;
+  tlsClientKeyPath?: string;
 }
 
 export function resolveGrpcTarget(endpoint: string): string {
@@ -53,12 +55,15 @@ export function resolveGrpcCredentials(
   endpoint: string,
   tlsCaPath?: string,
   tlsMode?: "auto" | "tls" | "insecure",
+  tlsClientCertPath?: string,
+  tlsClientKeyPath?: string,
 ): grpc.ChannelCredentials {
   if (resolveGrpcCredentialMode(endpoint, tlsMode) === "insecure") {
     return grpc.credentials.createInsecure();
   }
+  // tlsMode is "tls" or "auto"/undefined resolved to "tls"
+  let rootCerts: Buffer | null = null;
   if (tlsCaPath) {
-    let rootCerts: Buffer;
     try {
       rootCerts = fs.readFileSync(tlsCaPath);
     } catch (err) {
@@ -67,9 +72,37 @@ export function resolveGrpcCredentials(
         `LibraVDB: failed to load TLS CA certificate from "${tlsCaPath}": ${msg}`,
       );
     }
-    return grpc.credentials.createSsl(rootCerts, null, null);
   }
-  return grpc.credentials.createSsl();
+  // Client certificate and key must both be present or both absent
+  const hasCert = tlsClientCertPath !== undefined;
+  const hasKey = tlsClientKeyPath !== undefined;
+  if (hasCert !== hasKey) {
+    throw new Error(
+      "LibraVDB: grpcEndpointTlsClientCert and grpcEndpointTlsClientKey " +
+      "must both be set or both be omitted",
+    );
+  }
+  let clientKey: Buffer | null = null;
+  let clientCert: Buffer | null = null;
+  if (tlsClientCertPath && tlsClientKeyPath) {
+    try {
+      clientCert = fs.readFileSync(tlsClientCertPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `LibraVDB: failed to load TLS client certificate from "${tlsClientCertPath}": ${msg}`,
+      );
+    }
+    try {
+      clientKey = fs.readFileSync(tlsClientKeyPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `LibraVDB: failed to load TLS client key from "${tlsClientKeyPath}": ${msg}`,
+      );
+    }
+  }
+  return grpc.credentials.createSsl(rootCerts, clientKey, clientCert);
 }
 
 function extractGrpcHost(target: string): string {
@@ -111,7 +144,13 @@ export class GrpcKernelClient {
 
     const target = resolveGrpcTarget(options.endpoint);
 
-    this.client = new kernelService(target, resolveGrpcCredentials(options.endpoint, options.tlsCaPath, options.tlsMode));
+    this.client = new kernelService(target, resolveGrpcCredentials(
+      options.endpoint,
+      options.tlsCaPath,
+      options.tlsMode,
+      options.tlsClientCertPath,
+      options.tlsClientKeyPath,
+    ));
   }
 
   private getMetadata(signed = true): grpc.Metadata {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -58,6 +58,43 @@ export function createPluginRuntime(
     }
     if (!started) {
       started = (async () => {
+        if (cfg.grpcEndpoint) {
+          if (
+            cfg.grpcEndpointTlsMode !== undefined &&
+            !isTlsModeValid(cfg.grpcEndpointTlsMode)
+          ) {
+            throw new Error(
+              `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
+              `must be "auto", "tls", or "insecure"`,
+            );
+          }
+
+          const hasClientCert = cfg.grpcEndpointTlsClientCert !== undefined;
+          const hasClientKey = cfg.grpcEndpointTlsClientKey !== undefined;
+          if (hasClientCert !== hasClientKey) {
+            throw new Error(
+              "LibraVDB: grpcEndpointTlsClientCert and " +
+              "grpcEndpointTlsClientKey must both be set or both be omitted",
+            );
+          }
+
+          if (cfg.grpcEndpointTlsMode === "insecure") {
+            if (cfg.grpcEndpointTlsCa) {
+              logger.warn?.(
+                `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
+                `is "insecure" — the CA file will not be used`,
+              );
+            }
+            if (cfg.grpcEndpointTlsClientCert) {
+              logger.warn?.(
+                `LibraVDB: grpcEndpointTlsClientCert is set but ` +
+                `grpcEndpointTlsMode is "insecure" — client certificate ` +
+                `will not be sent`,
+              );
+            }
+          }
+        }
+
         const sidecar = await startSidecar(cfg, logger);
         const rpc = new RpcClient(sidecar.socket, {
           timeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
@@ -75,37 +112,21 @@ export function createPluginRuntime(
         }
         let kernel: GrpcKernelClient | null = null;
         if (cfg.grpcEndpoint) {
-          try {
             const secret = loadSecretFromEnv();
-            if (
-              cfg.grpcEndpointTlsMode !== undefined &&
-              !isTlsModeValid(cfg.grpcEndpointTlsMode)
-            ) {
-              throw new Error(
-                `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
-                `must be "auto", "tls", or "insecure"`,
-              );
+            try {
+              kernel = new GrpcKernelClient({
+                endpoint: cfg.grpcEndpoint,
+                secret,
+                timeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
+                tlsCaPath: cfg.grpcEndpointTlsCa,
+                tlsMode: cfg.grpcEndpointTlsMode,
+                tlsClientCertPath: cfg.grpcEndpointTlsClientCert,
+                tlsClientKeyPath: cfg.grpcEndpointTlsClientKey,
+              });
+            } catch (error) {
+              // Only gRPC init errors land here — config validation already threw above
+              logger.warn?.(`LibraVDB: failed to initialize gRPC kernel client: ${formatError(error)}`);
             }
-            if (
-              cfg.grpcEndpointTlsMode === "insecure" &&
-              cfg.grpcEndpointTlsCa
-            ) {
-              // logger is provided by the host and may not have all methods
-              logger.warn?.(
-                `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
-                `is "insecure" — the CA file will not be used`,
-              );
-            }
-            kernel = new GrpcKernelClient({
-              endpoint: cfg.grpcEndpoint,
-              secret,
-              timeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
-              tlsCaPath: cfg.grpcEndpointTlsCa,
-              tlsMode: cfg.grpcEndpointTlsMode,
-            });
-          } catch (error) {
-            logger.warn?.(`LibraVDB: failed to initialize gRPC kernel client: ${formatError(error)}`);
-          }
         }
 
         return { rpc, sidecar, kernel };

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,17 @@ export interface PluginConfig {
   logLevel?: "debug" | "info" | "warn" | "error";
   grpcEndpoint?: string;
   grpcEndpointTlsCa?: string;  // path to CA cert PEM file for remote TLS verification
+  /** Path to a client certificate PEM file for mTLS.
+   * The file must contain a PEM-encoded X.509 certificate. Leaf first;
+   * intermediates may follow in the same file. Required when the daemon
+   * requires a client certificate (mTLS). Must be paired with
+   * grpcEndpointTlsClientKey. */
+  grpcEndpointTlsClientCert?: string;
+  /** Path to the client private key PEM file.
+   * Must correspond to the leaf certificate in grpcEndpointTlsClientCert.
+   * Accepts RSA (PKCS#1/PKCS#8), ECDSA (P-256/P-384/P-521), Ed25519.
+   * Required when grpcEndpointTlsClientCert is set. */
+  grpcEndpointTlsClientKey?: string;
   /** Controls gRPC credential mode.
    * "auto" (default) — loopback and unix → plaintext, remote → TLS.
    * "tls"            — always use TLS regardless of address.

--- a/test/unit/grpc-client.test.ts
+++ b/test/unit/grpc-client.test.ts
@@ -1,11 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import type * as fsType from "node:fs";
+import type * as grpcType from "@grpc/grpc-js";
 
 import {
   resolveGrpcCredentialMode,
   resolveGrpcCredentials,
   resolveGrpcTarget,
 } from "../../src/grpc-client.js";
+
+const require = createRequire(import.meta.url);
+const fs = require("fs") as typeof fsType;
+const grpc = require("@grpc/grpc-js") as typeof grpcType;
 
 test("resolveGrpcTarget strips tcp prefix for grpc-js host targets", () => {
   assert.equal(resolveGrpcTarget("tcp:127.0.0.1:37421"), "127.0.0.1:37421");
@@ -85,4 +92,119 @@ test("resolveGrpcCredentials tlsMode 'tls' forces secure credentials on loopback
   // Access .secureContext via any to verify TLS — ChannelCredentials is opaque to consumers
   const creds = resolveGrpcCredentials("tcp:127.0.0.1:37421", undefined, "tls") as any;
   assert.notEqual(creds.secureContext, undefined);
+});
+
+test("resolveGrpcCredentials passes key+cert buffers to createSsl", (t) => {
+  const certBuffer = Buffer.from("CERT_DATA");
+  const keyBuffer = Buffer.from("KEY_DATA");
+  const returned = { mocked: true } as unknown as grpcType.ChannelCredentials;
+
+  const readMock = t.mock.method(fs, "readFileSync", (filePath: fsType.PathOrFileDescriptor) => {
+    if (filePath === "/certs/client.crt") return certBuffer;
+    if (filePath === "/certs/client.key") return keyBuffer;
+    throw new Error(`unexpected read: ${String(filePath)}`);
+  });
+  const createSslMock = t.mock.method(
+    grpc.credentials,
+    "createSsl",
+    () => returned,
+  );
+
+  const creds = resolveGrpcCredentials(
+    "tcp:192.0.2.10:37421",
+    undefined,
+    "tls",
+    "/certs/client.crt",
+    "/certs/client.key",
+  );
+
+  assert.equal(creds, returned);
+  assert.equal(readMock.mock.callCount(), 2);
+  assert.deepEqual(readMock.mock.calls.map((call) => call.arguments[0]), [
+    "/certs/client.crt",
+    "/certs/client.key",
+  ]);
+  assert.equal(createSslMock.mock.callCount(), 1);
+  assert.deepEqual(createSslMock.mock.calls[0]?.arguments, [
+    null,
+    keyBuffer,
+    certBuffer,
+  ]);
+});
+
+test("resolveGrpcCredentials throws when only tlsClientCertPath is set", () => {
+  assert.throws(
+    () => resolveGrpcCredentials(
+      "tcp:192.0.2.10:37421",
+      undefined,
+      "auto",
+      "/path/to/client.crt",
+      undefined,
+    ),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("resolveGrpcCredentials throws when only tlsClientKeyPath is set", () => {
+  assert.throws(
+    () => resolveGrpcCredentials(
+      "tcp:192.0.2.10:37421",
+      undefined,
+      "auto",
+      undefined,
+      "/path/to/client.key",
+    ),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("resolveGrpcCredentials throws ENOENT when client cert file does not exist", (t) => {
+  t.mock.method(fs, "readFileSync", (filePath: fsType.PathOrFileDescriptor) => {
+    throw new Error(`ENOENT: no such file or directory, open '${String(filePath)}'`);
+  });
+
+  assert.throws(
+    () => resolveGrpcCredentials(
+      "tcp:192.0.2.10:37421",
+      undefined,
+      "auto",
+      "/nonexistent/client.crt",
+      "/certs/client.key",
+    ),
+    /LibraVDB: failed to load TLS client certificate from "\/nonexistent\/client.crt": ENOENT/,
+  );
+});
+
+test("resolveGrpcCredentials throws ENOENT when client key file does not exist", (t) => {
+  const certBuffer = Buffer.from("CERT_DATA");
+  t.mock.method(fs, "readFileSync", (filePath: fsType.PathOrFileDescriptor) => {
+    if (filePath === "/certs/client.crt") return certBuffer;
+    throw new Error(`ENOENT: no such file or directory, open '${String(filePath)}'`);
+  });
+
+  assert.throws(
+    () => resolveGrpcCredentials(
+      "tcp:192.0.2.10:37421",
+      undefined,
+      "auto",
+      "/certs/client.crt",
+      "/nonexistent/client.key",
+    ),
+    /LibraVDB: failed to load TLS client key from "\/nonexistent\/client.key": ENOENT/,
+  );
+});
+
+test("resolveGrpcCredentials does NOT read client cert/key files when mode is 'insecure'", (t) => {
+  const readMock = t.mock.method(fs, "readFileSync", () => {
+    throw new Error("should not read TLS files in insecure mode");
+  });
+  const creds = resolveGrpcCredentials(
+    "tcp:192.0.2.10:37421",
+    undefined,
+    "insecure",
+    "/nonexistent/client.crt",
+    "/nonexistent/client.key",
+  ) as any;
+  assert.equal(creds.secureContext, undefined);
+  assert.equal(readMock.mock.callCount(), 0);
 });

--- a/test/unit/grpc-client.test.ts
+++ b/test/unit/grpc-client.test.ts
@@ -132,6 +132,41 @@ test("resolveGrpcCredentials passes key+cert buffers to createSsl", (t) => {
   ]);
 });
 
+test("resolveGrpcCredentials passes CA root with key+cert buffers to createSsl", (t) => {
+  const caBuffer = Buffer.from("CA_DATA");
+  const certBuffer = Buffer.from("CERT_DATA");
+  const keyBuffer = Buffer.from("KEY_DATA");
+  const returned = { mocked: true } as unknown as grpcType.ChannelCredentials;
+
+  t.mock.method(fs, "readFileSync", (filePath: fsType.PathOrFileDescriptor) => {
+    if (filePath === "/certs/ca.pem") return caBuffer;
+    if (filePath === "/certs/client.crt") return certBuffer;
+    if (filePath === "/certs/client.key") return keyBuffer;
+    throw new Error(`unexpected read: ${String(filePath)}`);
+  });
+  const createSslMock = t.mock.method(
+    grpc.credentials,
+    "createSsl",
+    () => returned,
+  );
+
+  const creds = resolveGrpcCredentials(
+    "tcp:192.0.2.10:37421",
+    "/certs/ca.pem",
+    "tls",
+    "/certs/client.crt",
+    "/certs/client.key",
+  );
+
+  assert.equal(creds, returned);
+  assert.equal(createSslMock.mock.callCount(), 1);
+  assert.deepEqual(createSslMock.mock.calls[0]?.arguments, [
+    caBuffer,
+    keyBuffer,
+    certBuffer,
+  ]);
+});
+
 test("resolveGrpcCredentials throws when only tlsClientCertPath is set", () => {
   assert.throws(
     () => resolveGrpcCredentials(

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -61,3 +61,57 @@ test("insecure mode with tlsCaPath logs warning about CA not being used", async 
     console.warn = origWarn;
   }
 });
+
+test("validation throws when grpcEndpointTlsClientCert is set but grpcEndpointTlsClientKey is omitted", async () => {
+  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
+  const runtime = createPluginRuntime({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+    grpcEndpointTlsClientCert: "/etc/certs/client.crt",
+  });
+  await assert.rejects(
+    () => runtime.getKernel(),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("validation throws when grpcEndpointTlsClientKey is set but grpcEndpointTlsClientCert is omitted", async () => {
+  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
+  const runtime = createPluginRuntime({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+    grpcEndpointTlsClientKey: "/etc/certs/client.key",
+  });
+  await assert.rejects(
+    () => runtime.getKernel(),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("warning fires when grpcEndpointTlsClientCert is set and grpcEndpointTlsMode is 'insecure'", async () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    const msg = args.join(" ");
+    if (msg.includes("grpcEndpointTlsClientCert") || msg.includes("insecure")) {
+      warnings.push(msg);
+    }
+  };
+  try {
+    const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
+    const runtime = createPluginRuntime({
+      grpcEndpoint: "tcp:127.0.0.1:50051",
+      grpcEndpointTlsMode: "insecure",
+      grpcEndpointTlsClientCert: "/etc/certs/client.crt",
+      grpcEndpointTlsClientKey: "/etc/certs/client.key",
+    });
+    try {
+      await runtime.getKernel();
+    } catch {
+      // gRPC init may fail — we only care about the warning
+    }
+    assert.equal(warnings.length, 1, "should have logged one client cert/insecure warning");
+    assert.match(warnings[0], /grpcEndpointTlsClientCert/);
+    assert.match(warnings[0], /insecure/);
+  } finally {
+    console.warn = origWarn;
+  }
+});


### PR DESCRIPTION
## Summary
- add plugin config/schema fields for gRPC mTLS client certificate and key paths
- load and pass client key/cert buffers to grpc.credentials.createSsl when TLS is active
- validate partial cert/key config in plugin runtime and credential construction, with insecure-mode warnings
- add operator-facing mTLS configuration docs and unit coverage

## Tests
- pnpm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mutual TLS (mTLS) support for gRPC connections with configurable client certificate and private key paths for enhanced security.

* **Documentation**
  * Added comprehensive mTLS configuration guide including certificate requirements, OpenSSL command examples, and error reference table for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->