### PR TITLE
chore: close hypothetical SidecarSocket off() cleanup

### DIFF
--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -59,7 +59,15 @@ class PlaceholderSocket implements SidecarSocket {
     this.errorOnce.add(handler as ErrorHandler);
   }
 
-  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+  off(event: "data" | "close" | "connect" | "error", handler: DataHandler | CloseHandler | ErrorHandler): void {
+    if (event === "data") {
+      this.onData.delete(handler as DataHandler);
+      return;
+    }
+    if (event === "close") {
+      this.onClose.delete(handler as CloseHandler);
+      return;
+    }
     if (event === "connect") {
       this.connectOnce.delete(handler as CloseHandler);
       return;
@@ -209,7 +217,15 @@ class SupervisorSocket implements SidecarSocket {
     this.errorOnce.add(handler as ErrorHandler);
   }
 
-  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+  off(event: "data" | "close" | "connect" | "error", handler: DataHandler | CloseHandler | ErrorHandler): void {
+    if (event === "data") {
+      this.onData.delete(handler as DataHandler);
+      return;
+    }
+    if (event === "close") {
+      this.onClose.delete(handler as CloseHandler);
+      return;
+    }
     if (event === "connect") {
       this.connectOnce.delete(handler as CloseHandler);
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,8 @@ export interface SidecarSocket {
   on(event: "error", handler: (error: Error) => void): void;
   once(event: "connect", handler: () => void): void;
   once(event: "error", handler: (error: Error) => void): void;
+  off(event: "data", handler: (chunk: Buffer) => void): void;
+  off(event: "close", handler: () => void): void;
   off(event: "connect", handler: () => void): void;
   off(event: "error", handler: (error: Error) => void): void;
   write(chunk: Buffer | string): void;

--- a/test/integration/sidecar-lifecycle.test.ts
+++ b/test/integration/sidecar-lifecycle.test.ts
@@ -53,7 +53,15 @@ class ControlledSocket implements SidecarSocket {
     this.errorOnce.add(handler as ErrorHandler);
   }
 
-  off(event: "connect" | "error", handler: CloseHandler | ErrorHandler): void {
+  off(event: "data" | "close" | "connect" | "error", handler: DataHandler | CloseHandler | ErrorHandler): void {
+    if (event === "data") {
+      this.onData.delete(handler as DataHandler);
+      return;
+    }
+    if (event === "close") {
+      this.onClose.delete(handler as CloseHandler);
+      return;
+    }
     if (event === "connect") {
       this.connectOnce.delete(handler as CloseHandler);
       return;
@@ -152,7 +160,7 @@ function createFailingConnectSocket(errorCode: string): SidecarSocket {
         );
       }
     },
-    off() {},
+    off(_event?: unknown, _handler?: unknown) {},
     write() {},
     destroy() {},
   };
@@ -303,7 +311,7 @@ test("missing daemon errors point users at libravdbd instead of spawn internals"
         queueMicrotask(() => (handler as (error: Error) => void)(Object.assign(new Error("missing"), { code: "ENOENT" })));
       }
     },
-    off() {},
+    off(_event?: unknown, _handler?: unknown) {},
     write() {},
     destroy() {},
   });
@@ -330,7 +338,7 @@ test("startup connect retries ENOENT until the daemon becomes available", async 
             queueMicrotask(() => (handler as (error: Error) => void)(Object.assign(new Error("missing"), { code: "ENOENT" })));
           }
         },
-        off() {},
+        off(_event?: unknown, _handler?: unknown) {},
         write() {},
         destroy() {},
       };

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -52,7 +52,20 @@ class FakeSocket implements SidecarSocket {
     }
   }
 
-  off(event: "connect" | "error", handler: (() => void) | ((error: Error) => void)): void {
+  off(
+    event: "data" | "close" | "connect" | "error",
+    handler: ((chunk: Buffer) => void) | (() => void) | ((error: Error) => void),
+  ): void {
+    if (event === "data") {
+      const idx = this.dataHandlers.indexOf(handler as (chunk: Buffer) => void);
+      if (idx >= 0) this.dataHandlers.splice(idx, 1);
+      return;
+    }
+    if (event === "close") {
+      const idx = this.closeHandlers.indexOf(handler as () => void);
+      if (idx >= 0) this.closeHandlers.splice(idx, 1);
+      return;
+    }
     if (event === "connect") {
       const idx = this.connectOnce.indexOf(handler as () => void);
       if (idx >= 0) this.connectOnce.splice(idx, 1);
@@ -108,14 +121,21 @@ class ReconnectingSocket extends FakeSocket {
     this.reconnectErrorHandlers.push(handler as (error: Error) => void);
   }
 
-  override off(event: "connect" | "error", handler: (() => void) | ((error: Error) => void)): void {
+  override off(
+    event: "data" | "close" | "connect" | "error",
+    handler: ((chunk: Buffer) => void) | (() => void) | ((error: Error) => void),
+  ): void {
     if (event === "connect") {
       const index = this.reconnectHandlers.indexOf(handler as () => void);
       if (index >= 0) this.reconnectHandlers.splice(index, 1);
       return;
     }
-    const index = this.reconnectErrorHandlers.indexOf(handler as (error: Error) => void);
-    if (index >= 0) this.reconnectErrorHandlers.splice(index, 1);
+    if (event === "error") {
+      const index = this.reconnectErrorHandlers.indexOf(handler as (error: Error) => void);
+      if (index >= 0) this.reconnectErrorHandlers.splice(index, 1);
+      return;
+    }
+    super.off(event, handler);
   }
 
   override write(chunk: Buffer | string): void {

--- a/test/unit/sidecar.test.ts
+++ b/test/unit/sidecar.test.ts
@@ -205,7 +205,15 @@ class ManualSidecarSocket implements SidecarSocket {
     this.errorOnce.add(handler as UnitErrorHandler);
   }
 
-  off(event: "connect" | "error", handler: UnitCloseHandler | UnitErrorHandler): void {
+  off(event: "data" | "close" | "connect" | "error", handler: UnitDataHandler | UnitCloseHandler | UnitErrorHandler): void {
+    if (event === "data") {
+      this.onData.delete(handler as UnitDataHandler);
+      return;
+    }
+    if (event === "close") {
+      this.onClose.delete(handler as UnitCloseHandler);
+      return;
+    }
     if (event === "connect") {
       this.connectOnce.delete(handler as UnitCloseHandler);
       return;


### PR DESCRIPTION
## Status

Closed as not worth standalone upstream churn.

The change completes the listener API, but there is no current leak or short-lived consumer that needs it. Keeping this open beside real runtime fixes just adds review noise.

Closes #213 as not planned.

– Vale