### PR TITLE
fix: create identity file with owner-only permissions

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -96,7 +96,7 @@ function writeIdentityFile(path: string, userId: string, parts: DerivedParts): v
   mkdirSync(dir, { recursive: true });
 
   const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-  writeFileSync(tmp, JSON.stringify(identity, null, 2) + "\n");
+  writeFileSync(tmp, JSON.stringify(identity, null, 2) + "\n", { mode: 0o600 });
   renameSync(tmp, path);
 }
 

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1060,6 +1060,20 @@ test("resolveIdentity with noAutoPersist skips writing identity file", () => {
   }
 });
 
+test("resolveIdentity creates identity file with owner-only permissions", () => {
+  const tmpDir = `/tmp/libravdb-test-identity-perms-${process.pid}`;
+  const identityPath = `${tmpDir}/libravdb-identity.json`;
+  try {
+    resolveIdentity({ identityPath });
+    assert.ok(fs.existsSync(identityPath), "identity file should exist");
+    const stat = fs.statSync(identityPath);
+    const mode = stat.mode & 0o777;
+    assert.equal(mode & 0o077, 0, `identity file should not be group/world readable, got ${mode.toString(8)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("context engine exact recall escapes control characters inside injected memory facts", async () => {
   const rpc = new FakeRpc();
   const marker = "CONTROL_CHAR_MEMORY_MARKER_1234567890";


### PR DESCRIPTION
## Summary

Creates the auto-derived identity file with owner-only permissions instead of relying on process defaults/umask.

## Scope

- Passes `{ mode: 0o600 }` when writing the temporary identity file.
- Relies on `renameSync` preserving the temporary file mode for the final path.
- Adds a test that checks group/world read bits are absent.

## Audit Notes

- This matters mainly on shared systems or permissive parent directories.
- On typical single-user installs with private config directories, impact is low but the explicit mode is still better hygiene.

## Review Follow-up

- This PR fixes newly-created identity files only. Existing permissive identity files are not chmodded by this patch.
- If maintainers want upgrade-time repair, add a separate migration/startup chmod path or document a manual `chmod 600` step.
- Windows permission semantics should be skipped or handled separately in tests.

## Verification

```bash
npx tsx --test test/unit/context-engine.test.ts
```

Refs #193.

– Vale