### PR TITLE
chore: close over-bundled runtime cleanup batch

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2,6 +2,7 @@ import type { PluginRuntime } from "./plugin-runtime.js";
 import type {
   LoggerLike,
   PluginConfig,
+  PredictedContext,
   SearchResult,
 } from "./types.js";
 import {
@@ -575,12 +576,35 @@ export function normalizeAssembleResult(result: {
   };
 }
 
+function isPredictedContext(value: unknown): value is PredictedContext {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as { id?: unknown; text?: unknown; reason?: unknown };
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.text === "string" &&
+    typeof candidate.reason === "string"
+  );
+}
+
+function extractPredictedContexts(result: unknown): PredictedContext[] {
+  if (typeof result !== "object" || result === null) {
+    return [];
+  }
+  const predictions = (result as { predictions?: unknown }).predictions;
+  if (!Array.isArray(predictions)) {
+    return [];
+  }
+  return predictions.filter(isPredictedContext);
+}
+
 export function buildContextEngineFactory(
   runtime: PluginRuntime,
   cfg: PluginConfig,
   logger: LoggerLike = console,
 ) {
-  const predictiveContextCache = new Map<string, import("./types.js").PredictedContext[]>();
+  const predictiveContextCache = new Map<string, PredictedContext[]>();
   let cachedIdentity: ResolvedIdentity | null = null;
   let cachedSessionKey: string | undefined;
 
@@ -744,6 +768,42 @@ export function buildContextEngineFactory(
       ),
       estimatedTokens: assembled.estimatedTokens + additionTokens,
     };
+  }
+
+  function appendPredictiveContext(
+    assembled: OpenClawCompatibleAssembleResult,
+    sessionId: string,
+  ): OpenClawCompatibleAssembleResult {
+    const predictions = predictiveContextCache.get(sessionId) ?? [];
+    predictiveContextCache.delete(sessionId);
+    if (predictions.length === 0) {
+      return assembled;
+    }
+
+    const injection = [
+      "<predictive_context>",
+      ...predictions.map((prediction) => prediction.text),
+      "</predictive_context>",
+    ].join("\n");
+    return {
+      ...assembled,
+      systemPromptAddition: appendSystemPromptAddition(assembled.systemPromptAddition, injection),
+      estimatedTokens: assembled.estimatedTokens + approximateTokenCount(injection),
+    };
+  }
+
+  async function finalizeAssembleResult(
+    assembled: OpenClawCompatibleAssembleResult,
+    args: {
+      queryText: string;
+      userId: string;
+      sessionId: string;
+      tokenBudget: number;
+    },
+  ): Promise<OpenClawCompatibleAssembleResult> {
+    const withExactRecall = await augmentWithExactRecall(assembled, args);
+    const withPredictiveContext = appendPredictiveContext(withExactRecall, args.sessionId);
+    return enforceTokenBudgetInvariant(withPredictiveContext, args.tokenBudget);
   }
 
   function buildCompactSessionRequest(args: {
@@ -1031,15 +1091,12 @@ export function buildContextEngineFactory(
             config: buildAssemblyConfig(args.tokenBudget),
             emitDebug: true,
           }));
