### PR TITLE
Operational numeric config lacks basic bounds.

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -193,7 +193,9 @@
         "type": "string"
       },
       "sessionTTL": {
-        "type": "number"
+        "type": "number",
+        "minimum": 1,
+        "maximum": 2592000
       },
       "topK": {
         "type": "number"
@@ -245,6 +247,8 @@
       },
       "markdownIngestionObsidianDebounceMs": {
         "type": "number",
+        "minimum": 0,
+        "maximum": 600000,
         "default": 150
       },
       "markdownIngestionInclude": {
@@ -261,6 +265,8 @@
       },
       "markdownIngestionDebounceMs": {
         "type": "number",
+        "minimum": 0,
+        "maximum": 600000,
         "default": 150
       },
       "markdownIngestionSnapshotPath": {
@@ -281,10 +287,14 @@
       },
       "dreamPromotionDebounceMs": {
         "type": "number",
+        "minimum": 0,
+        "maximum": 600000,
         "default": 150
       },
       "lifecycleJournalMaxEntries": {
         "type": "number",
+        "minimum": 1,
+        "maximum": 100000,
         "default": 500
       },
       "compactionQualityWeight": {
@@ -314,17 +324,25 @@
       },
       "compactSessionTokenBudget": {
         "type": "number",
+        "minimum": 0,
+        "maximum": 1000000,
         "default": 2000,
         "description": "Auto-trigger compaction when the session accumulates this many tokens since the last compaction. Set to 0 to disable auto-compaction."
       },
       "continuityMinTurns": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1000
       },
       "continuityTailBudgetTokens": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1000000
       },
       "continuityPriorContextTokens": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1000000
       },
       "recoveryFloorScore": {
         "type": "number"
@@ -343,10 +361,14 @@
       },
       "rpcTimeoutMs": {
         "type": "number",
+        "minimum": 1,
+        "maximum": 600000,
         "default": 30000
       },
       "maxRetries": {
-        "type": "number"
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
       },
       "logLevel": {
         "type": "string"

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -53,7 +53,45 @@ test("manifest schema includes runtime-consumed context tuning keys", async () =
   ];
 
   for (const key of tuningKeys) {
-    assert.equal(properties[key]?.type, "number", `${key} must be accepted by configSchema`);
+    assert.ok(
+      properties[key]?.type === "number" || properties[key]?.type === "integer",
+      `${key} must be accepted by configSchema as numeric`,
+    );
+  }
+});
+
+test("manifest schema bounds operational numeric config", async () => {
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "openclaw.plugin.json"), "utf8"));
+  const properties = manifest.configSchema.properties as Record<string, {
+    type?: string;
+    minimum?: number;
+    maximum?: number;
+  }>;
+  const boundedKeys = [
+    "sessionTTL",
+    "markdownIngestionObsidianDebounceMs",
+    "markdownIngestionDebounceMs",
+    "dreamPromotionDebounceMs",
+    "lifecycleJournalMaxEntries",
+    "compactSessionTokenBudget",
+    "continuityMinTurns",
+    "continuityTailBudgetTokens",
+    "continuityPriorContextTokens",
+    "rpcTimeoutMs",
+    "maxRetries",
+  ];
+
+  for (const key of boundedKeys) {
+    const property = properties[key];
+    assert.equal(property?.type, "number", `${key} must be numeric`);
+    assert.equal(typeof property.minimum, "number", `${key} must have a minimum`);
+    assert.equal(typeof property.maximum, "number", `${key} must have a maximum`);
+    const minimum = property.minimum;
+    const maximum = property.maximum;
+    assert.ok(
+      typeof minimum === "number" && typeof maximum === "number" && maximum >= minimum,
+      `${key} maximum must be >= minimum`,
+    );
   }
 });
 


### PR DESCRIPTION
P2: Operational numeric config lacks basic bounds. openclaw.plugin.json:195-348 leaves operational numbers without obvious minimum or integer constraints: sessionTTL, debounce values, rpcTimeoutMs, maxRetries, lifecycleJournalMaxEntries, and token/continuity budgets. Bad values here can produce invalid timers, negative retry limits, disabled or excessive retention, or memory pressure. This intentionally excludes mathematically interpreted knobs like topK, scoring weights, and recovery thresholds unless a concrete bad code path is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration parameters now enforce minimum and maximum value bounds for improved validation
  * Several settings receive new default values for baseline configuration
  * RPC and debounce settings constrained with numeric limits

* **Tests**
  * Enhanced validation tests for configuration schema constraints and bounds verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/189)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->