### PR TITLE
fix: fail fast when sidecar is degraded

### DIFF
--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -105,7 +105,11 @@ export function createPluginRuntime(
 
   return {
     async getRpc() {
-      return (await ensureStarted()).rpc;
+      const active = await ensureStarted();
+      if (active.sidecar.isDegraded()) {
+        throw new Error("LibraVDB sidecar is in degraded mode — RPC unavailable");
+      }
+      return active.rpc;
     },
     async getKernel() {
       return (await ensureStarted()).kernel;
@@ -113,6 +117,10 @@ export function createPluginRuntime(
     async emitLifecycleHint(hint: LifecycleHint) {
       try {
         const active = await ensureStarted();
+        if (active.sidecar.isDegraded()) {
+          logger.warn?.("LibraVDB lifecycle hint dropped: sidecar in degraded mode");
+          return;
+        }
         await active.rpc.call("session_lifecycle_hint", hint);
       } catch (error) {
         logger.warn?.(`LibraVDB lifecycle hint dropped: ${formatError(error)}`);


### PR DESCRIPTION
## Summary

Makes plugin runtime paths fail fast once the sidecar supervisor has entered degraded mode.

## Scope

- `getRpc()` checks `active.sidecar.isDegraded()` before handing out an RPC client.
- `emitLifecycleHint()` drops lifecycle hints with a warning when the sidecar is degraded.
- Avoids waiting for the normal RPC timeout when reconnect is no longer expected.

## Audit Notes

- The behavior is correct in principle, but this PR is under-tested.
- Before merge, add a targeted degraded-sidecar test. Existing mocks do not exercise the degraded path.
- Consider whether memory search/ingest callers should receive a specific error type in a follow-up.

## Review Follow-up

- Add a targeted degraded-sidecar test before merge; the current build-only verification does not exercise the new guard.
- Review whether `getKernel()` should also check degraded sidecar state. If direct gRPC kernel mode is independent of sidecar health, document that explicitly.
- Lifecycle hints being dropped with a warning is acceptable because they are advisory.

## Verification

- `pnpm run build`
- Missing: targeted degraded-mode unit test.

Refs #196.

– Vale