### PR TITLE
fix: tighten dream promotion section matching

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -386,7 +386,7 @@ function parseHeading(value: string): string | null {
 }
 
 function isPromotionSection(section: string): boolean {
-  return section.includes("deep sleep") || section.includes("promot") || section.includes("dream");
+  return /^(?:deep sleep|dream promotion(?: candidates?)?|promotion candidates?|promote candidates?)$/.test(section);
 }
 
 function parseBulletCandidate(line: string): { body: string } | null {

--- a/test/unit/dream-promotion.test.ts
+++ b/test/unit/dream-promotion.test.ts
@@ -32,6 +32,58 @@ test("dream promotion parser only accepts explicit deep-sleep candidate bullets"
   assert.equal(candidates[1]?.text, "too weak to promote");
 });
 
+test("dream promotion parser accepts explicit promotion candidate headings", () => {
+  const candidates = parseDreamPromotionCandidates(
+    [
+      "## Dream Promotion Candidates",
+      "- Keep dream promotion {score=0.82 recall=3 unique=2}",
+      "",
+      "## Promotion Candidates",
+      "- Keep promotion candidate {score=0.83 recall=4 unique=3}",
+      "",
+      "## Promote Candidates",
+      "- Keep promote candidate {score=0.84 recall=5 unique=4}",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.text),
+    ["Keep dream promotion", "Keep promotion candidate", "Keep promote candidate"],
+  );
+});
+
+test("dream promotion parser rejects substring-only section matches", () => {
+  const candidates = parseDreamPromotionCandidates(
+    [
+      "## Daydreaming",
+      "- Ignore daydreaming {score=0.9 recall=3 unique=2}",
+      "",
+      "## Dream Team",
+      "- Ignore dream team {score=0.9 recall=3 unique=2}",
+      "",
+      "## Dreaming of Refactors",
+      "- Ignore dreaming heading {score=0.9 recall=3 unique=2}",
+      "",
+      "## Promotional Content",
+      "- Ignore promotional content {score=0.9 recall=3 unique=2}",
+      "",
+      "## Promote Your Work",
+      "- Ignore promote your work {score=0.9 recall=3 unique=2}",
+      "",
+      "## Deep Sleepwalking",
+      "- Ignore deep sleepwalking {score=0.9 recall=3 unique=2}",
+      "",
+      "## Deep Sleep",
+      "- Keep explicit deep sleep {score=0.9 recall=3 unique=2}",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.text),
+    ["Keep explicit deep sleep"],
+  );
+});
+
 test("dream promotion parser rejects partially parsed numeric metadata", () => {
   const candidates = parseDreamPromotionCandidates(
     [


### PR DESCRIPTION
## Summary

Tighten dream diary promotion section detection so only explicit promotion headings are parsed.

Fixes #206.

## Root cause

`isPromotionSection()` used broad substring checks for `dream`, `promot`, and `deep sleep`. That let unrelated headings such as `Daydreaming`, `Dream Team`, `Promotional Content`, or `Deep Sleepwalking` pass the section gate when their bullets happened to contain valid metadata.

## What changed

- Replace the substring checks with an explicit heading allowlist.
- Keep `Deep Sleep` and direct promotion-candidate headings accepted.
- Add regression coverage for the false-positive headings from #206.

## Why this is safe

- Valid `Deep Sleep` diary sections still promote as before.
- Explicit promotion-candidate headings continue to work.
- Unrelated Markdown sections no longer become promotion sections just because their title contains a matching substring.
- The change is local to the dream promotion parser and focused tests.
- No daemon protocol, storage, dependency, network, install, or config changes.

## Tests

- `node node_modules/typescript/bin/tsc -p tsconfig.tests.json`
- `node --test .ts-build/test/unit/dream-promotion.test.js`
- `node --test .ts-build/test/integration/dream-promotion.test.js`
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/@openclaw/plugin-inspector/src/cli.js inspect --no-openclaw`
- `git diff --check origin/main...HEAD`

## Real behavior proof

After the fix, parsing a diary with `Daydreaming`, `Promotional Content`, and `Deep Sleep` returns only the explicit `Deep Sleep` candidate:

```json
[
  {
    "text": "Keep explicit deep sleep",
    "section": "deep sleep"
  }
]
```

## Not run

- Full daemon test suite, because this is a local parser gate fix and the focused unit/integration coverage exercises the affected promotion path.
