### PR TITLE
fix: default-exclude dependency and build directories from markdown ingestion

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,12 +140,12 @@ The plugin exposes `ingestionGateThreshold` for host-side gating decisions:
 | `markdownIngestionEnabled` | boolean | `false` | Watch markdown roots for changes |
 | `markdownIngestionRoots` | string[] | — | Directories to watch |
 | `markdownIngestionInclude` | string[] | — | Glob patterns to include |
-| `markdownIngestionExclude` | string[] | — | Glob patterns to exclude |
+| `markdownIngestionExclude` | string[] | dependency/build dirs | Glob patterns to exclude; when empty, defaults exclude `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, `.cache`, `.venv`, `venv`, `__pycache__` at any depth |
 | `markdownIngestionDebounceMs` | number | `150` | Debounce window for file change events |
 | `markdownIngestionObsidianEnabled` | boolean | `false` | Watch Obsidian vault roots |
 | `markdownIngestionObsidianRoots` | string[] | — | Obsidian vault directories |
 | `markdownIngestionObsidianInclude` | string[] | — | Obsidian glob include patterns |
-| `markdownIngestionObsidianExclude` | string[] | — | Obsidian glob exclude patterns |
+| `markdownIngestionObsidianExclude` | string[] | same defaults as above | Obsidian glob exclude patterns; defaults to the same set as generic markdown ingestion |
 | `markdownIngestionObsidianDebounceMs` | number | `150` | Obsidian debounce window |
 
 Configured markdown roots are ignored unless the matching enable flag is set to

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,12 +53,12 @@ Relevant config fields:
 | `markdownIngestionEnabled` | Enables or disables generic markdown ingestion. |
 | `markdownIngestionRoots` | Generic markdown roots to watch. |
 | `markdownIngestionInclude` | Optional include globs for generic roots. |
-| `markdownIngestionExclude` | Optional exclude globs for generic roots. |
+| `markdownIngestionExclude` | Optional exclude globs for generic roots; defaults to common dependency/build directories (`**/node_modules/**`, `**/.git/**`, `**/dist/**`, and more) when not set. Setting an explicit list replaces the defaults entirely. |
 | `markdownIngestionDebounceMs` | Watch debounce window, default `150`. |
 | `markdownIngestionObsidianEnabled` | Enables Obsidian ingestion when vault roots exist. |
 | `markdownIngestionObsidianRoots` | Obsidian vault roots to watch. |
 | `markdownIngestionObsidianInclude` | Optional include globs for Obsidian roots. |
-| `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots. |
+| `markdownIngestionObsidianExclude` | Optional exclude globs for Obsidian roots; same defaults as generic markdown ingestion. |
 | `markdownIngestionObsidianDebounceMs` | Obsidian watch debounce window, default `150`. |
 
 By default, the Obsidian adapter auto-ingests notes that look like memory notes,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -239,6 +239,21 @@
       },
       "markdownIngestionObsidianExclude": {
         "type": "array",
+        "default": [
+          "**/node_modules/**",
+          "**/.git/**",
+          "**/dist/**",
+          "**/build/**",
+          "**/coverage/**",
+          "**/.next/**",
+          "**/.nuxt/**",
+          "**/.svelte-kit/**",
+          "**/.turbo/**",
+          "**/.cache/**",
+          "**/.venv/**",
+          "**/venv/**",
+          "**/__pycache__/**"
+        ],
         "items": {
           "type": "string"
         }
@@ -255,6 +270,21 @@
       },
       "markdownIngestionExclude": {
         "type": "array",
+        "default": [
+          "**/node_modules/**",
+          "**/.git/**",
+          "**/dist/**",
+          "**/build/**",
+          "**/coverage/**",
+          "**/.next/**",
+          "**/.nuxt/**",
+          "**/.svelte-kit/**",
+          "**/.turbo/**",
+          "**/.cache/**",
+          "**/.venv/**",
+          "**/venv/**",
+          "**/__pycache__/**"
+        ],
         "items": {
           "type": "string"
         }

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -15,6 +15,21 @@ const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
 const STREAM_CHUNK_BYTES = 64 * 1024;
+const DEFAULT_MARKDOWN_INGEST_EXCLUDES = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/coverage/**",
+  "**/.next/**",
+  "**/.nuxt/**",
+  "**/.svelte-kit/**",
+  "**/.turbo/**",
+  "**/.cache/**",
+  "**/.venv/**",
+  "**/venv/**",
+  "**/__pycache__/**",
+];
 type Disposable = { close(): void };
 
 interface FsDirentLike {
@@ -282,7 +297,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.kind = kind;
     this.roots = config.roots;
     this.includePatterns = config.include?.length ? config.include : [];
-    this.excludePatterns = config.exclude?.length ? config.exclude : [];
+    this.excludePatterns = config.exclude?.length ? config.exclude : DEFAULT_MARKDOWN_INGEST_EXCLUDES;
     this.debounceMs = config.debounceMs ?? DEFAULT_DEBOUNCE_MS;
     this.fsApi = fsApi;
     this.getClient = getClient;

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -948,3 +948,50 @@ test("REPLACE and APPEND ingest modes are unaffected by feedback interface chang
     await handle.stop();
   }
 });
+
+test("markdown ingestion default-excludes dependency and build directories", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-md-default-exclude-"));
+  const keepPath = path.join(tempRoot, "docs", "guide.md");
+  const nodeModulesPath = path.join(tempRoot, "node_modules", "pkg", "CHANGELOG.md");
+  const gitPath = path.join(tempRoot, ".git", "README.md");
+  const distPath = path.join(tempRoot, "dist", "README.md");
+  const nestedNodeModulesPath = path.join(tempRoot, "packages", "app", "node_modules", "pkg", "README.md");
+  const nestedBuildPath = path.join(tempRoot, "packages", "app", "build", "README.md");
+  await fsp.mkdir(path.dirname(keepPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nodeModulesPath), { recursive: true });
+  await fsp.mkdir(path.dirname(gitPath), { recursive: true });
+  await fsp.mkdir(path.dirname(distPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nestedNodeModulesPath), { recursive: true });
+  await fsp.mkdir(path.dirname(nestedBuildPath), { recursive: true });
+  await fsp.writeFile(keepPath, "# Keep\n\nUser-authored doc.");
+  await fsp.writeFile(nodeModulesPath, "# Changelog\n\nDependency docs.");
+  await fsp.writeFile(gitPath, "# Git internals\n\nVCS docs.");
+  await fsp.writeFile(distPath, "# Build output\n\nBuild artifact.");
+  await fsp.writeFile(nestedNodeModulesPath, "# Nested deps\n\nShould not ingest.");
+  await fsp.writeFile(nestedBuildPath, "# Nested build\n\nShould not ingest.");
+
+  const rpc = new FakeRpcClient();
+  const fsApi = new FakeFsApi();
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [tempRoot],
+      markdownIngestionDebounceMs: 0,
+    },
+    async () => rpc as never,
+    console,
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  assert.equal(rpc.calls.filter((call) => call.method === "ingest_markdown_document").length, 1);
+  assert.equal(rpc.documents.has(keepPath), true);
+  assert.equal(rpc.documents.has(nodeModulesPath), false);
+  assert.equal(rpc.documents.has(gitPath), false);
+  assert.equal(rpc.documents.has(distPath), false);
+  assert.equal(rpc.documents.has(nestedNodeModulesPath), false);
+  assert.equal(rpc.documents.has(nestedBuildPath), false);
+
+  await handle.stop();
+});


### PR DESCRIPTION
## Summary

When no explicit `markdownIngestionExclude` is configured, markdown ingestion now skips common generated/dependency directories at any depth. Setting an explicit list replaces the defaults entirely — users retain full control.

Replaces #131 with a minimal implementation: the codebase already has `shouldPruneDirectory` + `matchesExcludedDirectory` handling the pruning, so only the default constant and schema defaults were needed.

## Changes

- **`src/markdown-ingest.ts`**: Added `DEFAULT_MARKDOWN_INGEST_EXCLUDES` constant. When `config.exclude` is empty/absent, `this.excludePatterns` falls back to the defaults. The existing `shouldPruneDirectory` does the rest.
- **`openclaw.plugin.json`**: Schema defaults for both `markdownIngestionExclude` and `markdownIngestionObsidianExclude`.
- **`docs/configuration.md`**, **`docs/features.md`**: Document the default excludes and the replacement behavior.
- **`test/integration/markdown-ingest.test.ts`**: Integration test covering root-level and nested excluded directories.

## Default excludes

`**/node_modules/**`, `**/.git/**`, `**/dist/**`, `**/build/**`, `**/coverage/**`, `**/.next/**`, `**/.nuxt/**`, `**/.svelte-kit/**`, `**/.turbo/**`, `**/.cache/**`, `**/.venv/**`, `**/venv/**`, `**/__pycache__/**`

Closes #118.