### PR TITLE
fix: reject failed markdown ingest chunks

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -164,7 +164,7 @@ export class IngestQueue {
         const resp = await this.ingestDocument(params);
         if (!resp.ok) {
           throw new Error(
-            `ingest_markdown_document(${params.sourceDoc}) returned ok=false`,
+            `ingest_markdown_document(${params.sourceDoc}) mode=${params.mode} returned ok=false`,
           );
         }
         return resp;

--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -160,7 +160,15 @@ export class IngestQueue {
 
   private async ingestWithRetry(params: IngestMarkdownDocumentParams): Promise<IngestMarkdownDocumentResponse> {
     return withRetry(
-      () => this.ingestDocument(params),
+      async () => {
+        const resp = await this.ingestDocument(params);
+        if (!resp.ok) {
+          throw new Error(
+            `ingest_markdown_document(${params.sourceDoc}) returned ok=false`,
+          );
+        }
+        return resp;
+      },
       this.options.maxRetries,
       this.options.retryBaseDelayMs,
       this.logger,

--- a/test/unit/ingest-queue.test.ts
+++ b/test/unit/ingest-queue.test.ts
@@ -22,6 +22,31 @@ function baseParams() {
   };
 }
 
+function feedback(overrides: Partial<{
+  queueDepth: number;
+  queueCapacity: number;
+  acceptMore: boolean;
+  retryAfterMs: number;
+  processingTimeUs: number;
+  nodesAccepted: number;
+  nodesRejected: number;
+  tokensIngested: number;
+  tokenBurstLimit: number;
+}> = {}) {
+  return {
+    queueDepth: 0,
+    queueCapacity: 10,
+    acceptMore: true,
+    retryAfterMs: 0,
+    processingTimeUs: 1,
+    nodesAccepted: 1,
+    nodesRejected: 0,
+    tokensIngested: 1,
+    tokenBurstLimit: 8192,
+    ...overrides,
+  };
+}
+
 test("chunked ingest replaces first chunk then appends remaining chunks", async () => {
   const calls: Array<{ mode?: IngestMode; text: string }> = [];
   const queue = new IngestQueue(
@@ -49,4 +74,76 @@ test("chunked ingest replaces first chunk then appends remaining chunks", async 
   for (const call of calls.slice(1)) {
     assert.equal(call.mode, IngestMode.APPEND);
   }
+});
+
+test("ok=false ingest responses retry the same chunk before advancing", async () => {
+  const calls: Array<{ mode?: IngestMode; text: string }> = [];
+  let attempt = 0;
+  const queue = new IngestQueue(
+    async (params) => {
+      calls.push({ mode: params.mode, text: params.text });
+      attempt++;
+      return attempt === 1
+        ? { ok: false }
+        : { ok: true, feedback: feedback() };
+    },
+    async () => {},
+    { error() {}, warn() {} },
+    { chunkTokens: 4, maxRetries: 1, retryBaseDelayMs: 0 },
+  );
+
+  await queue.enqueueIngest(
+    "/vault/daily.md",
+    [
+      "first chunk has enough text to force a split.",
+      "second chunk should append instead of replacing prior chunks.",
+    ].join("\n\n"),
+    baseParams(),
+  );
+
+  assert.ok(calls.length > 2, "test input should split after the retried chunk succeeds");
+  assert.equal(calls[0]?.mode, IngestMode.REPLACE);
+  assert.equal(calls[1]?.mode, IngestMode.REPLACE);
+  assert.equal(calls[0]?.text, calls[1]?.text, "retry must not advance the chunk offset");
+  for (const call of calls.slice(2)) {
+    assert.equal(call.mode, IngestMode.APPEND);
+  }
+});
+
+test("ok=false ingest responses fail instead of being treated as accepted", async () => {
+  const calls: Array<{ mode?: IngestMode; text: string }> = [];
+  const queue = new IngestQueue(
+    async (params) => {
+      calls.push({ mode: params.mode, text: params.text });
+      return {
+        ok: false,
+        feedback: feedback({
+          nodesAccepted: 0,
+          nodesRejected: 1,
+          tokensIngested: 0,
+          tokenBurstLimit: 512,
+        }),
+      };
+    },
+    async () => {},
+    { error() {}, warn() {} },
+    { chunkTokens: 4, maxRetries: 1, retryBaseDelayMs: 0 },
+  );
+
+  await assert.rejects(
+    queue.enqueueIngest(
+      "/vault/daily.md",
+      [
+        "first chunk has enough text to force a split.",
+        "second chunk must not be reached if the first chunk is rejected.",
+      ].join("\n\n"),
+      baseParams(),
+    ),
+    /returned ok=false/,
+  );
+
+  assert.equal(calls.length, 2, "maxRetries=1 should attempt the same rejected chunk twice");
+  assert.equal(calls[0]?.mode, IngestMode.REPLACE);
+  assert.equal(calls[1]?.mode, IngestMode.REPLACE);
+  assert.equal(calls[0]?.text, calls[1]?.text, "rejected chunks must not advance the offset");
 });


### PR DESCRIPTION
## Summary

- Problem: `IngestQueue` treated `ingest_markdown_document` responses with `ok: false` as successful attempts.
- Solution: make `ok: false` enter the same retry/failure path as thrown ingest errors.
- What changed: `ingestWithRetry()` now rejects failed daemon payloads, with focused coverage for retry recovery and permanent rejection.
- What did NOT change: no gRPC protocol, config shape, daemon behavior, or successful chunked `REPLACE` / `APPEND` flow changes.

## Motivation

Current `main` / `v1.6.0` can silently accept a markdown ingest chunk even when the vector service returns a structured rejection. If the first `REPLACE` chunk is rejected but the queue advances to later `APPEND` chunks, markdown memory can become partial or stale without surfacing the failed ingest.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Touched files:

- `src/ingest-queue.ts`
- `test/unit/ingest-queue.test.ts`

## Linked Issue/PR

- Related: self-found during current `v1.6.0` LibraVDB memory-ingest audit
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: failed markdown ingest payloads with `ok: false` were able to resolve as successful queue attempts.
- Real environment tested: disposable Linux Node 22 checkout on current `v1.6.0` base, built package code, no persistent daemon/service and no real secrets.
- Exact steps or command run after this patch: built the test artifacts, ran the focused ingest regression, full unit tests, markdown integration tests, plugin inspector, typechecks, and the before/after proof runner against the built package.
- Evidence after fix:

```text
After this patch:
outcome=rejected
error=ingest_markdown_document(/redacted/vault/daily.md) returned ok=false
callCount=1
modes=["REPLACE"]
advancedPastRejectedChunk=false
```

- Observed result after fix: the rejected `REPLACE` chunk no longer advances to later `APPEND` chunks; the queue rejects the failed ingest instead of counting it as accepted.
- What was not tested: no persistent LibraVDB daemon, OpenClaw live chat, or real user vault was used.
- Before evidence:

```text
Before current main:
outcome=resolved
callCount=7
modes=["REPLACE","APPEND",...]
advancedPastRejectedChunk=true
```

## Root Cause

- Root cause: `ingestWithRetry()` awaited the daemon call but did not inspect the returned `IngestMarkdownDocumentResponse.ok` flag.
- Missing detection / guardrail: tests covered thrown retry failures and successful chunk flow, but not a daemon payload that returned cleanly with `ok: false`.
- Contributing context: chunked ingest uses `REPLACE` for the first chunk and `APPEND` for later chunks, so accepting a rejected first chunk can corrupt the logical ingest sequence.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/ingest-queue.test.ts`
- Scenario the test should lock in: `ok: false` should retry the same chunk; persistent `ok: false` should reject and never advance to `APPEND`.
- Why this is the smallest reliable guardrail: the bug is in queue control flow around the daemon response payload, so the queue unit test can assert retry/advance behavior directly.
- Existing test that already covers this: none before this patch.
- If no new test is added, why not: N/A; focused tests were added.

## User-visible / Behavior Changes

Markdown ingest failures from the vector service are now surfaced as failed queue attempts instead of being treated as accepted chunks.

## Diagram

```text
Before:
REPLACE -> ok:false -> counted as success -> APPEND continues

After:
REPLACE -> ok:false -> retry/reject -> APPEND does not run
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux disposable checkout
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel: LibraVDB plugin ingest queue
- Relevant config: no real credentials or private vault data

### Steps

1. On current `main` / `v1.6.0`, run the proof with an `ingest_markdown_document` response returning `ok:false`.
2. Observe that current main resolves and advances from `REPLACE` to later `APPEND` calls.
3. Apply this patch and rerun the same proof.
4. Observe that the patched queue rejects at the failed `REPLACE` chunk and does not advance.

### Expected

- A returned `ok:false` payload should behave like a failed ingest attempt.
- The queue should retry/reject the current chunk before any later chunk can run.

### Actual

- Before this patch, `ok:false` resolved successfully and later chunks could run.
- After this patch, `ok:false` rejects through the queue failure path.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

Focused and supplemental checks:

```text
tsc --noEmit -> passed
tsc -p tsconfig.tests.json -> passed
node --test .ts-build/test/unit/ingest-queue.test.js -> 3/3 passed
node --test .ts-build/test/unit/*.test.js -> 118/118 passed
node --test .ts-build/test/integration/markdown-ingest.test.js -> 20/20 passed
plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute -> PASS
git diff --check -> clean
```

## Human Verification

- Verified scenarios: before/after behavior for `ok:false`, retry recovery after one failed attempt, permanent rejection after repeated failed attempts, and unchanged successful chunked ingest flow.
- Edge cases checked: failed first `REPLACE` chunk does not advance to `APPEND`; successful retry can continue normally.
- What I did not verify: persistent daemon service behavior, real OpenClaw chat delivery, and real user vault ingestion.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversation has been addressed in code for this PR yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a daemon response with `ok:false` that was previously ignored will now fail the queue attempt.
  - Mitigation: this matches the response contract; only failed payloads change behavior, and successful `ok:true` chunk flow is covered by existing and focused tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ingest failures that previously could be treated as successes are now retried and surfaced as clear errors, improving reliability of ingestion.
* **Tests**
  * Added unit tests covering retry behavior for rejected ingests to ensure consistent handling and prevent silent acceptance of failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->