### PR TITLE
test: restore v1.6.14 test gates with correct budget formulas

### DIFF
--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -11,6 +11,12 @@ const NOOP_LOGGER: LoggerLike = {
   warn() {},
 };
 
+function effectiveAssembleBudget(tokenBudget: number): number {
+  const proportionalHeadroom = Math.max(1, Math.floor(tokenBudget * 0.2));
+  const headroom = Math.min(256, proportionalHeadroom);
+  return Math.max(1, tokenBudget - headroom);
+}
+
 /**
  * StaticContractRpc replaces the complex, logic-heavy mock with a strict API boundary.
  * It tracks outgoing calls and returns predefined static responses matching rpc_pb.d.ts,
@@ -246,7 +252,7 @@ test("assemble clamps oversized daemon context to token budget", async () => {
     tokenBudget: 512,
   });
 
-  assert.ok(assembled.estimatedTokens <= 256);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(512));
   assert.equal(assembled.messages[0]?.role, "user");
 });
 
@@ -268,7 +274,7 @@ test("assemble fail-closed on sidecar errors with budget-clamped fallback", asyn
     tokenBudget: 512,
   });
 
-  assert.ok(assembled.estimatedTokens <= 256);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(512));
   // User turn reinjection takes priority; when the fallback user dominates the
   // budget, downstream tool_calls may be dropped to preserve the user turn.
   assert.ok(assembled.messages.length >= 1);
@@ -395,7 +401,7 @@ test("assemble blocks daemon assembly when predictive compaction fails", async (
     tokenBudget: 1000,
   });
 
-  assert.ok(assembled.estimatedTokens <= 744);
+  assert.ok(assembled.estimatedTokens <= effectiveAssembleBudget(1000));
   assert.equal(assembled.systemPromptAddition, "");
   const assembleCalls = rpc.calls.filter((call) => call.method === "assemble_context_internal");
   assert.equal(assembleCalls.length, 0, "assemble_context_internal must be blocked on compaction failure");

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -772,6 +772,7 @@ test("resume cursor invalidates when target file is deleted during pause", async
     return { acceptMore: true, retryAfterMs: 0 };
   };
 
+  const fsApi = new FakeFsApi();
   const handle = createMarkdownIngestionHandle(
     {
       markdownIngestionEnabled: true,
@@ -782,6 +783,7 @@ test("resume cursor invalidates when target file is deleted during pause", async
     },
     async () => rpc as never,
     { error() {}, warn() {}, info() {} },
+    fsApi as never,
   );
 
   try {
@@ -789,6 +791,11 @@ test("resume cursor invalidates when target file is deleted during pause", async
 
     const afterFirstPass = rpc.calls.filter((call) => call.method === "ingest_markdown_document");
     assert.equal(afterFirstPass.length, 1, "first file should be ingested before backpressure");
+    assert.equal(
+      (afterFirstPass[0].params as { sourceDoc: string }).sourceDoc,
+      firstPath,
+      "first ingested file is the newest file",
+    );
 
     await fsp.rm(secondPath);
     await handle.refresh();

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -12,7 +12,6 @@ import {
   isLegacyJsonRpcHealthResponse,
   LibravDBClient,
   loadSecretFromEnv,
-  loadSecretFromEnv,
 } from "../../src/libravdb-client.js";
 
 import type { AuthInterceptorState } from "../../src/libravdb-client.js";


### PR DESCRIPTION
## Summary

Replace hardcoded token budget assertions with `effectiveAssembleBudget()`:
```typescript
function effectiveAssembleBudget(tokenBudget: number): number {
  const proportionalHeadroom = Math.max(1, Math.floor(tokenBudget * 0.2));
  const headroom = Math.min(256, proportionalHeadroom);
  return Math.max(1, tokenBudget - headroom);
}
```

Fixes three incorrect test thresholds:
- `assemble clamps oversized daemon context` (512 → 410 instead of 256)
- `assemble fail-closed on sidecar errors` (512 → 410 instead of 256)
- `assemble blocks daemon assembly when predictive compaction fails` (1000 → 800 instead of 744)

Also fixes a missing `fsApi` parameter in a markdown-ingest test and removes a duplicate import.

Supersedes #245 (which included unintended reverts due to old base). This is a clean-only version targeting current main.

## Test plan
- [ ] `pnpm run check` passes
- [ ] `pnpm run test:integration` passes

🤖 Generated with [Claude Code](https://claude.ai/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to verify token budget clamping behavior.
  * Enhanced markdown ingestion test with improved file system mocking.
  * Updated test imports for client library testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->