### PR TITLE
fix: guard dream promotion against concurrent scans

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -170,73 +170,7 @@ export function createDreamPromotionHandle(
     }
     state.scanning = true;
     try {
-      await ensureWatcher();
-
-      const stat = await safeStat(diaryPath);
-      if (!stat) {
-        lastFileState = null;
-        return;
-      }
-
-      if (lastFileState && lastFileState.size === stat.size && lastFileState.mtimeMs === stat.mtimeMs) {
-        return;
-      }
-
-      const bytes = await safeReadFile(diaryPath);
-      if (!bytes) {
-        lastFileState = null;
-        return;
-      }
-
-      const fileHash = hashBytes(bytes);
-      if (lastFileState && lastFileState.fileHash === fileHash) {
-        lastFileState = {
-          size: stat.size,
-          mtimeMs: stat.mtimeMs,
-          fileHash,
-        };
-        return;
-      }
-
-      const text = textDecoder.decode(bytes);
-      const candidates = parseDreamPromotionCandidates(text);
-      if (candidates.length === 0) {
-        lastFileState = {
-          size: stat.size,
-          mtimeMs: stat.mtimeMs,
-          fileHash,
-        };
-        return;
-      }
-
-      const client = await getClient();
-      await client.promoteDreamEntries({
-        userId,
-        sourceDoc: diaryPath,
-        sourceRoot: path.dirname(diaryPath),
-        sourcePath: path.basename(diaryPath),
-        sourceKind: DREAM_SOURCE_KIND,
-        fileHash,
-        sourceSize: BigInt(stat.size),
-        sourceMtimeMs: BigInt(Math.trunc(stat.mtimeMs)),
-        ingestVersion: DREAM_PROMOTION_VERSION,
-        hashBackend: getHashBackendName(),
-        entries: candidates.map((candidate): PartialMessage<ProtoEntry> => ({
-          text: candidate.text,
-          score: candidate.score,
-          recallCount: candidate.recallCount,
-          uniqueQueries: candidate.uniqueQueries,
-          section: candidate.section,
-          line: candidate.line,
-          sourceLine: candidate.line,
-        })),
-      });
-
-      lastFileState = {
-        size: stat.size,
-        mtimeMs: stat.mtimeMs,
-        fileHash,
-      };
+      await performScan();
     } finally {
       state.scanning = false;
     }
@@ -245,6 +179,76 @@ export function createDreamPromotionHandle(
       state.dirty = false;
       await refreshDiary();
     }
