### PR TITLE
fix: add remote embedder support to plugin config schema

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -19,6 +19,13 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
+    "if": {
+      "properties": { "embeddingBackend": { "const": "remote" } },
+      "required": ["embeddingBackend"]
+    },
+    "then": {
+      "required": ["embeddingEndpoint"]
+    },
     "properties": {
       "dbPath": {
         "type": "string"
@@ -142,8 +149,10 @@
         "enum": [
           "bundled",
           "onnx-local",
-          "custom-local"
-        ]
+          "custom-local",
+          "remote"
+        ],
+        "description": "Embedder backend: bundled (built-in ONNX), onnx-local (local ONNX model), custom-local (custom ONNX), remote (HTTP API)"
       },
       "embeddingProfile": {
         "type": "string",
@@ -164,6 +173,18 @@
       },
       "embeddingNormalize": {
         "type": "boolean"
+      },
+      "embeddingEndpoint": {
+        "type": "string",
+        "description": "HTTP endpoint URL for the remote embedder backend (required when embeddingBackend is 'remote')"
+      },
+      "embeddingRemoteModel": {
+        "type": "string",
+        "description": "Model identifier used when embeddingBackend is 'remote', e.g. 'nomic-embed-text-v1.5'"
+      },
+      "embeddingAPIKey": {
+        "type": "string",
+        "description": "API key for the remote embedder endpoint (when embeddingBackend is 'remote')"
       },
       "summarizerBackend": {
         "type": "string",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,13 +20,19 @@ export interface PluginConfig {
   /** Optional ONNX execution provider override passed through to libravdbd.
    *  Use "cpu" to bypass CoreML/MPS on Intel Macs or fragile GPU/NPU providers. */
   onnxDevice?: "auto" | "cpu" | "cuda" | "coreml" | "directml" | "openvino";
-  embeddingBackend?: "bundled" | "onnx-local" | "custom-local";
+  embeddingBackend?: "bundled" | "onnx-local" | "custom-local" | "remote";
   embeddingProfile?: string;
   fallbackProfile?: string;
   embeddingModelPath?: string;
   embeddingTokenizerPath?: string;
   embeddingDimensions?: number;
   embeddingNormalize?: boolean;
+  /** HTTP endpoint URL for the remote embedder backend (when embeddingBackend is 'remote') */
+  embeddingEndpoint?: string;
+  /** Model identifier for the remote embedder backend */
+  embeddingRemoteModel?: string;
+  /** API key for the remote embedder endpoint */
+  embeddingAPIKey?: string;
   summarizerBackend?: "bundled" | "onnx-local" | "ollama-local" | "custom-local";
   summarizerProfile?: string;
   summarizerRuntimePath?: string;


### PR DESCRIPTION
## Summary
- Add `embeddingEndpoint`, `embeddingRemoteModel`, and `embeddingAPIKey` fields to the plugin configSchema
- Add `"remote"` option to the `embeddingBackend` enum

This enables users to configure HTTP-based remote embedding backends through the plugin interface, bridging the gap between the plugin's schema and the libravdbd sidecar's remote embedder capability.

## Test plan
- [ ] Verify plugin builds successfully (`npm run build`)
- [ ] Confirm config schema accepts the new fields

🤖 Generated with [Claude Code](https://claude.ai/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended embedding backend capabilities to include remote server-based services alongside existing local options. Users can now configure remote embedding endpoints by specifying HTTP URLs, selecting remote model identifiers, and providing API authentication credentials, enabling integration with external embedding providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->