### PR TITLE
fix: report legacy json-rpc daemon handshakes

### DIFF
--- a/src/libravdb-client.ts
+++ b/src/libravdb-client.ts
@@ -87,6 +87,59 @@ export function resolveClientEndpoint(configuredEndpoint?: string): string {
   return `unix:${path.join(os.homedir(), ".libravdbd", "run", sockName)}`;
 }
 
+export function isLegacyJsonRpcHealthResponse(payload: string): boolean {
+  try {
+    const parsed = JSON.parse(payload.trim()) as { jsonrpc?: unknown; result?: { ok?: unknown } };
+    return parsed.jsonrpc === "2.0" && parsed.result?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectLegacyJsonRpcDaemon(endpoint: string, timeoutMs = 500): Promise<boolean> {
+  if (!endpoint.startsWith("unix:")) {
+    return false;
+  }
+  const socketPath = endpoint.slice(5);
+  if (!socketPath) {
+    return false;
+  }
+
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    let response = "";
+    const socket = net.createConnection(socketPath);
+    const finish = (value: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(false), Math.max(1, timeoutMs));
+    timer.unref?.();
+
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write('{"jsonrpc":"2.0","id":1,"method":"health","params":{}}\n');
+    });
+    socket.on("data", (chunk) => {
+      response += chunk;
+      if (isLegacyJsonRpcHealthResponse(response)) {
+        finish(true);
+      } else if (response.length > 4096) {
+        finish(false);
+      }
+    });
+    socket.on("end", () => finish(isLegacyJsonRpcHealthResponse(response)));
+    socket.on("close", () => finish(isLegacyJsonRpcHealthResponse(response)));
+    socket.on("error", () => finish(false));
+  });
+}
+
 type PromiseClient = ReturnType<typeof createPromiseClient<typeof LibravDB>>;
 
 // ---------------------------------------------------------------------------
@@ -176,6 +229,8 @@ export function createAuthInterceptor(
 export class LibravDBClient {
   private client: PromiseClient;
   private readonly secret: string | undefined;
+  private readonly endpoint: string;
+  private readonly legacyProbeTimeoutMs: number;
   private nonceHex: string | undefined;
   private closed = false;
 
@@ -183,6 +238,8 @@ export class LibravDBClient {
     this.secret = options.secret ?? loadSecretFromEnv();
 
     const rawEndpoint = resolveClientEndpoint(options.endpoint);
+    this.endpoint = rawEndpoint;
+    this.legacyProbeTimeoutMs = Math.min(options.timeoutMs ?? 30000, 1000);
     const isUnix = rawEndpoint.startsWith("unix:");
     const socketPath = isUnix ? rawEndpoint.slice(5) : undefined;
     const credMode = resolveCredentialMode(rawEndpoint, options.tlsMode);
@@ -245,8 +302,16 @@ export class LibravDBClient {
         },
       );
     } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (detail.includes("Protocol error") && await detectLegacyJsonRpcDaemon(this.endpoint, this.legacyProbeTimeoutMs)) {
+        throw new Error(
+          `LibraVDB: failed to handshake with daemon: ${detail}. ` +
+          "The endpoint answered legacy JSON-RPC health; this plugin requires a gRPC-compatible libravdbd daemon. " +
+          "Update or restart libravdbd with gRPC support, or pin the plugin to a daemon-compatible release.",
+        );
+      }
       throw new Error(
-        `LibraVDB: failed to handshake with daemon: ${error instanceof Error ? error.message : String(error)}`,
+        `LibraVDB: failed to handshake with daemon: ${detail}`,
       );
     }
   }

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -11,6 +11,12 @@ const NOOP_LOGGER: LoggerLike = {
   warn() {},
 };
 
