### PR TITLE
chore: close standalone OPENCLAW_STATE_DIR refactor

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { getHashBackendName, hashBytes } from "./markdown-hash.js";
 import { formatError } from "./format-error.js";
+import { resolveStateDir } from "./state-dir.js";
 import type { LoggerLike, PluginConfig } from "./types.js";
 
 const DEFAULT_DEBOUNCE_MS = 150;
@@ -495,11 +496,11 @@ function normalizeDiaryPath(value?: string): string {
 
   // Restrict to known-safe locations to prevent arbitrary file reads.
   // Allowed roots: home directory and the configured OpenClaw state dir.
+  const stateDir = resolveStateDir();
   const allowedRoots = [
     os.homedir(),
-    process.env.OPENCLAW_STATE_DIR,
+    stateDir,
   ]
-    .filter((r): r is string => typeof r === "string" && r.trim().length > 0)
     .map((root) => path.resolve(root));
 
   const isAllowed = allowedRoots.some(

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,5 +1,6 @@
 import { userInfo, hostname } from "node:os";
 import { createHash } from "node:crypto";
+import { resolveStateDir } from "./state-dir.js";
 import {
   existsSync,
   readFileSync,
@@ -21,11 +22,8 @@ import type { LoggerLike } from "./types.js";
 function resolveIdentityPath(configuredPath?: string): string {
   if (configuredPath) return configuredPath;
 
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
-  if (stateDir) return join(stateDir, "libravdb-identity.json");
-
-  const home = userInfo().homedir;
-  return join(home, ".openclaw", "libravdb-identity.json");
+  const stateDir = resolveStateDir();
+  return join(stateDir, "libravdb-identity.json");
 }
 
 export type IdentitySource = "config" | "file" | "auto" | "session-key" | "default";

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -7,6 +7,7 @@ import type { LoggerLike, PluginConfig } from "./types.js";
 import { hashBytes } from "./markdown-hash.js";
 import { formatError } from "./format-error.js";
 import { IngestQueue } from "./ingest-queue.js";
+import { resolveStateDir } from "./state-dir.js";
 
 const DEFAULT_DEBOUNCE_MS = 150;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
@@ -733,7 +734,7 @@ function resolveMarkdownSnapshotPath(kind: string, configuredPath?: string): str
   if (trimmed) {
     return path.resolve(trimmed);
   }
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
+  const stateDir = resolveStateDir();
   return path.join(stateDir, `libravdb-markdown-ingest-${kind}.json`);
 }
 

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -1,0 +1,15 @@
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Resolve the OpenClaw state directory.
+ *
+ * Resolution order:
+ *   1. `OPENCLAW_STATE_DIR` env var (trimmed, must be non-empty)
+ *   2. `~/.openclaw` (default)
+ */
+export function resolveStateDir(): string {
+  const envVal = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (envVal) return envVal;
+  return path.join(os.homedir(), ".openclaw");
+}


### PR DESCRIPTION
## Status

Closed as not worth standalone upstream churn.

This mostly consolidates duplicated state-dir logic. The only behavior change is the whitespace-only `OPENCLAW_STATE_DIR` edge in dream promotion. That is too small to keep as an independent PR beside the real runtime fixes.

Closes #217 as not planned.

– Vale