### PR TITLE
fix: clear predictive context cache on session lifecycle

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -755,6 +755,7 @@ export function buildContextEngineFactory(
   logger: LoggerLike = console,
 ) {
   const predictiveContextCache = new Map<string, import("./types.js").PredictedContext[]>();
+  const PREDICTIVE_CACHE_MAX_SIZE = 100;
   let cachedIdentity: ResolvedIdentity | null = null;
   let cachedSessionKey: string | undefined;
 
@@ -1040,6 +1041,7 @@ export function buildContextEngineFactory(
     ownsCompaction: true,
     async bootstrap(args: { sessionId: string; sessionKey?: string; userId?: string }) {
       const sessionId = requireSessionId(args.sessionId, "bootstrap");
+      predictiveContextCache.delete(sessionId);
       const userId = resolveUserId({
         userIdOverride: args.userId,
         sessionKey: args.sessionKey,
@@ -1276,6 +1278,10 @@ export function buildContextEngineFactory(
         });
         const predictions = (result as any).predictions;
         if (Array.isArray(predictions) && predictions.length > 0) {
+          if (predictiveContextCache.size >= PREDICTIVE_CACHE_MAX_SIZE) {
+            const oldest = predictiveContextCache.keys().next().value;
+            if (oldest !== undefined) predictiveContextCache.delete(oldest);
+          }
           predictiveContextCache.set(sessionId, predictions);
         }
         return result;
@@ -1286,6 +1292,9 @@ export function buildContextEngineFactory(
         );
         throw error;
       }
-    }
+    },
+    async dispose() {
+      predictiveContextCache.clear();
+    },
   };
 }


### PR DESCRIPTION
## Summary

Predictive context cache entries were only deleted when `assemble` consumed them. Sessions ending without a final assemble leaked entries indefinitely, causing memory accumulation and stale data risk on recycled `sessionId` values.

Fixes #211.

## What changed

Three guards against cache leakage:

1. **`bootstrap()`** — deletes any stale cache entry for the sessionId being bootstrapped (prevents recycled sessionIds from picking up old predictions)
2. **Max-size eviction** — if the cache reaches 100 entries, the oldest entry is dropped before inserting a new one (fallback for hosts that don't deliver lifecycle hints)
3. **`dispose()`** — clears the entire cache on engine shutdown (prevents leaks across engine replacements)

## Why this is safe

- Bootstrap deletion is a no-op if the sessionId isn't in the cache
- Max-size guard only fires after 100 concurrent sessions — well above typical usage
- `dispose()` is a ContextEngine interface method, called by the host on plugin shutdown
- All existing tests pass