+function effectiveAssembleBudget(tokenBudget: number): number {
+  const proportionalHeadroom = Math.max(1, Math.floor(tokenBudget * 0.2));
+  const headroom = Math.min(256, proportionalHeadroom);
+  return Math.max(1, tokenBudget - headroom);
+}
+
 /**
  * StaticContractRpc replaces the complex, logic-heavy mock with a strict API boundary.
  * It tracks outgoing calls and returns predefined static responses matching rpc_pb.d.ts,
@@ -246,7 +252,7 @@ test("assemble clamps oversized daemon context to token budget", async () => {
     tokenBudget: 512,
   });
 
-  assert.ok(assembled.estimatedTokens <= 256);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(512));
   assert.equal(assembled.messages[0]?.role, "user");
 });
 
@@ -268,7 +274,7 @@ test("assemble fail-closed on sidecar errors with budget-clamped fallback", asyn
     tokenBudget: 512,
   });
 
-  assert.ok(assembled.estimatedTokens <= 256);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(512));
   // User turn reinjection takes priority; when the fallback user dominates the
   // budget, downstream tool_calls may be dropped to preserve the user turn.
   assert.ok(assembled.messages.length >= 1);
@@ -395,7 +401,7 @@ test("assemble blocks daemon assembly when predictive compaction fails", async (
     tokenBudget: 1000,
   });
 
-  assert.ok(assembled.estimatedTokens <= 744);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(1000));
   assert.equal(assembled.systemPromptAddition, "");
   const assembleCalls = rpc.calls.filter((call) => call.method === "assemble_context_internal");
   assert.equal(assembleCalls.length, 0, "assemble_context_internal must be blocked on compaction failure");

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -772,6 +772,7 @@ test("resume cursor invalidates when target file is deleted during pause", async
     return { acceptMore: true, retryAfterMs: 0 };
   };
 
+  const fsApi = new FakeFsApi();
   const handle = createMarkdownIngestionHandle(
     {
       markdownIngestionEnabled: true,
@@ -782,6 +783,7 @@ test("resume cursor invalidates when target file is deleted during pause", async
     },
     async () => rpc as never,
     { error() {}, warn() {}, info() {} },
+    fsApi as never,
   );
 
   try {
@@ -789,6 +791,11 @@ test("resume cursor invalidates when target file is deleted during pause", async
 
     const afterFirstPass = rpc.calls.filter((call) => call.method === "ingest_markdown_document");
     assert.equal(afterFirstPass.length, 1, "first file should be ingested before backpressure");
+    assert.equal(
+      (afterFirstPass[0].params as { sourceDoc: string }).sourceDoc,
+      firstPath,
+      "first ingested file is the newest file",
+    );
 
     await fsp.rm(secondPath);
     await handle.refresh();

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -9,7 +9,6 @@ import {
   createAuthInterceptor,
   LibravDBClient,
   loadSecretFromEnv,
-  loadSecretFromEnv,
 } from "../../src/libravdb-client.js";
 
 import type { AuthInterceptorState } from "../../src/libravdb-client.js";

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -1,17 +1,53 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
   resolveClientEndpoint,
   createAuthInterceptor,
+  detectLegacyJsonRpcDaemon,
+  isLegacyJsonRpcHealthResponse,
   LibravDBClient,
   loadSecretFromEnv,
 } from "../../src/libravdb-client.js";
 
 import type { AuthInterceptorState } from "../../src/libravdb-client.js";
+
+async function withLegacyJsonRpcSocket(run: (endpoint: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "libravdb-legacy-jsonrpc-"));
+  const socketPath = path.join(dir, "libravdb.sock");
+  const server = net.createServer((socket) => {
+    let replied = false;
+    socket.setEncoding("utf8");
+    socket.on("data", () => {
+      if (replied) {
+        return;
+      }
+      replied = true;
+      socket.end('{"jsonrpc":"2.0","id":1,"result":{"ok":true,"message":"ok"}}\n');
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+
+  try {
+    await run(`unix:${socketPath}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // resolveClientEndpoint
@@ -108,6 +144,21 @@ test("loadSecretFromEnv ignores whitespace direct secrets without file fallback"
   }
 });
 
+test("isLegacyJsonRpcHealthResponse recognizes legacy health responses", () => {
+  assert.equal(
+    isLegacyJsonRpcHealthResponse('{"jsonrpc":"2.0","id":1,"result":{"ok":true,"message":"ok"}}'),
+    true,
+  );
+  assert.equal(isLegacyJsonRpcHealthResponse('{"jsonrpc":"2.0","result":{"ok":false}}'), false);
+  assert.equal(isLegacyJsonRpcHealthResponse("not json"), false);
+});
+
+test("detectLegacyJsonRpcDaemon probes legacy JSON-RPC unix health", { skip: process.platform === "win32" }, async () => {
+  await withLegacyJsonRpcSocket(async (endpoint) => {
+    assert.equal(await detectLegacyJsonRpcDaemon(endpoint, 500), true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Client lifecycle
 // ---------------------------------------------------------------------------
@@ -123,6 +174,17 @@ test("close prevents RPC methods", async () => {
 test("bootstrapHandshake wraps transport errors", async () => {
   const client = new LibravDBClient({ secret: "test" });
   await assert.rejects(client.bootstrapHandshake(), /LibraVDB: failed to handshake/);
+});
+
+test("bootstrapHandshake reports legacy JSON-RPC daemon compatibility", { skip: process.platform === "win32" }, async () => {
+  await withLegacyJsonRpcSocket(async (endpoint) => {
+    const client = new LibravDBClient({ endpoint, timeoutMs: 500 });
+    await assert.rejects(
+      client.bootstrapHandshake(),
+      /legacy JSON-RPC health; this plugin requires a gRPC-compatible libravdbd daemon/,
+    );
+    client.close();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- detect a Unix socket that answers legacy JSON-RPC `health` after a gRPC protocol-error handshake
- replace the opaque protocol error with an actionable daemon/plugin compatibility message
- add unit coverage for JSON-RPC health detection and the enriched bootstrap error

Closes #243.

Stacked on #245 so this branch has green gates while upstream main is currently red. Once #245 lands, this PR diff should collapse to the client/test changes for #243.

## Verification

```text
COREPACK_ENABLE_AUTO_PIN=0 pnpm run check
COREPACK_ENABLE_AUTO_PIN=0 pnpm run test:integration
```

Both pass locally.

– Vale