### PR TITLE
docs: fix stale comment describing chunk ingest replace/append order

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -88,7 +88,8 @@ export class IngestQueue {
     }
 
     // Multiple chunks: clear the source once, then append the remaining chunks.
-    // Sending REPLACE last deletes the earlier chunks from the same source_doc.
+    // The first chunk uses REPLACE to clear any existing data for this source_doc,
+    // subsequent chunks use APPEND to add to it.
     for (let i = 0; i < chunks.length; i++) {
       const isFirst = i === 0;
       const chunkParams: IngestMarkdownDocumentParams = {


### PR DESCRIPTION
## Summary

Updates a stale code comment in `src/ingest-queue.ts` that still described the old #106 behavior.

## Scope

- Comment-only change.
- Describes current chunk ingest ordering: first chunk uses `REPLACE`, later chunks use `APPEND`.
- No runtime behavior changes.

## Audit Notes

- This is intentionally small and safe.
- Keeping the comment accurate matters because this area previously had a real data-loss bug.

## Verification

- Not run; comment-only change.
- Reviewer should confirm the comment matches the current `mode` selection logic.

Refs #106.

– Vale