### PR TITLE
refactor: extract complete gRPC config validation

### DIFF
--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -58,42 +58,7 @@ export function createPluginRuntime(
     }
     if (!started) {
       started = (async () => {
-        if (cfg.grpcEndpoint) {
-          if (
-            cfg.grpcEndpointTlsMode !== undefined &&
-            !isTlsModeValid(cfg.grpcEndpointTlsMode)
-          ) {
-            throw new Error(
-              `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
-              `must be "auto", "tls", or "insecure"`,
-            );
-          }
-
-          const hasClientCert = cfg.grpcEndpointTlsClientCert !== undefined;
-          const hasClientKey = cfg.grpcEndpointTlsClientKey !== undefined;
-          if (hasClientCert !== hasClientKey) {
-            throw new Error(
-              "LibraVDB: grpcEndpointTlsClientCert and " +
-              "grpcEndpointTlsClientKey must both be set or both be omitted",
-            );
-          }
-
-          if (cfg.grpcEndpointTlsMode === "insecure") {
-            if (cfg.grpcEndpointTlsCa) {
-              logger.warn?.(
-                `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
-                `is "insecure" — the CA file will not be used`,
-              );
-            }
-            if (cfg.grpcEndpointTlsClientCert) {
-              logger.warn?.(
-                `LibraVDB: grpcEndpointTlsClientCert is set but ` +
-                `grpcEndpointTlsMode is "insecure" — client certificate ` +
-                `will not be sent`,
-              );
-            }
-          }
-        }
+        validateGrpcKernelConfig(cfg, logger);
 
         const sidecar = await startSidecar(cfg, logger);
         const rpc = new RpcClient(sidecar.socket, {
@@ -188,6 +153,46 @@ export function createPluginRuntime(
       }
     },
   };
+}
+
+export function validateGrpcKernelConfig(cfg: PluginConfig, logger: LoggerLike): void {
+  if (!cfg.grpcEndpoint) {
+    return;
+  }
+  if (
+    cfg.grpcEndpointTlsMode !== undefined &&
+    !isTlsModeValid(cfg.grpcEndpointTlsMode)
+  ) {
+    throw new Error(
+      `LibraVDB: invalid grpcEndpointTlsMode "${cfg.grpcEndpointTlsMode}" — ` +
+      `must be "auto", "tls", or "insecure"`,
+    );
+  }
+
+  const hasClientCert = cfg.grpcEndpointTlsClientCert !== undefined;
+  const hasClientKey = cfg.grpcEndpointTlsClientKey !== undefined;
+  if (hasClientCert !== hasClientKey) {
+    throw new Error(
+      "LibraVDB: grpcEndpointTlsClientCert and " +
+      "grpcEndpointTlsClientKey must both be set or both be omitted",
+    );
+  }
+
+  if (cfg.grpcEndpointTlsMode === "insecure") {
+    if (cfg.grpcEndpointTlsCa) {
+      logger.warn?.(
+        `LibraVDB: grpcEndpointTlsCa is set but grpcEndpointTlsMode ` +
+        `is "insecure" — the CA file will not be used`,
+      );
+    }
+    if (cfg.grpcEndpointTlsClientCert) {
+      logger.warn?.(
+        `LibraVDB: grpcEndpointTlsClientCert is set but ` +
+        `grpcEndpointTlsMode is "insecure" — client certificate ` +
+        `will not be sent`,
+      );
+    }
+  }
 }
 
 function loadSecretFromEnv(): string | undefined {

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { enrichStartupError, resolveStartupHealthTimeoutMs } from "../../src/plugin-runtime.js";
+import { enrichStartupError, resolveStartupHealthTimeoutMs, validateGrpcKernelConfig } from "../../src/plugin-runtime.js";
 
 test("enrichStartupError adds provisioning guidance for daemon startup failures", () => {
   const err = enrichStartupError("LibraVDB daemon failed health check", "embedder running in deterministic fallback mode");
@@ -21,97 +21,82 @@ test("resolveStartupHealthTimeoutMs uses the normal RPC timeout when it is highe
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 1000 }), 2000);
 });
 
