### PR TITLE
fix: enforce Windows ACLs on identity file to restrict to owner-only

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
+import { execSync } from "node:child_process";
 import type { LoggerLike } from "./types.js";
 
 /**
@@ -98,6 +99,18 @@ function writeIdentityFile(path: string, userId: string, parts: DerivedParts): v
   const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 8)}.tmp`;
   writeFileSync(tmp, JSON.stringify(identity, null, 2) + "\n", { mode: 0o600 });
   renameSync(tmp, path);
+
+  // POSIX mode bits are advisory on Windows — enforce owner-only access via ACLs.
+  if (process.platform === "win32") {
+    try {
+      execSync(
+        `icacls "${path}" /inheritance:r /grant:r "%USERNAME%:(R,W)"`,
+        { stdio: "ignore", timeout: 5000 },
+      );
+    } catch {
+      // best-effort; the file is already written with 0o600
+    }
+  }
 }
 
 export function resolveIdentity(params: {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { buildContextEngineFactory } from "../../src/context-engine.js";
 import fs from "node:fs";
+import { execSync } from "node:child_process";
 import { resolveIdentity } from "../../src/identity.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
@@ -865,9 +866,31 @@ test("resolveIdentity creates identity file with owner-only permissions", () => 
   try {
     resolveIdentity({ identityPath });
     assert.ok(fs.existsSync(identityPath), "identity file should exist");
-    const stat = fs.statSync(identityPath);
-    const mode = stat.mode & 0o777;
-    assert.equal(mode & 0o077, 0, `identity file should not be group/world readable, got ${mode.toString(8)}`);
+
+    if (process.platform === "win32") {
+      // POSIX mode bits are advisory on Windows — verify the ACL is restricted
+      // to the current user via icacls output.
+      const acls = execSync(`icacls "${identityPath}"`, { encoding: "utf8" });
+      // A locked-down file has no inherited ACEs and grants only the owner.
+      assert.ok(
+        acls.includes("(R,W)"),
+        `identity file ACLs should grant (R,W) to owner, got:\n${acls}`,
+      );
+      // After /inheritance:r, there should be no inherited entries.
+      assert.equal(
+        acls.includes("BUILTIN"),
+        false,
+        `identity file ACLs should not include built-in principals, got:\n${acls}`,
+      );
+    } else {
+      const stat = fs.statSync(identityPath);
+      const mode = stat.mode & 0o777;
+      assert.equal(
+        mode & 0o077,
+        0,
+        `identity file should not be group/world readable, got ${mode.toString(8)}`,
+      );
+    }
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

PR #197 added `{ mode: 0o600 }` for the identity file, but on Windows POSIX mode bits are advisory — inherited ACEs from the parent directory can still grant access to other users. This PR adds an `icacls` call on Windows to disable inheritance and grant only the current user Read+Write access.

## Changes

- **`src/identity.ts`**: After writing the identity file, on Windows, runs `icacls /inheritance:r /grant:r "%USERNAME%:(R,W)"` to lock down the ACL. Best-effort — failures are silently ignored, same as the existing persistence error handling.
- **`test/unit/context-engine.test.ts`**: On Windows, validates the ACL via `icacls` output instead of checking POSIX mode bits. On POSIX, the existing `0o077` bits check is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced permission enforcement for identity files on Windows systems, adding an additional layer of access control to ensure only the file owner can access identity data, with graceful handling if enforcement mechanisms are unavailable.

* **Tests**
  * Expanded test coverage to validate identity file permission enforcement across Windows and other platforms, verifying access controls function as intended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->