### PR TITLE
fix: add assemble promptAuthority signal and bound oversized afterTurn payloads

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -27,14 +27,19 @@ type OpenClawCompatibleMessage = {
   [key: string]: unknown;
 };
 
+type OpenClawCompatiblePromptAuthority = "preassembly_may_overflow";
+
 type OpenClawCompatibleAssembleResult = {
   messages: OpenClawCompatibleMessage[];
   estimatedTokens: number;
   systemPromptAddition: string;
+  promptAuthority: OpenClawCompatiblePromptAuthority;
   debug?: AssembleContextInternalResponse["debug"];
 };
 
 const APPROX_CHARS_PER_TOKEN = 4;
+const PROMPT_AUTHORITY_PREASSEMBLY_MAY_OVERFLOW: OpenClawCompatiblePromptAuthority =
+  "preassembly_may_overflow";
 const ASSEMBLE_BUDGET_HEADROOM_TOKENS = 256;
 const ASSEMBLE_BUDGET_HEADROOM_FRACTION = 0.2;
 const DEFAULT_COMPACTION_THRESHOLD_FRACTION = 0.8;
@@ -44,6 +49,7 @@ const QUOTED_PHRASE_RE = /"([^"]{4,})"|'([^']{4,})'/g;
 const EXACT_RECALL_SEARCH_K = 32;
 const EXACT_RECALL_MAX_TOKENS = 4;
 const RESERVED_CURRENT_TURN_TOKENS = 150;
+const AFTER_TURN_INGEST_MAX_TOKENS = 2048;
 const COMMON_QUERY_WORDS = new Set([
   "what", "does", "mean", "remember", "recall", "about", "this", "that",
   "the", "and", "for", "with", "from", "your", "have", "been", "were",
@@ -345,6 +351,26 @@ function trimMessagesToBudget(
   return [{ ...last, content: truncated }];
 }
 
+function boundAfterTurnMessagesForIngest(
+  messages: KernelCompatibleMessage[],
+  logger: LoggerLike,
+  sessionId: string,
+): KernelCompatibleMessage[] {
+  const estimatedTokens = approximateMessagesTokens(messages);
+  if (estimatedTokens <= AFTER_TURN_INGEST_MAX_TOKENS) {
+    return messages;
+  }
+
+  const bounded = trimMessagesToBudget(messages, AFTER_TURN_INGEST_MAX_TOKENS)
+    .map((message) => normalizeKernelMessage(message));
+  logger.warn?.(
+    `LibraVDB afterTurn trimmed oversized ingest payload sessionId=${sessionId} ` +
+    `estimatedTokens=${estimatedTokens} maxTokens=${AFTER_TURN_INGEST_MAX_TOKENS} ` +
+    `forwardedMessages=${bounded.length}`,
+  );
+  return bounded;
+}
+
 function enforceTokenBudgetInvariant(
   result: OpenClawCompatibleAssembleResult,
   tokenBudget: number | undefined,
@@ -395,6 +421,7 @@ function buildBudgetFallbackContext(
     messages: fallbackMessages,
     estimatedTokens: approximateMessagesTokens(fallbackMessages),
     systemPromptAddition: "",
+    promptAuthority: PROMPT_AUTHORITY_PREASSEMBLY_MAY_OVERFLOW,
   };
 }
 
@@ -403,10 +430,17 @@ function resolvePredictiveCompactionTokenCount(args: {
   messages: OpenClawCompatibleMessage[];
   prompt?: string;
 }): number {
-  return (
-    normalizeCurrentTokenCount(args.currentTokenCount) ??
-    approximateMessagesTokens(args.messages) + approximateTokenCount(args.prompt ?? "")
+  const currentTokenCount = normalizeCurrentTokenCount(args.currentTokenCount);
+  const sourcePressureEstimate = normalizeCurrentTokenCount(
+    approximateMessagesTokens(args.messages) + approximateTokenCount(args.prompt ?? ""),
   );
+  if (currentTokenCount == null) {
+    return sourcePressureEstimate ?? 1;
+  }
+  if (sourcePressureEstimate == null) {
+    return currentTokenCount;
+  }
+  return Math.max(currentTokenCount, sourcePressureEstimate);
 }
 
 function resolveAfterTurnPredictiveCompactionTokenCount(args: {
@@ -745,6 +779,7 @@ export function normalizeAssembleResult(result: {
       typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
     systemPromptAddition:
       typeof result.systemPromptAddition === "string" ? result.systemPromptAddition : "",
+    promptAuthority: PROMPT_AUTHORITY_PREASSEMBLY_MAY_OVERFLOW,
     ...(result.debug != null ? { debug: result.debug } : {}),
   };
 }
@@ -1249,6 +1284,7 @@ export function buildContextEngineFactory(
       });
       const afterTurnMessages = selectAfterTurnMessages(args.messages, args.prePromptMessageCount, logger);
       const messages = normalizeKernelMessages(afterTurnMessages);
+      const ingestMessages = boundAfterTurnMessagesForIngest(messages, logger, sessionId);
       const msgCount = messages.length;
       logger.info?.(
         `LibraVDB afterTurn sessionId=${sessionId} userId=${userId} ` +
@@ -1267,7 +1303,7 @@ export function buildContextEngineFactory(
           sessionId,
           sessionKey: args.sessionKey,
           userId,
-          messages,
+          messages: ingestMessages,
           isHeartbeat: args.isHeartbeat,
         });
         await performAfterTurnPredictiveCompaction({


### PR DESCRIPTION
## Summary

Combine two fixes from #247 and #239 into a clean, non-breaking PR:

**1. Assemble promptAuthority signal**
- Add `promptAuthority: "preassembly_may_overflow"` to `AssembleResult` type and returned from `buildBudgetFallbackContext()` and `normalizeAssembleResult()`
- Allows the host to detect when preassembly exceeded its budget

**2. Fix resolvePredictiveCompactionTokenCount underreporting**
- Use `Math.max(currentTokenCount, sourcePressureEstimate)` instead of `??` fallback
- Prevents underreporting when `currentTokenCount` is stale or missing

**3. Bound oversized afterTurn ingest payloads**
- New `AFTER_TURN_INGEST_MAX_TOKENS = 2048` cap on daemon ingest messages
- Predictive compaction still uses original oversized payload for correct sizing
- Logs a warning when trimming occurs

## Test plan
- [x] `pnpm run test:ts` — 157 tests pass
- [x] `pnpm run test:integration` — 44 tests pass

Supersedes #247 (promptAuthority) and #239 (afterTurn bounds) — both had unintended reverts due to old base branches.

🤖 Generated with [Claude Code](https://claude.ai/codex)