-test("invalid grpcEndpointTlsMode throws with the bad value", async () => {
-  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-  const runtime = createPluginRuntime({
-    grpcEndpoint: "tcp:127.0.0.1:50051",
-    grpcEndpointTlsMode: "mtls" as any,
-  });
-  await assert.rejects(
-    () => runtime.getKernel(),
+test("validateGrpcKernelConfig: invalid grpcEndpointTlsMode throws with the bad value", () => {
+  assert.throws(
+    () => validateGrpcKernelConfig({
+      grpcEndpoint: "tcp:127.0.0.1:50051",
+      grpcEndpointTlsMode: "mtls" as any,
+    }, console),
     /invalid grpcEndpointTlsMode.*mtls/,
   );
 });
 
-test("insecure mode with tlsCaPath logs warning about CA not being used", async () => {
-  const warnings: string[] = [];
-  const origWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    const msg = args.join(" ");
-    if (msg.includes("grpcEndpointTlsCa") || msg.includes("insecure")) {
-      warnings.push(msg);
-    }
-  };
-  try {
-    const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-    const runtime = createPluginRuntime({
-      grpcEndpoint: "tcp:127.0.0.1:50051",
-      grpcEndpointTlsMode: "insecure",
-      grpcEndpointTlsCa: "/etc/certs/ca.pem",
-    });
-    try {
-      await runtime.getKernel();
-    } catch {
-      // gRPC init may fail — we only care about the warning
-    }
-    assert.equal(warnings.length, 1, "should have logged one CA/insecure warning");
-    assert.match(warnings[0], /grpcEndpointTlsCa/);
-    assert.match(warnings[0], /insecure/);
-  } finally {
-    console.warn = origWarn;
-  }
-});
-
-test("validation throws when grpcEndpointTlsClientCert is set but grpcEndpointTlsClientKey is omitted", async () => {
-  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-  const runtime = createPluginRuntime({
+test("validateGrpcKernelConfig: omitted grpcEndpointTlsMode is valid for auto credential selection", () => {
+  assert.doesNotThrow(() => validateGrpcKernelConfig({
     grpcEndpoint: "tcp:127.0.0.1:50051",
-    grpcEndpointTlsClientCert: "/etc/certs/client.crt",
-  });
-  await assert.rejects(
-    () => runtime.getKernel(),
-    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
-  );
+  }, console));
 });
 
-test("validation throws when grpcEndpointTlsClientKey is set but grpcEndpointTlsClientCert is omitted", async () => {
-  const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-  const runtime = createPluginRuntime({
-    grpcEndpoint: "tcp:127.0.0.1:50051",
-    grpcEndpointTlsClientKey: "/etc/certs/client.key",
-  });
-  await assert.rejects(
-    () => runtime.getKernel(),
-    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
-  );
-});
-
-test("warning fires when grpcEndpointTlsClientCert is set and grpcEndpointTlsMode is 'insecure'", async () => {
+test("validateGrpcKernelConfig: insecure mode with tlsCaPath logs warning about CA not being used", () => {
   const warnings: string[] = [];
-  const origWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    const msg = args.join(" ");
-    if (msg.includes("grpcEndpointTlsClientCert") || msg.includes("insecure")) {
-      warnings.push(msg);
-    }
+  const logger = {
+    error() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
   };
-  try {
-    const { createPluginRuntime } = await import("../../src/plugin-runtime.js");
-    const runtime = createPluginRuntime({
+  validateGrpcKernelConfig({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+    grpcEndpointTlsMode: "insecure",
+    grpcEndpointTlsCa: "/etc/certs/ca.pem",
+  }, logger);
+  assert.equal(warnings.length, 1, "should have logged one CA/insecure warning");
+  assert.match(warnings[0], /grpcEndpointTlsCa/);
+  assert.match(warnings[0], /insecure/);
+});
+
+test("validateGrpcKernelConfig: throws when grpcEndpointTlsClientCert is set but grpcEndpointTlsClientKey is omitted", () => {
+  assert.throws(
+    () => validateGrpcKernelConfig({
       grpcEndpoint: "tcp:127.0.0.1:50051",
-      grpcEndpointTlsMode: "insecure",
       grpcEndpointTlsClientCert: "/etc/certs/client.crt",
+    }, console),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("validateGrpcKernelConfig: throws when grpcEndpointTlsClientKey is set but grpcEndpointTlsClientCert is omitted", () => {
+  assert.throws(
+    () => validateGrpcKernelConfig({
+      grpcEndpoint: "tcp:127.0.0.1:50051",
       grpcEndpointTlsClientKey: "/etc/certs/client.key",
-    });
-    try {
-      await runtime.getKernel();
-    } catch {
-      // gRPC init may fail — we only care about the warning
-    }
-    assert.equal(warnings.length, 1, "should have logged one client cert/insecure warning");
-    assert.match(warnings[0], /grpcEndpointTlsClientCert/);
-    assert.match(warnings[0], /insecure/);
-  } finally {
-    console.warn = origWarn;
-  }
+    }, console),
+    /grpcEndpointTlsClientCert and grpcEndpointTlsClientKey must both be set or both be omitted/,
+  );
+});
+
+test("validateGrpcKernelConfig: warning fires when grpcEndpointTlsClientCert is set and grpcEndpointTlsMode is 'insecure'", () => {
+  const warnings: string[] = [];
+  const logger = {
+    error() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+  };
+  validateGrpcKernelConfig({
+    grpcEndpoint: "tcp:127.0.0.1:50051",
+    grpcEndpointTlsMode: "insecure",
+    grpcEndpointTlsClientCert: "/etc/certs/client.crt",
+    grpcEndpointTlsClientKey: "/etc/certs/client.key",
+  }, logger);
+  assert.equal(warnings.length, 1, "should have logged one client cert/insecure warning");
+  assert.match(warnings[0], /grpcEndpointTlsClientCert/);
+  assert.match(warnings[0], /insecure/);
+});
+
+test("validateGrpcKernelConfig: returns early when grpcEndpoint is not set", () => {
+  assert.doesNotThrow(() => validateGrpcKernelConfig({
+    grpcEndpointTlsMode: "insecure",
+    grpcEndpointTlsCa: "/etc/certs/ca.pem",
+  }, console));
 });


### PR DESCRIPTION
## Summary
- Extract all gRPC TLS validation into a single `validateGrpcKernelConfig()` function
- Validation runs before sidecar startup for fail-fast behavior on misconfiguration
- Covers: TLS mode validity, mTLS cert/key pair symmetry, insecure mode warnings
- Replaces inline validation with a call to the new exported function

## Changes
- **src/plugin-runtime.ts**: Inline validation replaced with `validateGrpcKernelConfig(cfg, logger)` call before sidecar startup. New function exported for direct testing.
- **test/unit/plugin-runtime.test.ts**: Tests now call `validateGrpcKernelConfig()` directly instead of going through `createPluginRuntime().getKernel()`. All gRPC config scenarios covered including cert/key pair validation.

## Test results
- `pnpm run check`: 171 tests pass
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/plugin-runtime.test.js`: 10 tests pass

---

Supersedes #185 — that PR only extracted TLS mode validation, leaving mTLS cert/key pair validation inline and creating an incomplete validation function. This PR extracts ALL gRPC config validation and properly tests the complete surface.