### PR TITLE
Fail closed for incomplete onnx-local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Then activate the plugin in `~/.openclaw/openclaw.json`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -185,6 +186,8 @@ All keys are optional. For the full reference, see [Configuration](./docs/config
 | `sidecarPath` | string | `auto` | `"auto"` probes standard paths; set `unix:/path` or `tcp:host:port` to override |
 | `embeddingProfile` | string | `nomic-embed-text-v1.5` | Primary embedding model |
 | `fallbackProfile` | string | `bge-small-en-v1.5` | Fallback profile for dimension mismatches |
+| `embeddingRuntimePath` | string | — | Required with `embeddingBackend: "onnx-local"`; path to `libonnxruntime` visible to `libravdbd` |
+| `embeddingModelPath` | string | — | Required with `embeddingBackend: "onnx-local"`; directory containing `embedding.json`, `model.onnx`, and `tokenizer.json` |
 | `onnxDevice` | string | `auto` | ONNX execution provider; set `cpu` to bypass CoreML/MPS on Intel Macs |
 | `userId` | string | auto-derived | Stable identity for cross-session durable memory |
 | `crossSessionRecall` | boolean | `true` | When `false`, only session-scoped memories are retrieved |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,10 +87,10 @@ address, explicitly set `grpcEndpointTlsMode: "tls"` to match:
 |---|---|---|---|
 | `embeddingProfile` | string | `nomic-embed-text-v1.5` | Primary embedding model |
 | `fallbackProfile` | string | `bge-small-en-v1.5` | Fallback when primary model fails dimension checks |
-| `embeddingBackend` | string | — | `bundled`, `onnx-local`, or `custom-local` |
+| `embeddingBackend` | string | — | `bundled`, `onnx-local`, `custom-local`, or `remote` |
 | `onnxDevice` | string | `auto` | ONNX execution provider: `auto`, `cpu`, `coreml` (macOS), `cuda` (Linux/Windows), `directml` (Windows), `openvino` (Linux) |
-| `embeddingRuntimePath` | string | — | Path to ONNX runtime library (maps to `LIBRAVDB_ONNX_RUNTIME`) |
-| `embeddingModelPath` | string | — | Path to custom embedding model `.onnx` file |
+| `embeddingRuntimePath` | string | — | Path to ONNX runtime library visible to the daemon (maps to `LIBRAVDB_ONNX_RUNTIME`; required with `embeddingBackend: "onnx-local"`) |
+| `embeddingModelPath` | string | — | Path to the model directory containing `embedding.json`, `model.onnx`, and `tokenizer.json` (maps to `LIBRAVDB_EMBEDDING_MODEL`; required with `embeddingBackend: "onnx-local"`) |
 | `embeddingTokenizerPath` | string | — | Path to custom tokenizer file |
 | `embeddingDimensions` | number | — | Embedding dimension override |
 | `embeddingNormalize` | boolean | — | Enable embedding normalization |

--- a/docs/install.md
+++ b/docs/install.md
@@ -174,6 +174,13 @@ export LIBRAVDB_ONNX_RUNTIME=/home/node/.openclaw/libravdbd/models/onnxruntime/l
 export LIBRAVDB_EMBEDDING_MODEL=/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5
 export LIBRAVDB_ONNX_DEVICE=cpu
 libravdbd serve &
+
+# Wait for socket to be ready
+for i in {1..30}; do
+  [ -S "$LIBRAVDB_GRPC_ENDPOINT" ] && break
+  sleep 0.5
+done
+
 node dist/index.js gateway --bind lan --port 18789
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,7 +37,8 @@ openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 ```
 
 If you use the OpenClaw.ai plugin UI instead of the CLI, install the same
-package and then assign the plugin id `libravdb-memory` to the `memory` slot.
+package and then assign the plugin id `libravdb-memory` to the `memory` and
+`contextEngine` slots.
 
 Activate the plugin in `~/.openclaw/openclaw.json`:
 
@@ -45,7 +46,8 @@ Activate the plugin in `~/.openclaw/openclaw.json`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     }
   }
 }
@@ -57,7 +59,8 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -73,7 +76,7 @@ If you run the daemon on a non-default endpoint, add a plugin config:
 
 When `sidecarPath` is set to `"auto"`, the plugin resolves endpoints in this order on macOS/Linux:
 
-1. `LIBRAVDB_RPC_ENDPOINT` if it is set to a valid daemon endpoint
+1. `LIBRAVDB_GRPC_ENDPOINT` if it is set to a valid daemon endpoint
 2. `$HOME/.libravdbd/run/libravdb.sock` if it exists
 3. `/opt/homebrew/var/libravdbd/run/libravdb.sock` if it exists
 4. `/usr/local/var/libravdbd/run/libravdb.sock` if it exists
@@ -81,7 +84,7 @@ When `sidecarPath` is set to `"auto"`, the plugin resolves endpoints in this ord
 
 ## Sidecar Daemon Install
 
-The daemon owns the local database, embeddings, and JSON-RPC endpoint.
+The daemon owns the local database, embeddings, and gRPC endpoint.
 
 Default endpoints:
 
@@ -155,12 +158,61 @@ libravdbd serve
 That mode is useful for debugging or validating a local release asset before
 you wrap it in `brew services`, `systemd`, or `launchd`.
 
+### Containers and Docker
+
+The npm plugin does not start `libravdbd`. In a container, either run a separate
+daemon sidecar or use a small entrypoint wrapper that starts the daemon before
+the OpenClaw gateway.
+
+Keep the daemon assets and database in a mounted volume and point both the
+daemon and plugin at paths inside the container:
+
+```sh
+export LIBRAVDB_GRPC_ENDPOINT=unix:/home/node/.openclaw/libravdbd/run/libravdb.sock
+export LIBRAVDB_DB_PATH=/home/node/.openclaw/libravdbd/data.libravdb
+export LIBRAVDB_ONNX_RUNTIME=/home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so
+export LIBRAVDB_EMBEDDING_MODEL=/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5
+export LIBRAVDB_ONNX_DEVICE=cpu
+libravdbd serve &
+node dist/index.js gateway --bind lan --port 18789
+```
+
+Use matching plugin config:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    },
+    "entries": {
+      "libravdb-memory": {
+        "enabled": true,
+        "config": {
+          "sidecarPath": "unix:/home/node/.openclaw/libravdbd/run/libravdb.sock",
+          "embeddingBackend": "onnx-local",
+          "embeddingRuntimePath": "/home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so",
+          "embeddingModelPath": "/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5",
+          "onnxDevice": "cpu"
+        }
+      }
+    }
+  }
+}
+```
+
+For public bots, deny manual memory tools unless users are supposed to query the
+store directly. The context engine can still use LibraVDB for recall while
+`memory_search` and `memory_get` remain unavailable to channel users.
+
 ## Lifecycle Management
 
 ### Plugin Lifecycle
 
 - Install the package with `openclaw plugins install`.
-- Activate it by assigning `libravdb-memory` to the `memory` slot.
+- Activate it by assigning `libravdb-memory` to the `memory` and
+  `contextEngine` slots.
 - Update it with your normal OpenClaw plugin update flow.
 - Disable it by removing the slot assignment from `~/.openclaw/openclaw.json`.
 
@@ -185,7 +237,7 @@ openclaw memory status
 Healthy output should show that:
 
 - the daemon answered the local health check
-- the memory slot is active
+- the memory and context-engine slots are active
 - the plugin can read stored counts and runtime settings
 
 If OpenClaw cannot reach the daemon, verify the endpoint first:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,20 +60,22 @@ or run `libravdbd serve` in a terminal for validation.
 
 ## Activation
 
-Assign `libravdb-memory` to the OpenClaw memory slot:
+Assign `libravdb-memory` to the OpenClaw memory and context-engine slots:
 
 ```json
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     }
   }
 }
 ```
 
-The plugin registers both memory and context-engine capabilities at runtime;
-current OpenClaw config only needs the `memory` slot assignment.
+The memory slot owns `openclaw memory ...` and memory-runtime calls. The
+context-engine slot enables automatic bootstrap, ingest, after-turn, and recall
+hooks during sessions.
 
 If the daemon uses a non-default endpoint, add `sidecarPath`:
 
@@ -81,7 +83,8 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
 {
   "plugins": {
     "slots": {
-      "memory": "libravdb-memory"
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
     },
     "entries": {
       "libravdb-memory": {
@@ -97,7 +100,7 @@ If the daemon uses a non-default endpoint, add `sidecarPath`:
 
 When `sidecarPath` is `"auto"`, macOS/Linux endpoint resolution checks:
 
-1. `LIBRAVDB_RPC_ENDPOINT`
+1. `LIBRAVDB_GRPC_ENDPOINT`
 2. `$HOME/.libravdbd/run/libravdb.sock`
 3. `/opt/homebrew/var/libravdbd/run/libravdb.sock`
 4. `/usr/local/var/libravdbd/run/libravdb.sock`
@@ -116,6 +119,59 @@ Default data path:
 ```text
 $HOME/.libravdbd/data_nomic-embed-text-v1_5.libravdb
 ```
+
+## Container Layout
+
+In Docker, keep the daemon, model assets, socket, logs, and database in the
+same mounted OpenClaw state volume. A typical container-side layout is:
+
+```text
+/home/node/.openclaw/bin/libravdbd
+/home/node/.openclaw/libravdbd/run/libravdb.sock
+/home/node/.openclaw/libravdbd/data.libravdb
+/home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so
+/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5/embedding.json
+```
+
+Start the daemon with explicit local ONNX paths before starting the gateway:
+
+```sh
+LIBRAVDB_GRPC_ENDPOINT=unix:/home/node/.openclaw/libravdbd/run/libravdb.sock \
+LIBRAVDB_DB_PATH=/home/node/.openclaw/libravdbd/data.libravdb \
+LIBRAVDB_ONNX_RUNTIME=/home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so \
+LIBRAVDB_EMBEDDING_MODEL=/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5 \
+LIBRAVDB_ONNX_DEVICE=cpu \
+  /home/node/.openclaw/bin/libravdbd serve
+```
+
+Then configure the plugin with the same socket and asset paths:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "libravdb-memory",
+      "contextEngine": "libravdb-memory"
+    },
+    "entries": {
+      "libravdb-memory": {
+        "enabled": true,
+        "config": {
+          "sidecarPath": "unix:/home/node/.openclaw/libravdbd/run/libravdb.sock",
+          "embeddingBackend": "onnx-local",
+          "embeddingRuntimePath": "/home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so",
+          "embeddingModelPath": "/home/node/.openclaw/libravdbd/models/nomic-embed-text-v1.5",
+          "onnxDevice": "cpu"
+        }
+      }
+    }
+  }
+}
+```
+
+Do not let a container initialize a database with deterministic fallback
+embeddings and later switch the same file to ONNX embeddings. Move the fallback
+database aside first, then let the daemon create a fresh ONNX-backed store.
 
 ## Verification
 
@@ -157,6 +213,8 @@ Common causes:
 - `sidecarPath` points at the wrong endpoint
 - ONNX Runtime assets are missing or unpacked in the wrong place
 - a model asset failed checksum validation
+- `embeddingBackend` is set to `onnx-local` but `embeddingRuntimePath` or
+  `embeddingModelPath` is missing from plugin config
 
 Check the daemon first:
 
@@ -170,6 +228,15 @@ For foreground debugging:
 ```bash
 libravdbd serve
 ```
+
+### Deterministic fallback embeddings
+
+If daemon logs mention deterministic fallback mode, the daemon did not find the
+configured ONNX runtime or model manifest. Stop the daemon, set
+`LIBRAVDB_ONNX_RUNTIME` and `LIBRAVDB_EMBEDDING_MODEL`, confirm the model
+directory contains `embedding.json`, then restart. If a database was created
+while fallback mode was active, move that `.libravdb` file and its adjacent
+`.embedding.json` aside before starting with ONNX assets.
 
 ### Incompatible database or embedding profile
 
@@ -202,9 +269,10 @@ setup, or republish the release with corrected checksums.
 
 ### Default memory still appears active
 
-Confirm that `libravdb-memory` is assigned to `plugins.slots.memory`.
-Without that slot entry, OpenClaw's default memory path can continue to run in
-parallel.
+Confirm that `libravdb-memory` is assigned to both `plugins.slots.memory` and
+`plugins.slots.contextEngine`. Without the memory slot, OpenClaw's default
+memory path can continue to run in parallel. Without the context-engine slot,
+automatic session ingest and recall may not run.
 
 ### Lifecycle journal looks empty
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -19,21 +19,43 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "if": {
-      "properties": {
-        "embeddingBackend": {
-          "const": "remote"
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "embeddingBackend": {
+              "const": "remote"
+            }
+          },
+          "required": [
+            "embeddingBackend"
+          ]
+        },
+        "then": {
+          "required": [
+            "embeddingEndpoint"
+          ]
         }
       },
-      "required": [
-        "embeddingBackend"
-      ]
-    },
-    "then": {
-      "required": [
-        "embeddingEndpoint"
-      ]
-    },
+      {
+        "if": {
+          "properties": {
+            "embeddingBackend": {
+              "const": "onnx-local"
+            }
+          },
+          "required": [
+            "embeddingBackend"
+          ]
+        },
+        "then": {
+          "required": [
+            "embeddingRuntimePath",
+            "embeddingModelPath"
+          ]
+        }
+      }
+    ],
     "properties": {
       "dbPath": {
         "type": "string"
@@ -137,7 +159,8 @@
         "type": "number"
       },
       "embeddingRuntimePath": {
-        "type": "string"
+        "type": "string",
+        "description": "Path to the ONNX Runtime library visible to the daemon, for example /opt/homebrew/opt/libravdbd/models/onnxruntime/lib/libonnxruntime.dylib or /home/node/.openclaw/libravdbd/models/onnxruntime/lib/libonnxruntime.so."
       },
       "onnxDevice": {
         "type": "string",
@@ -171,7 +194,8 @@
         "default": "bge-small-en-v1.5"
       },
       "embeddingModelPath": {
-        "type": "string"
+        "type": "string",
+        "description": "Directory visible to the daemon containing embedding.json, model.onnx, and tokenizer.json for the selected embeddingProfile."
       },
       "embeddingTokenizerPath": {
         "type": "string"

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -1,6 +1,8 @@
 import { LibravDBClient } from "./libravdb-client.js";
 import type { LoggerLike, PluginConfig } from "./types.js";
 import { formatError } from "./format-error.js";
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
 
 export type ClientGetter = () => Promise<LibravDBClient>;
 export const DEFAULT_RPC_TIMEOUT_MS = 30000;
@@ -43,6 +45,37 @@ export function daemonProvisioningHint(): string {
   return "If you installed the npm package, install and start libravdbd separately; the package does not provision the daemon binary, ONNX Runtime, or model assets.";
 }
 
+export function validateEmbeddingConfig(cfg: PluginConfig): void {
+  if (cfg.embeddingBackend !== "onnx-local") {
+    return;
+  }
+
+  const runtimePath = cfg.embeddingRuntimePath?.trim();
+  const modelPath = cfg.embeddingModelPath?.trim();
+  if (!runtimePath || !modelPath) {
+    throw new Error(
+      `LibraVDB: embeddingBackend="onnx-local" requires embeddingRuntimePath and embeddingModelPath. ` +
+      `Start libravdbd with matching LIBRAVDB_ONNX_RUNTIME and LIBRAVDB_EMBEDDING_MODEL values.`,
+    );
+  }
+
+  if (!shouldValidateLocalEmbeddingPaths(cfg)) {
+    return;
+  }
+
+  if (!pathExistsAsFile(runtimePath)) {
+    throw new Error(
+      `LibraVDB: embeddingRuntimePath must point to a readable ONNX Runtime library: ${runtimePath}`,
+    );
+  }
+
+  if (!pathExistsAsDirectory(modelPath) || !pathExistsAsFile(path.join(modelPath, "embedding.json"))) {
+    throw new Error(
+      `LibraVDB: embeddingModelPath must point to a directory containing embedding.json: ${modelPath}`,
+    );
+  }
+}
+
 export function createPluginRuntime(
   cfg: PluginConfig,
   logger: LoggerLike = console,
@@ -59,6 +92,7 @@ export function createPluginRuntime(
     if (!started) {
       let client: LibravDBClient | undefined;
       started = (async () => {
+        validateEmbeddingConfig(cfg);
         validateTlsConfig(cfg, logger);
 
         client = new LibravDBClient({
@@ -133,6 +167,38 @@ export function createPluginRuntime(
       }
     },
   };
+}
+
+function shouldValidateLocalEmbeddingPaths(cfg: PluginConfig): boolean {
+  const endpoint = (cfg.grpcEndpoint || cfg.sidecarPath || "auto").trim();
+  if (!endpoint || endpoint === "auto" || endpoint.startsWith("unix:")) {
+    return true;
+  }
+  if (!endpoint.startsWith("tcp:")) {
+    return false;
+  }
+
+  const target = endpoint.slice("tcp:".length);
+  const host = target.startsWith("[")
+    ? target.slice(1, target.indexOf("]"))
+    : target.split(":")[0];
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+function pathExistsAsFile(filePath: string): boolean {
+  try {
+    return existsSync(filePath) && statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathExistsAsDirectory(dirPath: string): boolean {
+  try {
+    return existsSync(dirPath) && statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function validateTlsConfig(cfg: PluginConfig, logger: LoggerLike): void {

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -1,4 +1,4 @@
-import { LibravDBClient } from "./libravdb-client.js";
+import { LibravDBClient, resolveClientEndpoint } from "./libravdb-client.js";
 import type { LoggerLike, PluginConfig } from "./types.js";
 import { formatError } from "./format-error.js";
 import { existsSync, statSync } from "node:fs";
@@ -170,7 +170,8 @@ export function createPluginRuntime(
 }
 
 function shouldValidateLocalEmbeddingPaths(cfg: PluginConfig): boolean {
-  const endpoint = (cfg.grpcEndpoint || cfg.sidecarPath || "auto").trim();
+  // Resolve the same endpoint the client will use — respects LIBRAVDB_GRPC_ENDPOINT env var
+  const endpoint = resolveClientEndpoint(cfg.grpcEndpoint || cfg.sidecarPath).trim();
   if (!endpoint || endpoint === "auto" || endpoint.startsWith("unix:")) {
     return true;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface PluginConfig {
   crossSessionRecall?: boolean;
   useSessionRecallProjection?: boolean;
   useSessionSummarySearchExperiment?: boolean;
+  /** Path to the daemon-visible ONNX Runtime library.
+   * Required when embeddingBackend is "onnx-local". */
   embeddingRuntimePath?: string;
   /** Optional ONNX execution provider override passed through to libravdbd.
    *  Use "cpu" to bypass CoreML/MPS on Intel Macs or fragile GPU/NPU providers. */
@@ -23,6 +25,8 @@ export interface PluginConfig {
   embeddingBackend?: "bundled" | "onnx-local" | "custom-local" | "remote";
   embeddingProfile?: string;
   fallbackProfile?: string;
+  /** Path to a daemon-visible model directory containing embedding.json.
+   * Required when embeddingBackend is "onnx-local". */
   embeddingModelPath?: string;
   embeddingTokenizerPath?: string;
   embeddingDimensions?: number;

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -57,6 +57,33 @@ test("manifest schema includes runtime-consumed context tuning keys", async () =
   }
 });
 
+test("manifest schema requires explicit assets for onnx-local embedding setup", async () => {
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "openclaw.plugin.json"), "utf8"));
+  const allOf = manifest.configSchema.allOf as Array<{
+    if?: { properties?: Record<string, { const?: string }> };
+    then?: { required?: string[] };
+  }>;
+  const onnxLocalRule = allOf.find((rule) => rule.if?.properties?.embeddingBackend?.const === "onnx-local");
+
+  assert.ok(onnxLocalRule, "onnx-local config rule must exist");
+  assert.deepEqual(
+    onnxLocalRule.then?.required?.sort(),
+    ["embeddingModelPath", "embeddingRuntimePath"],
+  );
+});
+
+test("manifest schema requires a remote endpoint for remote embedding setup", async () => {
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "openclaw.plugin.json"), "utf8"));
+  const allOf = manifest.configSchema.allOf as Array<{
+    if?: { properties?: Record<string, { const?: string }> };
+    then?: { required?: string[] };
+  }>;
+  const remoteRule = allOf.find((rule) => rule.if?.properties?.embeddingBackend?.const === "remote");
+
+  assert.ok(remoteRule, "remote config rule must exist");
+  assert.deepEqual(remoteRule.then?.required, ["embeddingEndpoint"]);
+});
+
 test("source checklist invariants are present in host code", async () => {
   const indexTs = await readFile(path.join(repoRoot, "src/index.ts"), "utf8");
   const memoryProviderTs = await readFile(path.join(repoRoot, "src/memory-provider.ts"), "utf8");

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -172,7 +172,10 @@ test("close prevents RPC methods", async () => {
 });
 
 test("bootstrapHandshake wraps transport errors", async () => {
-  const client = new LibravDBClient({ secret: "test" });
+  const endpoint = process.platform === "win32"
+    ? "tcp:127.0.0.1:9"
+    : `unix:${path.join(tmpdir(), `libravdb-missing-${process.pid}-${Date.now()}.sock`)}`;
+  const client = new LibravDBClient({ endpoint, secret: "test", timeoutMs: 250 });
   await assert.rejects(client.bootstrapHandshake(), /LibraVDB: failed to handshake/);
 });
 

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { enrichStartupError, resolveStartupHealthTimeoutMs } from "../../src/plugin-runtime.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  enrichStartupError,
+  resolveStartupHealthTimeoutMs,
+  validateEmbeddingConfig,
+} from "../../src/plugin-runtime.js";
 
 test("enrichStartupError adds provisioning guidance for daemon startup failures", () => {
   const err = enrichStartupError("LibraVDB daemon failed health check", "embedder running in deterministic fallback mode");
@@ -19,4 +27,60 @@ test("resolveStartupHealthTimeoutMs uses the normal RPC timeout when it is highe
   assert.equal(resolveStartupHealthTimeoutMs({}), 30000);
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 5000 }), 5000);
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 1000 }), 2000);
+});
+
+test("validateEmbeddingConfig rejects onnx-local without explicit daemon asset paths", () => {
+  assert.throws(
+    () => validateEmbeddingConfig({ embeddingBackend: "onnx-local" }),
+    /embeddingBackend="onnx-local" requires embeddingRuntimePath and embeddingModelPath/,
+  );
+});
+
+test("validateEmbeddingConfig rejects missing local onnx-local model assets", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "libravdb-runtime-test-"));
+  try {
+    const runtimePath = path.join(tempDir, "libonnxruntime.so");
+    writeFileSync(runtimePath, "");
+
+    assert.throws(
+      () => validateEmbeddingConfig({
+        embeddingBackend: "onnx-local",
+        sidecarPath: "unix:/tmp/libravdb.sock",
+        embeddingRuntimePath: runtimePath,
+        embeddingModelPath: path.join(tempDir, "missing-model"),
+      }),
+      /embeddingModelPath must point to a directory containing embedding.json/,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("validateEmbeddingConfig skips filesystem checks for remote daemon endpoints", () => {
+  assert.doesNotThrow(() => validateEmbeddingConfig({
+    embeddingBackend: "onnx-local",
+    sidecarPath: "tcp:memory.internal:50051",
+    embeddingRuntimePath: "/daemon/only/libonnxruntime.so",
+    embeddingModelPath: "/daemon/only/nomic-embed-text-v1.5",
+  }));
+});
+
+test("validateEmbeddingConfig accepts complete local onnx-local asset paths", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "libravdb-runtime-test-"));
+  try {
+    const runtimePath = path.join(tempDir, "libonnxruntime.so");
+    const modelDir = path.join(tempDir, "nomic-embed-text-v1.5");
+    writeFileSync(runtimePath, "");
+    mkdirSync(modelDir, { recursive: true });
+    writeFileSync(path.join(modelDir, "embedding.json"), "{}", { flag: "wx" });
+
+    assert.doesNotThrow(() => validateEmbeddingConfig({
+      embeddingBackend: "onnx-local",
+      sidecarPath: "unix:/tmp/libravdb.sock",
+      embeddingRuntimePath: runtimePath,
+      embeddingModelPath: modelDir,
+    }));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- fail closed when `embeddingBackend: "onnx-local"` is configured without explicit daemon-visible ONNX runtime and model paths
- require `embeddingRuntimePath` and `embeddingModelPath` in the plugin schema for `onnx-local`, while preserving the remote endpoint requirement for `remote`
- document Docker/container setup with both `memory` and `contextEngine` slots, daemon env vars, and fallback-database recovery guidance
- make the transport-error unit test independent of any live default daemon on the developer machine

## Tests
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `npm run plugin:ci` (PASS; reports existing inspector follow-up: package dependency install required)
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js`
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local ONNX embedding backend with configurable runtime and model paths.
  * Plugin now requires assignment to both `memory` and `contextEngine` slots.

* **Documentation**
  * Updated installation and configuration guides with embedding backend options.
  * Added Docker/container deployment guidance with required environment variables.
  * Expanded troubleshooting section with configuration mismatch and fallback embedding scenarios.

* **Tests**
  * Added validation tests for embedding configuration schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->