-          return enforceTokenBudgetInvariant(
-            await augmentWithExactRecall(assembled, {
-              queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
-              userId,
-              sessionId,
-              tokenBudget: args.tokenBudget,
-            }),
-            args.tokenBudget,
-          );
+          return await finalizeAssembleResult(assembled, {
+            queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
+            userId,
+            sessionId,
+            tokenBudget: args.tokenBudget,
+          });
         } catch (error) {
           logger.warn?.(
             `LibraVDB assemble kernel failed, using budget-clamped fallback context: ${error instanceof Error ? error.message : String(error)
@@ -1062,22 +1119,12 @@ export function buildContextEngineFactory(
           config: buildAssemblyConfig(args.tokenBudget),
         });
         const assembled = normalizeAssembleResult(resp);
-        const enforced = enforceTokenBudgetInvariant(
-          await augmentWithExactRecall(assembled, {
-            queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
-            userId,
-            sessionId,
-            tokenBudget: args.tokenBudget,
-          }),
-          args.tokenBudget,
-        );
-        const predictions = predictiveContextCache.get(sessionId) || [];
-        predictiveContextCache.delete(sessionId);
-        if (predictions.length > 0) {
-          const injection = ["<predictive_context>", ...predictions.map((p) => p.text), "</predictive_context>"].join("\n");
-          enforced.systemPromptAddition = appendSystemPromptAddition(enforced.systemPromptAddition, injection);
-        }
-        return enforced;
+        return await finalizeAssembleResult(assembled, {
+          queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
+          userId,
+          sessionId,
+          tokenBudget: args.tokenBudget,
+        });
       } catch (error) {
         logger.warn?.(
           `LibraVDB assemble sidecar failed, using budget-clamped fallback context: ${error instanceof Error ? error.message : String(error)
@@ -1140,8 +1187,8 @@ export function buildContextEngineFactory(
             tokenBudget: args.tokenBudget,
             currentTokenCount,
           });
-          const predictions = (result as any).predictions;
-          if (Array.isArray(predictions) && predictions.length > 0) {
+          const predictions = extractPredictedContexts(result);
+          if (predictions.length > 0) {
             predictiveContextCache.set(sessionId, predictions);
           }
           return result;
@@ -1160,8 +1207,8 @@ export function buildContextEngineFactory(
           tokenBudget: args.tokenBudget,
           currentTokenCount,
         });
-        const predictions = (result as any).predictions;
-        if (Array.isArray(predictions) && predictions.length > 0) {
+        const predictions = extractPredictedContexts(result);
+        if (predictions.length > 0) {
           predictiveContextCache.set(sessionId, predictions);
         }
         return result;

--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -114,6 +114,7 @@ export function createDreamPromotionHandle(
     watcher: null,
   };
   let lastFileState: DreamFileState | null = null;
+  const activeScans = new Set<Promise<void>>();
   const debounceMs = cfg.dreamPromotionDebounceMs ?? DEFAULT_DEBOUNCE_MS;
 
   return {
@@ -139,6 +140,9 @@ export function createDreamPromotionHandle(
         state.watcher.close();
         state.watcher = null;
       }
+      if (activeScans.size > 0) {
+        await Promise.allSettled([...activeScans]);
+      }
     },
   };
 
@@ -152,10 +156,20 @@ export function createDreamPromotionHandle(
     }
     state.timer = setTimeout(() => {
       state.timer = null;
-      void scanDiary().catch((error) => {
-        logger.warn?.(`[dream-promotion] refresh failed for ${diaryPath}: ${formatError(error)}`);
-      });
+      trackScan(scanDiary());
     }, debounceMs);
+    state.timer.unref?.();
+  }
+
+  function trackScan(scan: Promise<void>): void {
+    activeScans.add(scan);
+    void scan
+      .catch((error) => {
+        logger.warn?.(`[dream-promotion] refresh failed for ${diaryPath}: ${formatError(error)}`);
+      })
+      .finally(() => {
+        activeScans.delete(scan);
+      });
   }
 
   async function scanDiary(): Promise<void> {
@@ -163,8 +177,14 @@ export function createDreamPromotionHandle(
       return;
     }
     await ensureWatcher();
+    if (!state.watching) {
+      return;
+    }
 
     const stat = await safeStat(diaryPath);
+    if (!state.watching) {
+      return;
+    }
     if (!stat) {
       lastFileState = null;
       return;
@@ -175,6 +195,9 @@ export function createDreamPromotionHandle(
     }
 
     const bytes = await safeReadFile(diaryPath);
+    if (!state.watching) {
+      return;
+    }
     if (!bytes) {
       lastFileState = null;
       return;
@@ -192,6 +215,9 @@ export function createDreamPromotionHandle(
 
     const text = textDecoder.decode(bytes);
     const candidates = parseDreamPromotionCandidates(text);
+    if (!state.watching) {
+      return;
+    }
     if (candidates.length === 0) {
       lastFileState = {
         size: stat.size,
@@ -202,6 +228,9 @@ export function createDreamPromotionHandle(
     }
 
     const rpc = await getRpc();
+    if (!state.watching) {
+      return;
+    }
     const params: DreamPromotionParams = {
       userId,
       sourceDoc: diaryPath,
@@ -218,6 +247,9 @@ export function createDreamPromotionHandle(
         sourceLine: candidate.line,
       })),
     };
+    if (!state.watching) {
+      return;
+    }
     await rpc.call<DreamPromotionResult>("promote_dream_entries", params);
 
     lastFileState = {

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -8,7 +8,10 @@ import {
   mkdirSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
+import { validateNamespace } from "./memory-scopes.js";
 import type { LoggerLike } from "./types.js";
+
+const COLLECTION_SAFE_CHAR_RE = /[^a-zA-Z0-9_.:@#-]+/g;
 
 /**
  * Resolves the identity file path, respecting OpenClaw's state directory conventions.
@@ -76,8 +79,34 @@ function deriveIdentityParts(): DerivedParts {
   return { username, host, home, homeHash };
 }
 
+export function sanitizeAutoIdentityForNamespace(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(COLLECTION_SAFE_CHAR_RE, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const prefixed = /^[a-zA-Z]/.test(normalized) ? normalized : `u-${normalized}`;
+  const hash = createHash("sha256").update(value).digest("hex").slice(0, 16);
+  const candidate = prefixed.length <= 128
+    ? prefixed
+    : `${prefixed.slice(0, 111)}-${hash}`;
+  if (isCollectionNamespace(candidate)) {
+    return candidate;
+  }
+  return `u-${hash}`;
+}
+
+function isCollectionNamespace(value: string): boolean {
+  try {
+    validateNamespace(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function deriveAutoId(parts: DerivedParts): string {
-  return `${parts.username}@${parts.host}#${parts.homeHash}`;
+  return sanitizeAutoIdentityForNamespace(`${parts.username}@${parts.host}#${parts.homeHash}`);
 }
 
 function writeIdentityFile(path: string, userId: string, parts: DerivedParts): void {

--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -16,13 +16,6 @@ const DEFAULT_OPTIONS: IngestQueueOptions = {
   maxRetries: 4,
 };
 
-interface QueuedIngest {
-  sourceDoc: string;
-  params: IngestMarkdownDocumentParams;
-  resolve: () => void;
-  reject: (err: Error) => void;
-}
-
 interface IngestMarkdownDocumentParams {
   sourceDoc: string;
   text: string;
@@ -42,11 +35,9 @@ interface IngestMarkdownDocumentParams {
 }
 
 export class IngestQueue {
-  private readonly queue: QueuedIngest[] = [];
   private readonly rpcCall: <T>(method: string, params: unknown) => Promise<T>;
   private readonly logger: LoggerLike;
   private readonly options: IngestQueueOptions;
-  private running = false;
 
   constructor(
     rpcCall: <T>(method: string, params: unknown) => Promise<T>,

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -321,9 +321,11 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       const startedAt = Date.now();
       try {
         const currentFiles = new Set<string>();
-        await this.walkDirectory(rootState, rootState.root, currentFiles, stats);
+        const currentDirectories = new Set<string>();
+        await this.walkDirectory(rootState, rootState.root, currentFiles, currentDirectories, stats);
         if (!this.stopping) {
           await this.pruneDeletedFiles(rootState, currentFiles, stats);
+          this.pruneDirectoryWatchers(rootState, currentDirectories);
           rootState.knownFiles = currentFiles;
           await this.saveSnapshotIfDirty();
           this.logScanStats(rootState.root, stats, Date.now() - startedAt);
@@ -366,14 +368,19 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }, this.debounceMs);
   }
 
-  private async walkDirectory(rootState: RootState, dir: string, currentFiles: Set<string>, stats: ScanStats): Promise<void> {
+  private async walkDirectory(
+    rootState: RootState,
+    dir: string,
+    currentFiles: Set<string>,
+    currentDirectories: Set<string>,
+    stats: ScanStats,
+  ): Promise<void> {
     if (this.shouldPruneDirectory(rootState.root, dir)) {
       stats.directoriesPruned++;
       return;
     }
 
     stats.directoriesScanned++;
-    await this.ensureDirectoryWatcher(rootState, dir);
 
     let entries: FsDirentLike[];
     try {
@@ -381,10 +388,14 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     } catch (error) {
       const message = formatError(error);
       if (!message.includes("ENOENT")) {
+        currentDirectories.add(dir);
         this.logger.warn?.(`[markdown-ingest] readdir failed for ${dir}: ${message}`);
       }
       return;
     }
+
+    currentDirectories.add(dir);
+    await this.ensureDirectoryWatcher(rootState, dir);
 
     for (const entry of entries) {
       if (this.stopping) {
@@ -392,7 +403,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       const child = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await this.walkDirectory(rootState, child, currentFiles, stats);
+        await this.walkDirectory(rootState, child, currentFiles, currentDirectories, stats);
         continue;
       }
       if (!entry.isFile() || !isMarkdownFile(entry.name)) {
@@ -447,6 +458,16 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       rootState.directoryWatchers.set(dir, watcher);
     } catch (error) {
       this.logger.warn?.(`[markdown-ingest] watch unavailable for ${dir}: ${formatError(error)}`);
+    }
+  }
+
+  private pruneDirectoryWatchers(rootState: RootState, currentDirectories: Set<string>): void {
+    for (const [dir, watcher] of rootState.directoryWatchers.entries()) {
+      if (currentDirectories.has(dir)) {
+        continue;
+      }
+      watcher.close();
+      rootState.directoryWatchers.delete(dir);
     }
   }
 

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -8,6 +8,7 @@ import type { LoggerLike, PluginConfig, SidecarHandle, SidecarSocket } from "./t
 type CloseHandler = () => void;
 type DataHandler = (chunk: Buffer) => void;
 type ErrorHandler = (error: Error) => void;
+type RestartTimer = ReturnType<typeof setTimeout>;
 
 const STARTUP_CONNECT_MAX_RETRIES = 5;
 const STARTUP_CONNECT_BASE_DELAY_MS = 100;
@@ -17,7 +18,7 @@ const CONNECTION_STABILITY_WINDOW_MS = 15_000;
 export interface SidecarRuntime {
   resolveEndpoint(cfg: PluginConfig): string | Promise<string>;
   createSocket(endpoint: string): SidecarSocket;
-  scheduleRestart(delayMs: number, restart: () => void): void;
+  scheduleRestart(delayMs: number, restart: () => void): RestartTimer | void;
   stabilityWindowMs?: number;
 }
 
@@ -235,6 +236,7 @@ class SidecarSupervisor implements SidecarHandle {
   private shuttingDown = false;
   private reconnectScheduled = false;
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: RestartTimer | null = null;
   public socket: SidecarSocket;
 
   constructor(
@@ -249,6 +251,7 @@ class SidecarSupervisor implements SidecarHandle {
     const endpoint = await this.runtime.resolveEndpoint(this.cfg);
     const socket = await this.connectEndpointWithRetry(endpoint);
     this.reconnectScheduled = false;
+    this.clearReconnectTimer();
     this.scheduleStabilityReset();
     if (this.socket instanceof SupervisorSocket) {
       this.socket.bind(socket);
@@ -265,6 +268,7 @@ class SidecarSupervisor implements SidecarHandle {
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
     this.clearStabilityTimer();
+    this.clearReconnectTimer();
     this.socket.destroy();
   }
 
@@ -287,6 +291,13 @@ class SidecarSupervisor implements SidecarHandle {
     if (this.stabilityTimer) {
       clearTimeout(this.stabilityTimer);
       this.stabilityTimer = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
     }
   }
 
@@ -358,7 +369,8 @@ class SidecarSupervisor implements SidecarHandle {
     const backoffMs = computeBackoffMs(this.retries);
     this.retries += 1;
     this.reconnectScheduled = true;
-    this.runtime.scheduleRestart(backoffMs, () => {
+    this.reconnectTimer = this.runtime.scheduleRestart(backoffMs, () => {
+      this.reconnectTimer = null;
       if (this.shuttingDown) {
         this.reconnectScheduled = false;
         return;
@@ -369,7 +381,8 @@ class SidecarSupervisor implements SidecarHandle {
         this.logger.error(`[libravdb] sidecar reconnect failed: ${message}`);
         void this.handleExit(1);
       });
-    });
+    }) ?? null;
+    this.reconnectTimer?.unref?.();
   }
 }
 
@@ -575,7 +588,9 @@ function createDefaultRuntime(): SidecarRuntime {
       return net.connect(endpoint) as unknown as SidecarSocket;
     },
     scheduleRestart(delayMs, restart) {
-      setTimeout(restart, delayMs);
+      const timer = setTimeout(restart, delayMs);
+      timer.unref?.();
+      return timer;
     },
   };
 }

--- a/test/integration/dream-promotion.test.ts
+++ b/test/integration/dream-promotion.test.ts
@@ -138,3 +138,83 @@ test("dream promotion handle reads diary bullets and forwards them to the sideca
     await fsp.rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("dream promotion stop waits for an in-flight scan and skips promotion after stop", async () => {
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-dream-stop-"));
+  let handle: ReturnType<typeof createDreamPromotionHandle> | null = null;
+  let readStarted!: () => void;
+  const readStartedPromise = new Promise<void>((resolve) => {
+    readStarted = resolve;
+  });
+  let releaseRead!: () => void;
+  let readReleased = false;
+  const releaseReadPromise = new Promise<void>((resolve) => {
+    releaseRead = () => {
+      readReleased = true;
+      resolve();
+    };
+  });
+  class SlowFsApi extends FakeFsApi {
+    async readFile(file: string) {
+      readStarted();
+      await releaseReadPromise;
+      return await super.readFile(file);
+    }
+  }
+  process.env.OPENCLAW_STATE_DIR = tempRoot;
+
+  try {
+    const diaryPath = path.join(tempRoot, "DREAMS.md");
+    await fsp.writeFile(
+      diaryPath,
+      [
+        "# DREAMS",
+        "",
+        "## Deep Sleep",
+        "- Preserve the recent tail buffer {score=0.82 recall=3 unique=2}",
+      ].join("\n"),
+    );
+
+    const rpc = new FakeRpcClient();
+    const fsApi = new SlowFsApi();
+    handle = createDreamPromotionHandle(
+      {
+        dreamPromotionEnabled: true,
+        dreamPromotionDiaryPath: diaryPath,
+        dreamPromotionUserId: "u1",
+        dreamPromotionDebounceMs: 0,
+      },
+      async () => rpc,
+      console,
+      fsApi as never,
+    );
+
+    await handle.start();
+    await readStartedPromise;
+
+    let stopResolved = false;
+    const stopPromise = handle.stop().then(() => {
+      stopResolved = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(stopResolved, false, "stop must wait for the in-flight scan");
+
+    releaseRead();
+    await stopPromise;
+
+    assert.equal(stopResolved, true);
+    assert.equal(rpc.calls.length, 0);
+  } finally {
+    if (!readReleased && releaseRead) {
+      releaseRead();
+    }
+    await handle?.stop();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -529,6 +529,41 @@ test("markdown ingestion prunes excluded directories before recursion", async ()
   await handle.stop();
 });
 
+test("markdown ingestion closes watchers for deleted directories", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-watch-prune-"));
+  const nestedDir = path.join(tempRoot, "notes", "daily");
+  const filePath = path.join(nestedDir, "today.md");
+  await fsp.mkdir(nestedDir, { recursive: true });
+  await fsp.writeFile(filePath, "# Today\n\nThis should ingest before the directory is deleted.");
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+      markdownIngestionSnapshotPath: path.join(tempRoot, "snapshot.json"),
+    },
+    async () => rpc,
+    { error() {}, warn() {}, info() {} },
+    fsApi as never,
+  );
+
+  await handle.start();
+  assert.equal(fsApi.callbacks.has(nestedDir), true);
+
+  await fsp.rm(path.join(tempRoot, "notes"), { recursive: true, force: true });
+  fsApi.callbacks.get(tempRoot)?.[0]?.("rename", "notes");
+  await delay(25);
+
+  assert.equal(fsApi.callbacks.has(tempRoot), true);
+  assert.equal(fsApi.callbacks.has(nestedDir), false);
+  assert.equal(rpc.calls.filter((call) => call.method === "delete_authored_document").length, 1);
+
+  await handle.stop();
+});
+
 test("markdown ingestion persists snapshots across adapter restarts", async () => {
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-snapshot-"));
   const filePath = path.join(tempRoot, "guide.md");

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { buildContextEngineFactory } from "../../src/context-engine.js";
 import fs from "node:fs";
-import { resolveIdentity } from "../../src/identity.js";
+import { resolveIdentity, sanitizeAutoIdentityForNamespace } from "../../src/identity.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
 import type { RpcClient } from "../../src/rpc.js";
@@ -333,6 +333,50 @@ test("context engine uses gRPC kernel on cold assemble without falling back to R
   assert.equal(params.sessionKey, "sk1");
   assert.equal(params.userId, "fixed-user");
   assert.deepEqual(assembled.messages, [{ role: "assistant", content: "kernel context" }]);
+});
+
+test("context engine drains predictive context on the gRPC assemble path", async () => {
+  const kernel = {
+    afterTurn: async () => ({
+      ok: true,
+      turnCount: 1,
+      predictions: [
+        { id: "p1", text: "Predicted follow-up context", reason: "likely-next-query" },
+      ],
+    }),
+    assembleContext: async () => ({
+      messages: [{ role: "assistant", content: "kernel context" }],
+      estimatedTokens: 12,
+      systemPromptAddition: "base prompt",
+    }),
+  };
+  const { runtime, getRpcCalls } = makeKernelFirstRuntime(kernel);
+  const engine = buildContextEngineFactory(runtime, { userId: "fixed-user" });
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "hello"), makeMessage("assistant", "hi")],
+  });
+  const firstAssemble = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "hello")],
+    prompt: "hello",
+    tokenBudget: 4000,
+  });
+  const secondAssemble = await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "hello again")],
+    prompt: "hello again",
+    tokenBudget: 4000,
+  });
+
+  assert.equal(getRpcCalls(), 0);
+  assert.match(firstAssemble.systemPromptAddition, /<predictive_context>/);
+  assert.match(firstAssemble.systemPromptAddition, /Predicted follow-up context/);
+  assert.doesNotMatch(secondAssemble.systemPromptAddition, /<predictive_context>/);
 });
 
 function makeMessage(role: string, content: string, id?: string) {
@@ -1024,6 +1068,18 @@ test("resolveIdentity returns config userId with whitespace trimming", () => {
   const result = resolveIdentity({ configUserId: "  padded-user  " });
   assert.equal(result.userId, "padded-user");
   assert.equal(result.source, "config");
+});
+
+test("auto-derived identities are sanitized for collection namespaces", () => {
+  const userId = sanitizeAutoIdentityForNamespace("123 bad/user@host name#abcdef12");
+  assert.match(userId, /^[a-zA-Z][a-zA-Z0-9_.:@#-]{0,127}$/);
+  assert.equal(userId.includes("/"), false);
+  assert.equal(userId.includes(" "), false);
+  assert.ok(userId.startsWith("u-123-bad-user@host-name#abcdef12"));
+
+  const longUserId = sanitizeAutoIdentityForNamespace(`user-${"x".repeat(200)}`);
+  assert.match(longUserId, /^[a-zA-Z][a-zA-Z0-9_.:@#-]{0,127}$/);
+  assert.ok(longUserId.length <= 128);
 });
 
 test("resolveIdentity auto-derives when only sessionKey is provided", () => {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -266,6 +266,10 @@ function flushAsyncWork(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 test("sidecar retry budget resets after stability window", async () => {
   const runtime = createManualRestartRuntime();
   runtime.runtime.stabilityWindowMs = 0;
@@ -288,6 +292,31 @@ test("sidecar retry budget resets after stability window", async () => {
 
   assert.equal(handle.isDegraded(), false);
   assert.equal(runtime.scheduled.length, 2);
+});
+
+test("sidecar shutdown cancels pending reconnect timers", async () => {
+  const runtime = createManualRestartRuntime();
+  let scheduled = 0;
+  let restartFired = false;
+  runtime.runtime.scheduleRestart = (_delayMs, restart) => {
+    scheduled += 1;
+    return setTimeout(() => {
+      restartFired = true;
+      restart();
+    }, 10);
+  };
+  const logger = { error() {}, info() {}, warn() {} };
+  const handle = await startSidecar({ rpcTimeoutMs: 50, maxRetries: 2 }, logger, runtime.runtime);
+
+  runtime.sockets[0]?.emitClose();
+  await flushAsyncWork();
+  assert.equal(scheduled, 1);
+
+  await handle.shutdown();
+  await delay(30);
+
+  assert.equal(restartFired, false);
+  assert.equal(runtime.sockets.length, 1);
 });
 
 test("crash before stability window preserves retry count and triggers degraded mode", async () => {


### PR DESCRIPTION
## Status

Closed because this PR is too bundled to review cleanly.

It mixes several unrelated runtime cleanups:

- predictive-context draining and typing guards;
- sidecar reconnect timer lifecycle;
- dream-promotion shutdown behavior;
- markdown watcher pruning;
- identity sanitization;
- ingest queue state cleanup.

Those may contain valid fixes, but as one PR this is audit-batch sludge. Any still-needed change should come back as a focused PR tied to one issue and one behavior gate.

– Vale