### PR TITLE
Add LibraVDB autoreview skill

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -16,6 +16,9 @@
       "memory"
     ]
   },
+  "skills": [
+    "./skills"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "openclaw.plugin.json",
     "package.json",
     "docs/",
+    "skills/",
     "dist/"
   ],
   "engines": {

--- a/skills/libravdb-autoreview/SKILL.md
+++ b/skills/libravdb-autoreview/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: libravdb-autoreview
+description: Use when closing out review or PR readiness work in the LibraVDB OpenClaw memory plugin, including Codex review target selection, focused plugin tests, plugin-inspector checks, package contents, and real OpenClaw host proof.
+---
+
+# LibraVDB Autoreview
+
+Use this workflow after non-trivial edits to the LibraVDB OpenClaw memory plugin, before calling a branch PR-ready, pushing, or shipping.
+
+## Ground Rules
+
+- Start with `git status -sb`; preserve unrelated local changes.
+- Prefer native Codex review. Treat findings as advisory and verify each one in the real code path before changing anything.
+- Reject speculative edge cases, broad rewrites, and changes that move behavior out of the plugin ownership boundary without a concrete bug.
+- If a review-triggered fix changes code, rerun the focused proof and rerun review. Stop when the final review has no accepted/actionable findings.
+- Do not push, comment, or open/update a PR unless the user asked for that.
+
+## Pick The Review Target
+
+Dirty local work:
+
+```bash
+codex review --uncommitted
+```
+
+Use this only when the patch being reviewed is actually in the local worktree. A clean `--uncommitted` review only proves there is no local diff.
+
+Branch or PR work:
+
+```bash
+git fetch origin
+codex review --base origin/main
+```
+
+If an open PR exists, use its real base:
+
+```bash
+base=$(gh pr view --json baseRefName --jq .baseRefName)
+codex review --base "origin/$base"
+```
+
+Already committed single-change work:
+
+```bash
+codex review --commit HEAD
+```
+
+Do not pass a custom prompt with `--base`, `--commit`, or `--uncommitted`; target review modes generate the native Codex review prompt.
+
+## Focused Proof
+
+For manifest, packaging, skill, and package-content changes:
+
+```bash
+./node_modules/.bin/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
+./node_modules/.bin/tsc -p tsconfig.tests.json
+node --test .ts-build/test/integration/checklist-validation.test.js
+npm pack --dry-run --json
+```
+
+For narrow TypeScript/runtime changes, prefer the smallest direct proof:
+
+```bash
+./node_modules/.bin/tsc -p tsconfig.tests.json
+node --test .ts-build/test/unit/<file>.test.js
+node --test .ts-build/test/integration/<file>.test.js
+```
+
+If `pnpm` trips package-manager policy or build-gate prompts, use direct local binaries when that proves the touched surface. Escalate to full `pnpm run check` only when package scripts, dependency graph, generated output, or broad behavior changed and the checkout is healthy.
+
+## Real Host Proof
+
+Mock inspector proof does not prove the plugin loads in a real OpenClaw host. When the question is whether LibraVDB works in OpenClaw, add host-backed proof:
+
+```bash
+plugin-inspector ci --openclaw "$(command -v openclaw)" --runtime --real-sdk --allow-execute
+openclaw plugins doctor
+openclaw memory status --json
+openclaw memory search --json memory
+```
+
+For daemon, install/update, cross-OS, large reindex, or live gateway behavior, use a real host or remote test box and report the run id or exact runtime evidence. Keep the distinction between repo-only checks, mock inspector checks, and real OpenClaw-backed checks explicit.
+
+## Closeout
+
+Report:
+
+- review command used
+- proof commands run
+- accepted fixes and rejected findings, with short reasons
+- the final clean review result or the remaining consciously rejected finding

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -14,9 +14,10 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.equal(manifest.configSchema.additionalProperties, false);
   assert.deepEqual(
     Object.keys(manifest).sort(),
-    ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "version"],
+    ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "skills", "version"],
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
+  assert.deepEqual(manifest.skills, ["./skills"]);
   assert.equal(manifest.version, pkg.version);
 
   assert.equal(pkg.main, "./dist/index.js");
@@ -25,7 +26,21 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.ok(pkg.openclaw.extensions.includes("./dist/index.js"));
   assert.equal(pkg.exports["."].import, "./dist/index.js");
   assert.ok(pkg.files.includes("cli-metadata.js"));
+  assert.ok(pkg.files.includes("skills/"));
   assert.match(hookMd, /name:\s*libravdb-memory/);
+});
+
+test("bundled review skill is packaged for plugin installs", async () => {
+  const skillMd = await readFile(
+    path.join(repoRoot, "skills/libravdb-autoreview/SKILL.md"),
+    "utf8",
+  );
+
+  assert.match(skillMd, /^---\nname:\s*libravdb-autoreview/m);
+  assert.match(skillMd, /description:\s*Use when closing out review or PR readiness work/m);
+  assert.match(skillMd, /codex review --base origin\/main/);
+  assert.match(skillMd, /plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute/);
+  assert.match(skillMd, /--real-sdk/);
 });
 
 test("manifest schema includes runtime-consumed context tuning keys", async () => {


### PR DESCRIPTION
## Summary
- Add a bundled `libravdb-autoreview` skill with a distilled closeout workflow for LibraVDB plugin review and PR readiness.
- Advertise `./skills` from `openclaw.plugin.json` and include `skills/` in the npm package file list.
- Extend checklist validation so manifest/package wiring and the skill contents stay covered.

## Verification
- `./node_modules/.bin/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute` — PASS; still reports the existing P2 `package-dependency-install-required` inspector gap for isolated dependency install.
- `./node_modules/.bin/tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js` — PASS, 4/4 tests.
- `npm pack --dry-run --json` — PASS; package contents include `skills/libravdb-autoreview/SKILL.md`.
- `git diff --check -- openclaw.plugin.json package.json test/integration/checklist-validation.test.ts skills/libravdb-autoreview/SKILL.md` — PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a skills framework for the plugin.
  * Added an autoreview skill with integrated validation workflow.

* **Chores**
  * Updated package configuration to include the skills directory in published artifacts.

* **Tests**
  * Updated integration tests to validate the new skills configuration and packaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->