### PR TITLE
Malformed RPC response frames create ambiguous mutating-call outcomes.

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -192,8 +192,8 @@ export class RpcClient {
     try {
       const msg = RpcResponse.fromBinary(payload as Uint8Array);
 
-      if (typeof msg.id !== "bigint") {
-        this.socket.destroy(new Error("Protocol violation: expected bigint message id"));
+      if (typeof msg.id !== "bigint" || msg.id <= 0n) {
+        this.socket.destroy(new Error("Protocol violation: expected positive bigint message id"));
         return false;
       }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -174,7 +174,9 @@ export class RpcClient {
       const payload = this.rxBuf.subarray(4, frameSize);
       this.rxBuf = this.rxBuf.subarray(frameSize);
 
-      this.dispatchMessage(payload);
+      if (!this.dispatchMessage(payload)) {
+        return;
+      }
     }
 
     // Compaction guard: release large backing allocations if the remainder is tiny
@@ -186,18 +188,18 @@ export class RpcClient {
     }
   }
 
-  private dispatchMessage(payload: Buffer): void {
+  private dispatchMessage(payload: Buffer): boolean {
     try {
       const msg = RpcResponse.fromBinary(payload as Uint8Array);
 
       if (typeof msg.id !== "bigint") {
         this.socket.destroy(new Error("Protocol violation: expected bigint message id"));
-        return;
+        return false;
       }
 
       const pending = this.pending.get(msg.id);
       if (!pending) {
-        return;
+        return true;
       }
 
       clearTimeout(pending.timer);
@@ -206,7 +208,7 @@ export class RpcClient {
       if (msg.error) {
         const message = msg.error.message?.trim() || `RPC error ${msg.error.code}`;
         pending.reject(new Error(msg.error.code ? `${message} (${msg.error.code})` : message));
-        return;
+        return true;
       }
 
       try {
@@ -214,8 +216,11 @@ export class RpcClient {
       } catch (error) {
         pending.reject(error instanceof Error ? error : new Error(String(error)));
       }
-    } catch {
-      // Ignore malformed frames
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.socket.destroy(new Error(`Protocol violation: malformed RPC response frame: ${message}`));
+      return false;
     }
   }
 

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -66,7 +66,10 @@ class FakeSocket implements SidecarSocket {
     this.writes.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
 
-  destroy(): void {
+  destroy(error?: Error): void {
+    if (error) {
+      this.emitError(error);
+    }
     for (const handler of this.closeHandlers) {
       handler();
     }
@@ -416,6 +419,16 @@ test("RpcClient rejects pending calls on runtime socket error", async () => {
   socket.emitError(new Error("ECONNRESET"));
 
   await assert.rejects(pending, /ECONNRESET/);
+});
+
+test("RpcClient rejects pending calls on malformed response frames", async () => {
+  const socket = new FakeSocket();
+  const client = new RpcClient(socket, { timeoutMs: 100 });
+
+  const pending = client.call("health", {});
+  socket.emitData(frameServerPayload(Buffer.from([0xff])));
+
+  await assert.rejects(pending, /Protocol violation: malformed RPC response frame/);
 });
 
 test("RpcClient supports per-call timeout overrides", async () => {

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -431,6 +431,16 @@ test("RpcClient rejects pending calls on malformed response frames", async () =>
   await assert.rejects(pending, /Protocol violation: malformed RPC response frame/);
 });
 
+test("RpcClient rejects pending calls on default response frames with id zero", async () => {
+  const socket = new FakeSocket();
+  const client = new RpcClient(socket, { timeoutMs: 100 });
+
+  const pending = client.call("health", {});
+  socket.emitData(frameServerPayload(new (RpcResponse as any)().toBinary()));
+
+  await assert.rejects(pending, /Protocol violation: expected positive bigint message id/);
+});
+
 test("RpcClient supports per-call timeout overrides", async () => {
   const socket = new FakeSocket();
   const client = new RpcClient(socket, { timeoutMs: 100 });


### PR DESCRIPTION
Malformed RPC response frames create ambiguous mutating-call outcomes. src/rpc.ts:189-219 catches protobuf decode errors and waits for the pending call to time out. For writes such as ingest, the daemon may have committed the request before emitting a malformed response, so the client reports a timeout with unknown commit status. Retrying can duplicate work unless the daemon layer is perfectly idempotent. The client should fail fast with a protocol error by rejecting pending calls or closing the socket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RPC client now treats malformed or unsupported response frames as protocol violations, closing the connection with a clear error instead of ignoring them.
  * Connections are terminated on invalid response shapes (e.g., bad message IDs), improving detection and debugging of communication errors.

* **Tests**
  * Added/updated tests to verify protocol-violation handling and socket error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/190)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->