### PR TITLE
fix: below-threshold early exit for direct compact

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1280,14 +1280,12 @@ export function buildContextEngineFactory(
       runtimeContext?: Record<string, unknown>;
       abortSignal?: AbortSignal;
     }) {
-      const rawTokenBudget = args.tokenBudget;
-      const rawCurrentTokenCount = args.currentTokenCount;
-      const tokenBudget = normalizeTokenBudget(
-        rawTokenBudget != null ? rawTokenBudget : readRuntimeNumber(args.runtimeContext, "tokenBudget"),
-      );
-      const currentTokenCount = normalizeCurrentTokenCount(
-        rawCurrentTokenCount != null ? rawCurrentTokenCount : readRuntimeNumber(args.runtimeContext, "currentTokenCount"),
-      );
+      const tokenBudget =
+        normalizeTokenBudget(args.tokenBudget) ??
+        normalizeTokenBudget(readRuntimeNumber(args.runtimeContext, "tokenBudget"));
+      const currentTokenCount =
+        normalizeCurrentTokenCount(args.currentTokenCount) ??
+        normalizeCurrentTokenCount(readRuntimeNumber(args.runtimeContext, "currentTokenCount"));
       const forceCompaction = args.force === true || isManualCompactionRequested(args.runtimeContext);
       const threshold = getDynamicCompactThreshold(tokenBudget);
       if (

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -267,6 +267,18 @@ function resolvePredictiveCompactionTarget(params: {
     : Math.max(1, currentTokenCount - 1);
 }
 
+function readRuntimeNumber(
+  runtimeContext: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = runtimeContext?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isManualCompactionRequested(runtimeContext: Record<string, unknown> | undefined): boolean {
+  return runtimeContext?.manualCompaction === true;
+}
+
 function logPredictiveCompactionAttempt(params: {
   logger: LoggerLike;
   phase: "assemble" | "afterTurn";
@@ -1264,8 +1276,43 @@ export function buildContextEngineFactory(
       targetSize?: number;
       tokenBudget?: number;
       currentTokenCount?: number;
+      compactionTarget?: "budget" | "threshold";
+      runtimeContext?: Record<string, unknown>;
+      abortSignal?: AbortSignal;
     }) {
-      return await runCompaction(args);
+      const tokenBudget = normalizeTokenBudget(
+        args.tokenBudget ?? readRuntimeNumber(args.runtimeContext, "tokenBudget"),
+      );
+      const currentTokenCount = normalizeCurrentTokenCount(
+        args.currentTokenCount ?? readRuntimeNumber(args.runtimeContext, "currentTokenCount"),
+      );
+      const forceCompaction = args.force === true || isManualCompactionRequested(args.runtimeContext);
+      const threshold = getDynamicCompactThreshold(tokenBudget);
+      if (
+        !forceCompaction &&
+        currentTokenCount != null &&
+        threshold != null &&
+        currentTokenCount < threshold
+      ) {
+        return {
+          ok: true,
+          compacted: false,
+          reason: "below threshold",
+          result: {
+            tokensBefore: currentTokenCount,
+            details: {
+              threshold,
+              targetTokens: args.compactionTarget === "threshold" ? threshold : tokenBudget,
+            },
+          },
+        };
+      }
+      return await runCompaction({
+        ...args,
+        force: forceCompaction || args.force,
+        ...(tokenBudget != null ? { tokenBudget } : {}),
+        ...(currentTokenCount != null ? { currentTokenCount } : {}),
+      });
     },
     async afterTurn(args: {
       sessionId: string;

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1280,11 +1280,13 @@ export function buildContextEngineFactory(
       runtimeContext?: Record<string, unknown>;
       abortSignal?: AbortSignal;
     }) {
+      const rawTokenBudget = args.tokenBudget;
+      const rawCurrentTokenCount = args.currentTokenCount;
       const tokenBudget = normalizeTokenBudget(
-        args.tokenBudget ?? readRuntimeNumber(args.runtimeContext, "tokenBudget"),
+        rawTokenBudget != null ? rawTokenBudget : readRuntimeNumber(args.runtimeContext, "tokenBudget"),
       );
       const currentTokenCount = normalizeCurrentTokenCount(
-        args.currentTokenCount ?? readRuntimeNumber(args.runtimeContext, "currentTokenCount"),
+        rawCurrentTokenCount != null ? rawCurrentTokenCount : readRuntimeNumber(args.runtimeContext, "currentTokenCount"),
       );
       const forceCompaction = args.force === true || isManualCompactionRequested(args.runtimeContext);
       const threshold = getDynamicCompactThreshold(tokenBudget);
@@ -1307,12 +1309,16 @@ export function buildContextEngineFactory(
           },
         };
       }
-      return await runCompaction({
+      const runArgs: Parameters<typeof runCompaction>[0] = {
         ...args,
         force: forceCompaction || args.force,
         ...(tokenBudget != null ? { tokenBudget } : {}),
         ...(currentTokenCount != null ? { currentTokenCount } : {}),
-      });
+        ...(args.compactionTarget === "threshold" && threshold != null
+          ? { targetSize: threshold }
+          : {}),
+      };
+      return await runCompaction(runArgs);
     },
     async afterTurn(args: {
       sessionId: string;

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -148,6 +148,68 @@ test("context engine direct compact honors forced compaction below threshold", a
   assert.match(result.reason ?? "", /client unavailable/);
 });
 
+test("context engine direct compact via runtimeContext short-circuits below threshold without acquiring client", async () => {
+  let clientCalls = 0;
+  const runtime: PluginRuntime = {
+    getClient: async () => {
+      clientCalls += 1;
+      throw new Error("client should not be acquired");
+    },
+    emitLifecycleHint: async () => {},
+    onShutdown: async () => {},
+    shutdown: async () => {},
+  };
+  const engine = buildContextEngineFactory(runtime, {
+    userId: "fixed-user",
+    compactionThresholdFraction: 0.8,
+  });
+
+  // Omit top-level tokenBudget/currentTokenCount — drive entirely through runtimeContext
+  const result = await engine.compact({
+    sessionId: "s1",
+    runtimeContext: {
+      tokenBudget: 200_000,
+      currentTokenCount: 57_000,
+      manualCompaction: false,
+    },
+  });
+
+  assert.equal(clientCalls, 0, "runtime.getClient must not be called");
+  assert.equal(result.ok, true);
+  assert.equal(result.compacted, false);
+  assert.equal(result.reason, "below threshold");
+  assert.equal(result.result?.tokensBefore, 57_000);
+});
+
+test("context engine direct compact via runtimeContext.manualCompaction honors forced compaction below threshold", async () => {
+  const runtime: PluginRuntime = {
+    getClient: async () => {
+      throw new Error("client unavailable");
+    },
+    emitLifecycleHint: async () => {},
+    onShutdown: async () => {},
+    shutdown: async () => {},
+  };
+  const engine = buildContextEngineFactory(runtime, {
+    userId: "fixed-user",
+    compactionThresholdFraction: 0.8,
+  });
+
+  // Omit top-level force — use runtimeContext.manualCompaction to force the path
+  const result = await engine.compact({
+    sessionId: "s1",
+    runtimeContext: {
+      tokenBudget: 200_000,
+      currentTokenCount: 57_000,
+      manualCompaction: true,
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.compacted, false);
+  assert.match(result.reason ?? "", /client unavailable/);
+});
+
 function makeMessage(role: string, content: string, id?: string) {
   return { role, content, ...(id ? { id } : {}) };
 }

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -93,6 +93,61 @@ test("context engine returns compact failure instead of throwing when client is 
   assert.match(result.reason ?? "", /client unavailable/);
 });
 
+test("context engine direct compact declines below threshold without acquiring client", async () => {
+  let clientCalls = 0;
+  const runtime: PluginRuntime = {
+    getClient: async () => {
+      clientCalls += 1;
+      throw new Error("client should not be acquired");
+    },
+    emitLifecycleHint: async () => {},
+    onShutdown: async () => {},
+    shutdown: async () => {},
+  };
+  const engine = buildContextEngineFactory(runtime, {
+    userId: "fixed-user",
+    compactionThresholdFraction: 0.8,
+  });
+
+  const result = await engine.compact({
+    sessionId: "s1",
+    tokenBudget: 200_000,
+    currentTokenCount: 57_000,
+  });
+
+  assert.equal(clientCalls, 0);
+  assert.equal(result.ok, true);
+  assert.equal(result.compacted, false);
+  assert.equal(result.reason, "below threshold");
+  assert.equal(result.result?.tokensBefore, 57_000);
+});
+
+test("context engine direct compact honors forced compaction below threshold", async () => {
+  const runtime: PluginRuntime = {
+    getClient: async () => {
+      throw new Error("client unavailable");
+    },
+    emitLifecycleHint: async () => {},
+    onShutdown: async () => {},
+    shutdown: async () => {},
+  };
+  const engine = buildContextEngineFactory(runtime, {
+    userId: "fixed-user",
+    compactionThresholdFraction: 0.8,
+  });
+
+  const result = await engine.compact({
+    sessionId: "s1",
+    tokenBudget: 200_000,
+    currentTokenCount: 57_000,
+    force: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.compacted, false);
+  assert.match(result.reason ?? "", /client unavailable/);
+});
+
 function makeMessage(role: string, content: string, id?: string) {
   return { role, content, ...(id ? { id } : {}) };
 }

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -210,6 +210,41 @@ test("context engine direct compact via runtimeContext.manualCompaction honors f
   assert.match(result.reason ?? "", /client unavailable/);
 });
 
+test("context engine direct compact falls back to runtimeContext on sentinel top-level values", async () => {
+  let clientCalls = 0;
+  const runtime: PluginRuntime = {
+    getClient: async () => {
+      clientCalls += 1;
+      throw new Error("client should not be acquired");
+    },
+    emitLifecycleHint: async () => {},
+    onShutdown: async () => {},
+    shutdown: async () => {},
+  };
+  const engine = buildContextEngineFactory(runtime, {
+    userId: "fixed-user",
+    compactionThresholdFraction: 0.8,
+  });
+
+  // Sentinel top-level values must not block fallback to valid runtimeContext
+  const result = await engine.compact({
+    sessionId: "s1",
+    tokenBudget: 0,
+    currentTokenCount: Number.NaN,
+    runtimeContext: {
+      tokenBudget: 200_000,
+      currentTokenCount: 57_000,
+      manualCompaction: false,
+    },
+  });
+
+  assert.equal(clientCalls, 0, "runtime.getClient must not be called");
+  assert.equal(result.ok, true);
+  assert.equal(result.compacted, false);
+  assert.equal(result.reason, "below threshold");
+  assert.equal(result.result?.tokensBefore, 57_000);
+});
+
 function makeMessage(role: string, content: string, id?: string) {
   return { role, content, ...(id ? { id } : {}) };
 }


### PR DESCRIPTION
## Summary
- Add early exit to `directCompact` when `currentTokenCount < threshold` (non-forced paths)
- Return `{ ok: true, compacted: false, reason: "below threshold" }` instead of attempting daemon call
- `tokenBudget` and `currentTokenCount` read from args or `runtimeContext`
- `force: true` and `runtimeContext.manualCompaction === true` bypass the check and attempt daemon path

## Test plan
- [ ] 57k/200k below-threshold no-op without acquiring daemon client
- [ ] Forced below-threshold compact still attempts daemon/client path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compaction now intelligently optimizes token usage with threshold-based processing that skips unnecessary work when token count is below the configured threshold.
  * Added support for manual compaction request detection and handling.
  * Enhanced diagnostic reporting with threshold and target token details when compaction is skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->