### PR TITLE
Fix oversized after-turn payloads tripping LibraVDB embedder

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -43,6 +43,7 @@ const QUOTED_PHRASE_RE = /"([^"]{4,})"|'([^']{4,})'/g;
 const EXACT_RECALL_SEARCH_K = 32;
 const EXACT_RECALL_MAX_TOKENS = 4;
 const RESERVED_CURRENT_TURN_TOKENS = 150;
+const AFTER_TURN_INGEST_MAX_TOKENS = 2048;
 const COMMON_QUERY_WORDS = new Set([
   "what", "does", "mean", "remember", "recall", "about", "this", "that",
   "the", "and", "for", "with", "from", "your", "have", "been", "were",
@@ -340,6 +341,26 @@ function trimMessagesToBudget(
     return [];
   }
   return [{ ...last, content: truncated }];
+}
+
+function boundAfterTurnMessagesForIngest(
+  messages: KernelCompatibleMessage[],
+  logger: LoggerLike,
+  sessionId: string,
+): KernelCompatibleMessage[] {
+  const estimatedTokens = approximateMessagesTokens(messages);
+  if (estimatedTokens <= AFTER_TURN_INGEST_MAX_TOKENS) {
+    return messages;
+  }
+
+  const bounded = trimMessagesToBudget(messages, AFTER_TURN_INGEST_MAX_TOKENS)
+    .map((message) => normalizeKernelMessage(message));
+  logger.warn?.(
+    `LibraVDB afterTurn trimmed oversized ingest payload sessionId=${sessionId} ` +
+    `estimatedTokens=${estimatedTokens} maxTokens=${AFTER_TURN_INGEST_MAX_TOKENS} ` +
+    `forwardedMessages=${bounded.length}`,
+  );
+  return bounded;
 }
 
 function enforceTokenBudgetInvariant(
@@ -1126,6 +1147,7 @@ export function buildContextEngineFactory(
       });
       const afterTurnMessages = selectAfterTurnMessages(args.messages, args.prePromptMessageCount, logger);
       const messages = normalizeKernelMessages(afterTurnMessages);
+      const ingestMessages = boundAfterTurnMessagesForIngest(messages, logger, sessionId);
       const msgCount = messages.length;
       logger.info?.(
         `LibraVDB afterTurn sessionId=${sessionId} userId=${userId} ` +
@@ -1144,7 +1166,7 @@ export function buildContextEngineFactory(
           sessionId,
           sessionKey: args.sessionKey,
           userId,
-          messages,
+          messages: ingestMessages,
           isHeartbeat: args.isHeartbeat,
         });
         await performAfterTurnPredictiveCompaction({

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -156,6 +156,39 @@ test("context engine afterTurn resolves config userId and passes messages to dae
   assert.equal(msgs.length, 2);
 });
 
+test("context engine bounds oversized afterTurn payloads before daemon ingest", async () => {
+  const client = new FakeClient();
+  const cfg: PluginConfig = { userId: "fixed-user" };
+  const engine = buildContextEngineFactory(fakeRuntime(client), cfg);
+  const oversized = "x".repeat(50_000);
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("assistant", oversized)],
+    tokenBudget: 1000,
+    runtimeContext: { currentTokenCount: Number.NaN },
+  });
+
+  const afterTurnCall = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(afterTurnCall, "after_turn_kernel RPC was called");
+  const messages = afterTurnCall.params.messages as Array<{ content: string }>;
+  assert.equal(messages.length, 1);
+  assert.ok(messages[0]!.content.length < oversized.length, "daemon ingest payload is bounded");
+  assert.equal(
+    oversized.endsWith(messages[0]!.content),
+    true,
+    "trimming preserves the newest tail of the oversized turn",
+  );
+
+  const compactCall = client.calls.find((c) => c.method === "compactSession");
+  assert.ok(compactCall, "oversized original payload still triggers predictive compaction");
+  assert.ok(
+    Number(compactCall.params.currentTokenCount) > 10_000,
+    "compaction sizing uses the original payload, not the bounded ingest copy",
+  );
+});
+
 test("context engine assemble resolves config userId and passes it to daemon", async () => {
   const client = new FakeClient();
   const cfg: PluginConfig = { userId: "fixed-user" };


### PR DESCRIPTION
## Summary
- Bound after-turn payloads before sending them to the daemon ingest path.
- Preserve the original message size for predictive compaction decisions.
- Add a regression test for oversized after-turn content.

## Why
On a local install with `@xdarkicex/openclaw-memory-libravdb@1.6.8` and `libravdbd 1.4.73`, existing memory search still worked, but fresh embedding/reindex hit `context deadline exceeded` followed by `embedding engine not ready`. The failing records were large after-turn payloads. Keeping daemon ingest bounded prevents future oversized turns from poisoning local ONNX embedding while still triggering compaction from the original size.

## Tests
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test --test-name-pattern "bounds oversized afterTurn" .ts-build/test/unit/context-engine.test.js`
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js`
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/host-flow.test.js`

Local note: `node --test .ts-build/test/unit/*.test.js` has one environment-sensitive failure on this machine because a live local daemon makes `bootstrapHandshake wraps transport errors` succeed instead of reject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Messages exceeding size limits are now automatically truncated in after-turn flows with warning notifications when truncation occurs.

* **Tests**
  * Added test coverage for message truncation behavior in after-turn flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->