### PR TITLE
chore: close magic-number constant extraction cleanup

### DIFF
--- a/src/grpc-client.ts
+++ b/src/grpc-client.ts
@@ -9,6 +9,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // The proto file is expected to be copied to dist/proto/ at build time.
 // In source, it's at api/proto/.
+/** Default gRPC call timeout in milliseconds. */
+const DEFAULT_GRPC_TIMEOUT_MS = 30_000;
+
 const PROTO_PATH = path.resolve(__dirname, "./proto/intelligence_kernel/v1/kernel.proto");
 
 export interface GrpcClientOptions {
@@ -129,7 +132,7 @@ export class GrpcKernelClient {
 
   constructor(options: GrpcClientOptions) {
     this.secret = options.secret;
-    this.timeoutMs = options.timeoutMs ?? 30000;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_GRPC_TIMEOUT_MS;
 
     const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
       keepCase: true,

--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -10,8 +10,11 @@ export interface IngestQueueOptions {
   maxRetries: number;
 }
 
+/** Default max tokens per chunk. */
+const DEFAULT_CHUNK_TOKENS = 8192;
+
 const DEFAULT_OPTIONS: IngestQueueOptions = {
-  chunkTokens: 8192,
+  chunkTokens: DEFAULT_CHUNK_TOKENS,
   retryBaseDelayMs: 500,
   maxRetries: 4,
 };

--- a/src/markdown-hash.ts
+++ b/src/markdown-hash.ts
@@ -67,9 +67,9 @@ class WasmFnv64 implements HashBackend {
       return;
     }
 
-    const pageSize = 65536;
-    const requiredPages = Math.ceil(size / pageSize);
-    const currentPages = this.memory.buffer.byteLength / pageSize;
+    const WASM_PAGE_SIZE = 65536;
+    const requiredPages = Math.ceil(size / WASM_PAGE_SIZE);
+    const currentPages = this.memory.buffer.byteLength / WASM_PAGE_SIZE;
     const deltaPages = requiredPages - currentPages;
     if (deltaPages > 0) {
       this.memory.grow(deltaPages);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -9,6 +9,9 @@ interface PendingCall {
   decodeResult(bytes: Uint8Array): unknown;
 }
 
+/** Maximum receive buffer size before compaction (64 KiB). */
+const RX_MAX_BUFFER_SIZE = 65536;
+
 export class RpcClient {
   private seq = 0n;
   private readonly pending = new Map<bigint, PendingCall>();
@@ -179,7 +182,7 @@ export class RpcClient {
 
     // Compaction guard: release large backing allocations if the remainder is tiny
     if (
-      this.rxBuf.buffer.byteLength > 65536 &&
+      this.rxBuf.buffer.byteLength > RX_MAX_BUFFER_SIZE &&
       this.rxBuf.byteLength < this.rxBuf.buffer.byteLength >>> 2
     ) {
       this.rxBuf = Buffer.from(this.rxBuf);


### PR DESCRIPTION
## Status

Closed as not worth standalone upstream churn.

The change was purely readability-focused and did not fix behavior. If these lines are touched later for a functional reason, naming the literals can be done in that PR.

Closes #214 as not planned.

– Vale