### PR TITLE
fix: log secret file read errors and expand ~ in diary paths

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -485,22 +485,28 @@ function normalizeSectionName(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-function normalizeDiaryPath(value?: string): string {
+export function normalizeDiaryPath(value?: string): string {
   const trimmed = value?.trim();
   if (!trimmed) {
     return "";
   }
 
+  // Expand ~ to home directory before resolving. path.resolve does not
+  // expand tilde, so "~/dreams.md" would resolve to "<cwd>/~/dreams.md".
+  const expanded = trimmed.startsWith("~")
+    ? path.join(os.homedir(), trimmed.slice(1))
+    : trimmed;
+
   // Reject traversal components — even though path.resolve collapses them,
   // their presence signals an attempt to escape intended boundaries.
-  const segments = trimmed.split(/[/\\]+/);
+  const segments = expanded.split(/[/\\]+/);
   if (segments.some((s) => s === "..")) {
     throw new Error(
       `dream diary path must not contain ".." traversal: ${trimmed}`,
     );
   }
 
-  const resolved = path.resolve(trimmed);
+  const resolved = path.resolve(expanded);
 
   // Restrict to known-safe locations to prevent arbitrary file reads.
   // Allowed roots: home directory and the configured OpenClaw state dir.

--- a/src/libravdb-client.ts
+++ b/src/libravdb-client.ts
@@ -5,6 +5,8 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { LibravDB } from "@xdarkicex/libravdb-contracts/client";
 import { createHmac } from "node:crypto";
 import fs from "node:fs";
+import type { LoggerLike } from "./types.js";
+import { formatError } from "./format-error.js";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -438,14 +440,15 @@ function extractHost(target: string): string {
   return sep > 0 ? withoutDns.slice(0, sep) : withoutDns;
 }
 
-export function loadSecretFromEnv(): string | undefined {
+export function loadSecretFromEnv(logger?: LoggerLike): string | undefined {
   const secret = process.env.LIBRAVDB_AUTH_SECRET?.trim();
   if (secret) return secret;
   const secretPath = process.env.LIBRAVDB_AUTH_SECRET_FILE;
   if (secretPath) {
     try {
       return fs.readFileSync(secretPath, "utf8").trim() || undefined;
-    } catch {
+    } catch (error) {
+      logger?.warn?.(`LibraVDB: failed to read auth secret file "${secretPath}": ${formatError(error)}`);
       return undefined;
     }
   }

--- a/test/unit/dream-promotion.test.ts
+++ b/test/unit/dream-promotion.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { createDreamPromotionHandle, parseDreamPromotionCandidates, promoteDreamDiaryFile } from "../../src/dream-promotion.js";
+import { createDreamPromotionHandle, normalizeDiaryPath, parseDreamPromotionCandidates, promoteDreamDiaryFile } from "../../src/dream-promotion.js";
 
 test("dream promotion parser only accepts explicit deep-sleep candidate bullets", () => {
   const candidates = parseDreamPromotionCandidates(
@@ -167,4 +167,30 @@ test("dream promotion accepts explicit diary files under an allowed root", async
     }
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
+});
+
+test("normalizeDiaryPath expands ~ to home directory", () => {
+  const result = normalizeDiaryPath("~/dreams.md");
+  assert.ok(!result.includes("/~/"), `path should not contain literal "~" directory: ${result}`);
+  assert.ok(result.includes("/dreams.md"), `path should end with /dreams.md: ${result}`);
+});
+
+test("normalizeDiaryPath expands ~subpath correctly", () => {
+  const result = normalizeDiaryPath("~/sub/path.md");
+  assert.ok(!result.includes("/~/"), `path should not contain literal "~" directory: ${result}`);
+  assert.ok(result.endsWith("/sub/path.md"), `path should preserve subpath: ${result}`);
+});
+
+test("normalizeDiaryPath rejects .. traversal", () => {
+  assert.throws(
+    () => normalizeDiaryPath("/tmp/../etc/passwd"),
+    /traversal/,
+  );
+});
+
+test("normalizeDiaryPath rejects paths outside allowed roots", () => {
+  assert.throws(
+    () => normalizeDiaryPath("/tmp/diary.md"),
+    /allowed root/,
+  );
 });

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -9,6 +9,7 @@ import {
   createAuthInterceptor,
   LibravDBClient,
   loadSecretFromEnv,
+  loadSecretFromEnv,
 } from "../../src/libravdb-client.js";
 
 import type { AuthInterceptorState } from "../../src/libravdb-client.js";
@@ -261,4 +262,33 @@ test("no auth headers without secret", async () => {
   }))({ method: { name: "Status" }, header } as any);
 
   assert.equal(sent.has("x-libravdb-auth"), false);
+});
+
+test("loadSecretFromEnv returns undefined when no env vars are set", () => {
+  const result = loadSecretFromEnv();
+  assert.equal(result, undefined);
+});
+
+test("loadSecretFromEnv returns secret from LIBRAVDB_AUTH_SECRET", () => {
+  process.env.LIBRAVDB_AUTH_SECRET = "test-secret-123";
+  try {
+    const result = loadSecretFromEnv();
+    assert.equal(result, "test-secret-123");
+  } finally {
+    delete process.env.LIBRAVDB_AUTH_SECRET;
+  }
+});
+
+test("loadSecretFromEnv warns and returns undefined for unreadable file", () => {
+  const warnings: string[] = [];
+  const logger = { error: () => {}, warn: (msg: string) => warnings.push(msg), info: () => {}, debug: () => {} };
+  process.env.LIBRAVDB_AUTH_SECRET_FILE = "/nonexistent/path/secret";
+  try {
+    const result = loadSecretFromEnv(logger);
+    assert.equal(result, undefined);
+    assert.ok(warnings.length > 0, "should have logged at least one warning");
+    assert.match(warnings[0], /failed to read auth secret file/);
+  } finally {
+    delete process.env.LIBRAVDB_AUTH_SECRET_FILE;
+  }
 });


### PR DESCRIPTION
## Summary

Fixes two small config/path handling failures that produce confusing runtime behavior.

## Scope

- `loadSecretFromEnv()` now warns when `LIBRAVDB_AUTH_SECRET_FILE` cannot be read instead of silently treating auth as unset.
- `normalizeDiaryPath()` expands `~/...` before resolving and applying allowed-root checks.

## Audit Notes

- Both changes are operator-facing diagnostics/ergonomics fixes.
- This is not an auth bypass; unreadable secret files still fail closed by leaving auth unavailable.
- The two changes are independent but small enough to review together.

## Review Follow-up

- Earlier review comments mention #219 / whitespace-only `LIBRAVDB_AUTH_SECRET`. That issue is not fixed by this PR and should remain separate.
- This branch also touches `src/plugin-runtime.ts`, so it should be rebased carefully around #199 if that lifecycle fix lands first.

## Verification

```bash
pnpm run build
npx tsx --test test/unit/plugin-runtime.test.ts
npx tsx --test test/unit/dream-promotion.test.ts
```

Fixes #201.
Fixes #204.

– Vale