### PR TITLE
fix: trim direct auth secret env

### DIFF
--- a/src/libravdb-client.ts
+++ b/src/libravdb-client.ts
@@ -438,13 +438,13 @@ function extractHost(target: string): string {
   return sep > 0 ? withoutDns.slice(0, sep) : withoutDns;
 }
 
-function loadSecretFromEnv(): string | undefined {
-  const secret = process.env.LIBRAVDB_AUTH_SECRET;
+export function loadSecretFromEnv(): string | undefined {
+  const secret = process.env.LIBRAVDB_AUTH_SECRET?.trim();
   if (secret) return secret;
   const secretPath = process.env.LIBRAVDB_AUTH_SECRET_FILE;
   if (secretPath) {
     try {
-      return fs.readFileSync(secretPath, "utf8").trim();
+      return fs.readFileSync(secretPath, "utf8").trim() || undefined;
     } catch {
       return undefined;
     }

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   resolveClientEndpoint,
   createAuthInterceptor,
   LibravDBClient,
+  loadSecretFromEnv,
 } from "../../src/libravdb-client.js";
 
 import type { AuthInterceptorState } from "../../src/libravdb-client.js";
@@ -32,6 +36,76 @@ test("resolveClientEndpoint returns env var when endpoint is undefined or auto",
 
 test("resolveClientEndpoint returns a unix socket path by default on darwin", () => {
   assert.ok(resolveClientEndpoint().startsWith("unix:"));
+});
+
+test("loadSecretFromEnv trims direct secrets", () => {
+  const savedSecret = process.env.LIBRAVDB_AUTH_SECRET;
+  const savedSecretFile = process.env.LIBRAVDB_AUTH_SECRET_FILE;
+  try {
+    process.env.LIBRAVDB_AUTH_SECRET = "  direct-secret  ";
+    process.env.LIBRAVDB_AUTH_SECRET_FILE = "/should/not/be/read";
+
+    assert.equal(loadSecretFromEnv(), "direct-secret");
+  } finally {
+    if (savedSecret === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET = savedSecret;
+    }
+    if (savedSecretFile === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET_FILE;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET_FILE = savedSecretFile;
+    }
+  }
+});
+
+test("loadSecretFromEnv treats whitespace direct secrets as unset and falls back to secret file", () => {
+  const savedSecret = process.env.LIBRAVDB_AUTH_SECRET;
+  const savedSecretFile = process.env.LIBRAVDB_AUTH_SECRET_FILE;
+  const dir = mkdtempSync(path.join(tmpdir(), "libravdb-secret-"));
+  try {
+    const secretFile = path.join(dir, "secret.txt");
+    writeFileSync(secretFile, "  file-secret  \n");
+    process.env.LIBRAVDB_AUTH_SECRET = "   ";
+    process.env.LIBRAVDB_AUTH_SECRET_FILE = secretFile;
+
+    assert.equal(loadSecretFromEnv(), "file-secret");
+  } finally {
+    if (savedSecret === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET = savedSecret;
+    }
+    if (savedSecretFile === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET_FILE;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET_FILE = savedSecretFile;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadSecretFromEnv ignores whitespace direct secrets without file fallback", () => {
+  const savedSecret = process.env.LIBRAVDB_AUTH_SECRET;
+  const savedSecretFile = process.env.LIBRAVDB_AUTH_SECRET_FILE;
+  try {
+    process.env.LIBRAVDB_AUTH_SECRET = " \t\n ";
+    delete process.env.LIBRAVDB_AUTH_SECRET_FILE;
+
+    assert.equal(loadSecretFromEnv(), undefined);
+  } finally {
+    if (savedSecret === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET = savedSecret;
+    }
+    if (savedSecretFile === undefined) {
+      delete process.env.LIBRAVDB_AUTH_SECRET_FILE;
+    } else {
+      process.env.LIBRAVDB_AUTH_SECRET_FILE = savedSecretFile;
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Problem: whitespace-only `LIBRAVDB_AUTH_SECRET` was treated as a configured secret.
- Solution: trim the direct env secret before accepting it, and fall back to `LIBRAVDB_AUTH_SECRET_FILE` when the direct value is blank.
- What changed: `LibravDBClient` secret loading now trims direct/file values and has focused unit coverage for direct trim, file fallback, and blank-direct behavior.
- What did NOT change: no config shape, daemon protocol, storage, dependency, install, manifest, or network behavior.

## Motivation

This fixes #219. A copied or templated env value like `LIBRAVDB_AUTH_SECRET="   "` could silently block the configured secret file and pass a blank auth value into the runtime path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #219
- [x] This PR fixes a bug or regression

## Real Behavior Proof

- Behavior addressed: whitespace-only direct auth secret no longer blocks file fallback.
- Real environment tested: disposable Linux Node 22 checkout with no real secrets, no daemon service, and no persistent runtime changes.
- Exact commands run after rebasing onto current `main` / v1.6.0:

```text
git apply --check libra232-rebased.patch
git apply libra232-rebased.patch
tsc -p tsconfig.tests.json
tsc --noEmit
node --test .ts-build/test/unit/libravdb-client.test.js
plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
node --test .ts-build/test/unit/*.test.js
git diff --check
```

- Evidence after fix:

```text
patch apply check -> clean on origin/main 1ef409b / v1.6.0
tsc -p tsconfig.tests.json -> passed
tsc --noEmit -> passed
node --test .ts-build/test/unit/libravdb-client.test.js -> 14/14 passed
plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute -> PASS
node --test .ts-build/test/unit/*.test.js -> 119/119 passed
git diff --check -> clean
```

- Focused built-JS proof:

```text
loadSecretFromEnv trims direct secrets -> passed
loadSecretFromEnv treats whitespace direct secrets as unset and falls back to secret file -> passed
loadSecretFromEnv ignores whitespace direct secrets without file fallback -> passed
```

- Observed result after fix: blank direct env values behave as absent, trimmed direct secrets still work, and file fallback remains intact.
- What was not tested: live OpenClaw daemon/gateway run, because this is a local auth-secret selection helper and the built-plugin runtime proof covers the changed path without real credentials.

## Root Cause

- Root cause: `loadSecretFromEnv()` checked `LIBRAVDB_AUTH_SECRET` for truthiness before trimming it.
- Missing detection / guardrail: no direct test covered whitespace-only direct env values with file fallback.
- Contributing context: after the v1.6.0 transport rewrite, this helper lives in `src/libravdb-client.ts`, so the rebase keeps the fix in that layer instead of restoring the old plugin-runtime path.

## Regression Test Plan

- Coverage level that should catch this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test file: `test/unit/libravdb-client.test.ts`
- Scenarios locked in:
  - direct env secret is trimmed
  - whitespace-only direct env secret falls back to secret file
  - whitespace-only direct env secret without file returns `undefined`
- Why this is the smallest reliable guardrail: the bug lives entirely inside `loadSecretFromEnv()`, so focused helper tests cover the decision point without needing a daemon or real secret.

## User-visible / Behavior Changes

Whitespace-only `LIBRAVDB_AUTH_SECRET` now behaves as unset instead of configured. Valid direct secrets and file-based secrets continue to work.

## Diagram

```text
Before:
LIBRAVDB_AUTH_SECRET="   " -> accepted as configured -> file fallback skipped

After:
LIBRAVDB_AUTH_SECRET="   " -> trimmed blank -> LIBRAVDB_AUTH_SECRET_FILE fallback used
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: this only rejects blank direct env secrets and preserves existing file fallback; tests cover direct, fallback, and unset cases.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22, pnpm 11.1.x
- Model/provider: N/A
- Integration/channel: LibraVDB client auth-secret loading
- Relevant config:

```text
LIBRAVDB_AUTH_SECRET="   "
LIBRAVDB_AUTH_SECRET_FILE=<redacted test file>
```

### Steps

1. Build the test artifacts.
2. Set a whitespace-only direct auth secret and a valid secret-file fallback.
3. Load the runtime helper from the built JS artifact.

### Expected

- Direct whitespace-only value is ignored.
- Secret file fallback is used.
- Blank direct value without file fallback returns `undefined`.

### Actual

- Matches expected after the patch.

## Evidence

- [x] Passing focused test output
- [x] Built-JS unit proof
- [x] Full unit test output
- [x] Plugin inspector output

## Human Verification

- Verified scenarios:
  - direct secret trimming
  - whitespace direct value plus file fallback
  - whitespace direct value without file fallback
  - full LibraVDB TypeScript/unit/plugin checks on current v1.6.0
- Edge cases checked:
  - spaces, tabs, and newlines in direct env values
  - trimmed file contents
- What I did not verify:
  - live daemon/gateway with real credentials

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] No bot review conversations have been addressed yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: exporting `loadSecretFromEnv()` from `src/libravdb-client.ts` could be mistaken for a package API change.
  - Mitigation: package exports are unchanged; the export is only for focused internal tests.
- Risk: behavior changes for intentionally blank direct secrets.
  - Mitigation: blank secrets are not useful credentials, and the safer behavior is to treat them as unset so configured fallback can work.