+  }
+
+  async function performScan(): Promise<void> {
+    await ensureWatcher();
+
+    const stat = await safeStat(diaryPath);
+    if (!stat) {
+      lastFileState = null;
+      return;
+    }
+
+    if (lastFileState && lastFileState.size === stat.size && lastFileState.mtimeMs === stat.mtimeMs) {
+      return;
+    }
+
+    const bytes = await safeReadFile(diaryPath);
+    if (!bytes) {
+      lastFileState = null;
+      return;
+    }
+
+    const fileHash = hashBytes(bytes);
+    if (lastFileState && lastFileState.fileHash === fileHash) {
+      lastFileState = {
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        fileHash,
+      };
+      return;
+    }
+
+    const text = textDecoder.decode(bytes);
+    const candidates = parseDreamPromotionCandidates(text);
+    if (candidates.length === 0) {
+      lastFileState = {
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        fileHash,
+      };
+      return;
+    }
+
+    const client = await getClient();
+    await client.promoteDreamEntries({
+      userId,
+      sourceDoc: diaryPath,
+      sourceRoot: path.dirname(diaryPath),
+      sourcePath: path.basename(diaryPath),
+      sourceKind: DREAM_SOURCE_KIND,
+      fileHash,
+      sourceSize: BigInt(stat.size),
+      sourceMtimeMs: BigInt(Math.trunc(stat.mtimeMs)),
+      ingestVersion: DREAM_PROMOTION_VERSION,
+      hashBackend: getHashBackendName(),
+      entries: candidates.map((candidate): PartialMessage<ProtoEntry> => ({
+        text: candidate.text,
+        score: candidate.score,
+        recallCount: candidate.recallCount,
+        uniqueQueries: candidate.uniqueQueries,
+        section: candidate.section,
+        line: candidate.line,
+        sourceLine: candidate.line,
+      })),
+    });
+
+    lastFileState = {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      fileHash,
+    };
   }
 
   async function safeStat(filePath: string): Promise<{ size: number; mtimeMs: number } | null> {

--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -79,6 +79,7 @@ interface DreamFileState {
 interface DreamPromotionState {
   watching: boolean;
   dirty: boolean;
+  scanning: boolean;
   timer: ReturnType<typeof setTimeout> | null;
   watcher: FsWatcherLike | null;
 }
@@ -110,6 +111,7 @@ export function createDreamPromotionHandle(
   const state: DreamPromotionState = {
     watching: false,
     dirty: false,
+    scanning: false,
     timer: null,
     watcher: null,
   };
@@ -146,6 +148,10 @@ export function createDreamPromotionHandle(
     if (!state.watching) {
       return;
     }
+    if (state.scanning) {
+      state.dirty = true;
+      return;
+    }
     if (state.timer) {
       state.dirty = true;
       return;
@@ -162,73 +168,78 @@ export function createDreamPromotionHandle(
     if (!state.watching) {
       return;
     }
-    await ensureWatcher();
+    state.scanning = true;
+    try {
+      await ensureWatcher();
 
-    const stat = await safeStat(diaryPath);
-    if (!stat) {
-      lastFileState = null;
-      return;
-    }
+      const stat = await safeStat(diaryPath);
+      if (!stat) {
+        lastFileState = null;
+        return;
+      }
 
-    if (lastFileState && lastFileState.size === stat.size && lastFileState.mtimeMs === stat.mtimeMs) {
-      return;
-    }
+      if (lastFileState && lastFileState.size === stat.size && lastFileState.mtimeMs === stat.mtimeMs) {
+        return;
+      }
 
-    const bytes = await safeReadFile(diaryPath);
-    if (!bytes) {
-      lastFileState = null;
-      return;
-    }
+      const bytes = await safeReadFile(diaryPath);
+      if (!bytes) {
+        lastFileState = null;
+        return;
+      }
 
-    const fileHash = hashBytes(bytes);
-    if (lastFileState && lastFileState.fileHash === fileHash) {
+      const fileHash = hashBytes(bytes);
+      if (lastFileState && lastFileState.fileHash === fileHash) {
+        lastFileState = {
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+          fileHash,
+        };
+        return;
+      }
+
+      const text = textDecoder.decode(bytes);
+      const candidates = parseDreamPromotionCandidates(text);
+      if (candidates.length === 0) {
+        lastFileState = {
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+          fileHash,
+        };
+        return;
+      }
+
+      const client = await getClient();
+      await client.promoteDreamEntries({
+        userId,
+        sourceDoc: diaryPath,
+        sourceRoot: path.dirname(diaryPath),
+        sourcePath: path.basename(diaryPath),
+        sourceKind: DREAM_SOURCE_KIND,
+        fileHash,
+        sourceSize: BigInt(stat.size),
+        sourceMtimeMs: BigInt(Math.trunc(stat.mtimeMs)),
+        ingestVersion: DREAM_PROMOTION_VERSION,
+        hashBackend: getHashBackendName(),
+        entries: candidates.map((candidate): PartialMessage<ProtoEntry> => ({
+          text: candidate.text,
+          score: candidate.score,
+          recallCount: candidate.recallCount,
+          uniqueQueries: candidate.uniqueQueries,
+          section: candidate.section,
+          line: candidate.line,
+          sourceLine: candidate.line,
+        })),
+      });
+
       lastFileState = {
         size: stat.size,
         mtimeMs: stat.mtimeMs,
         fileHash,
       };
-      return;
+    } finally {
+      state.scanning = false;
     }
-
-    const text = textDecoder.decode(bytes);
-    const candidates = parseDreamPromotionCandidates(text);
-    if (candidates.length === 0) {
-      lastFileState = {
-        size: stat.size,
-        mtimeMs: stat.mtimeMs,
-        fileHash,
-      };
-      return;
-    }
-
-    const client = await getClient();
-    await client.promoteDreamEntries({
-      userId,
-      sourceDoc: diaryPath,
-      sourceRoot: path.dirname(diaryPath),
-      sourcePath: path.basename(diaryPath),
-      sourceKind: DREAM_SOURCE_KIND,
-      fileHash,
-      sourceSize: BigInt(stat.size),
-      sourceMtimeMs: BigInt(Math.trunc(stat.mtimeMs)),
-      ingestVersion: DREAM_PROMOTION_VERSION,
-      hashBackend: getHashBackendName(),
-      entries: candidates.map((candidate): PartialMessage<ProtoEntry> => ({
-        text: candidate.text,
-        score: candidate.score,
-        recallCount: candidate.recallCount,
-        uniqueQueries: candidate.uniqueQueries,
-        section: candidate.section,
-        line: candidate.line,
-        sourceLine: candidate.line,
-      })),
-    });
-
-    lastFileState = {
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-      fileHash,
-    };
 
     if (state.dirty) {
       state.dirty = false;


### PR DESCRIPTION
## Summary

Adds a `scanning` flag to `DreamPromotionState` to prevent concurrent `scanDiary()` executions.

Fixes #220.

## Root cause

The debounce timer was the sole in-flight guard. Once it fired and cleared `timer = null`, a watcher event during the async scan (file IO + promotion RPC) could schedule a second scan via a new timer, leading to concurrent or duplicated promotions.

## What changed

- Added `scanning: boolean` to `DreamPromotionState`
- `scanDiary()` sets `scanning = true` on entry, clears it in a `finally` block
- `refreshDiary()` bails early with `dirty = true` when a scan is already in progress
- The existing dirty follow-up at the end of `scanDiary()` handles the deferred rescan

## Why this is safe

- Single-field state addition, no protocol or API changes
- `try/finally` guarantees the flag is cleared even if the scan throws
- Dirty follow-up already existed — this just prevents concurrent entry
- Unit and integration tests pass

## Verification

```bash
pnpm run build
npx tsx --test test/unit/dream-promotion.test.ts
npx tsx --test test/integration/dream-promotion.test.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diary scan reliability by preventing overlapping scans while ensuring subsequent changes properly trigger updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->