### PR TITLE
Register LibraVDB memory tools

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -9,7 +9,11 @@
   ],
   "contracts": {
     "memory": true,
-    "contextEngine": true
+    "contextEngine": true,
+    "tools": [
+      "memory_search",
+      "memory_get"
+    ]
   },
   "activation": {
     "onCommands": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ export function register(api: OpenClawPluginApi) {
     : createPluginRuntime(cfg, logger);
   registerMemoryCli(api, runtimeOrNull, cfg, logger);
 
-  if (runtimeOrNull) {
+  const ownsMemorySlot = memSlot === MEMORY_ID;
+  if (runtimeOrNull && ownsMemorySlot) {
     const memoryTools = createLibraVdbMemoryTools(runtimeOrNull.getClient, cfg, logger);
     api.registerTool?.((ctx) => memoryTools.createSearchTool(ctx), { names: ["memory_search"] });
     api.registerTool?.((ctx) => memoryTools.createGetTool(ctx), { names: ["memory_get"] });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createDreamPromotionHandle } from "./dream-promotion.js";
 import { createMarkdownIngestionHandle } from "./markdown-ingest.js";
 import { buildMemoryPromptSection } from "./memory-provider.js";
 import { buildMemoryRuntimeBridge } from "./memory-runtime.js";
+import { createLibraVdbMemoryTools } from "./memory-tools.js";
 import { createPluginRuntime } from "./plugin-runtime.js";
 import type { PluginConfig } from "./types.js";
 
@@ -67,6 +68,12 @@ export function register(api: OpenClawPluginApi) {
     ? null
     : createPluginRuntime(cfg, logger);
   registerMemoryCli(api, runtimeOrNull, cfg, logger);
+
+  if (runtimeOrNull) {
+    const memoryTools = createLibraVdbMemoryTools(runtimeOrNull.getClient, cfg, logger);
+    api.registerTool?.((ctx) => memoryTools.createSearchTool(ctx), { names: ["memory_search"] });
+    api.registerTool?.((ctx) => memoryTools.createGetTool(ctx), { names: ["memory_get"] });
+  }
 
   if (isLightweight || isDiscovery) {
     if (!isLightweight) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type { PluginConfig } from "./types.js";
 export const MEMORY_ID = "libravdb-memory";
 
 const LIGHTWEIGHT_MODES = new Set(["cli-metadata", "setup-only"]);
-const RUNTIME_CLEANUP_SHUTDOWN_REASONS = new Set(["delete", "restart"]);
+const RUNTIME_CLEANUP_SHUTDOWN_REASONS = new Set(["delete"]);
 
 export function shouldShutdownRuntimeForLifecycleCleanup(reason: string): boolean {
   return RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason);

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -16,6 +16,8 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
   const lines = [
     "For explicit memory lookup requests, call `memory_search` first.",
     "Use it for prior turns, remembered facts, earliest interactions, and channel history.",
+    "Do not answer memory lookup requests from prior transcript claims or earlier `memory_search` results; perform a fresh `memory_search` for the current request.",
+    "For earliest or oldest memory questions, request enough results, compare timestamps in the returned snippets, and use `memory_get` if the snippet is not enough.",
   ];
   if (availableTools.has("memory_get")) {
     lines.push("After a `memory_search` hit, call `memory_get` when exact wording or more context is needed.");

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -9,16 +9,34 @@ const MEMORY_PROMPT_HEADER = [
   "",
 ] as const;
 
+function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): string[] {
+  if (!availableTools?.has("memory_search")) {
+    return [];
+  }
+  const lines = [
+    "For explicit memory lookup requests, call `memory_search` first.",
+    "Use it for prior turns, remembered facts, earliest interactions, and channel history.",
+  ];
+  if (availableTools.has("memory_get")) {
+    lines.push("After a `memory_search` hit, call `memory_get` when exact wording or more context is needed.");
+  }
+  lines.push(
+    "Do not treat a missing `MEMORY.md` file as missing memory; LibraVDB memory is vector-backed and retrieved through the memory tools.",
+    "",
+  );
+  return lines;
+}
+
 export function buildMemoryPromptSection(
   _getClient: ClientGetter,
   _cfg: PluginConfig,
 ): MemoryPromptSectionBuilder {
   return function memoryPromptSection({
-    availableTools: _availableTools,
+    availableTools,
     citationsMode: _citationsMode,
   }): string[] {
     // OpenClaw builds the memory prompt section synchronously for embedded runs.
     // Actual retrieval and ranking happen in the context engine during assemble().
-    return [...MEMORY_PROMPT_HEADER];
+    return [...MEMORY_PROMPT_HEADER, ...buildToolGuidance(availableTools)];
   };
 }

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -125,9 +125,11 @@ function createMemorySearchManager(
 
       const legacyResults = filteredResults.map((item) => {
         const meta = parseMetadataJson(item);
+        const text = resolveSearchResultText(item, meta);
         return {
           ...item,
-          content: item.text || (typeof meta.text === "string" ? meta.text : ""),
+          text,
+          content: text,
         };
       });
       if (legacyCall) {
@@ -136,10 +138,10 @@ function createMemorySearchManager(
       const memoryResults = filteredResults.map((item) => {
         const meta = parseMetadataJson(item);
         const collection = typeof meta.collection === "string" ? meta.collection : "memory";
-        const effectiveText = item.text || (typeof meta.text === "string" ? meta.text : "") || "";
         const relPath = encodeSearchResultPath(collection, item.id);
-        returnedSearchPaths.set(relPath, effectiveText);
-        return toMemorySearchResult(item);
+        const text = resolveSearchResultText(item, meta);
+        returnedSearchPaths.set(relPath, text);
+        return toMemorySearchResult(item, meta, text);
       });
       return memoryResults;
     },
@@ -258,16 +260,28 @@ function parseMetadataJson(item: { metadataJson?: Uint8Array }): Record<string, 
   return {};
 }
 
-function toMemorySearchResult(item: ProtoSearchResult) {
-  const meta = parseMetadataJson(item);
+function resolveSearchResultText(
+  item: ProtoSearchResult,
+  meta: Record<string, unknown> = parseMetadataJson(item),
+): string {
+  if (typeof item.text === "string" && item.text.length > 0) {
+    return item.text;
+  }
+  return typeof meta.text === "string" ? meta.text : item.text;
+}
+
+function toMemorySearchResult(
+  item: ProtoSearchResult,
+  meta: Record<string, unknown> = parseMetadataJson(item),
+  text = resolveSearchResultText(item, meta),
+) {
   const collection = typeof meta.collection === "string" ? meta.collection : "memory";
-  const effectiveText = item.text || (typeof meta.text === "string" ? meta.text : "") || "";
   return {
     path: encodeSearchResultPath(collection, item.id),
     startLine: 1,
-    endLine: Math.max(1, effectiveText.split("\n").length),
+    endLine: Math.max(1, text.split("\n").length),
     score: item.score,
-    snippet: effectiveText,
+    snippet: text,
     source: collection.startsWith("session:") || collection.startsWith("session_") ? "sessions" : "memory",
     citation: `${collection}:${item.id}`,
   };

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -16,6 +16,7 @@ type MemorySearchParams = {
   maxResults?: number;
   minScore?: number;
   topK?: number;
+  corpus?: "all" | "memory" | "sessions";
   userId?: string;
   agentId?: string;
   sessionId?: string;
@@ -83,6 +84,7 @@ function createMemorySearchManager(
             query: queryOrParams,
             limit: opts.limit ?? opts.k ?? opts.maxResults ?? opts.topK,
             minScore: opts.minScore,
+            corpus: opts.corpus,
             sessionId: opts.sessionId,
             sessionKey: opts.sessionKey,
             userId: opts.userId,
@@ -96,6 +98,7 @@ function createMemorySearchManager(
       }
 
       const dreamQuery = detectDreamQuerySignal(queryText);
+      const searchCorpus = normalizeSearchCorpus(params.corpus);
       const sessionId = firstString(params.sessionId, params.context?.sessionId);
       const explicitUserId = firstString(params.userId, params.context?.userId);
       const resolvedUserId =
@@ -111,13 +114,13 @@ function createMemorySearchManager(
       const minScore = normalizeNumber(params.minScore);
       const client = await getClient();
 
-      const result = dreamQuery.active && cfg.crossSessionRecall !== false
+      const result = dreamQuery.active && cfg.crossSessionRecall !== false && searchCorpus !== "sessions"
         ? await client.searchText({
             collection: resolveDreamCollection(userId),
             text: queryText,
             k,
           })
-        : await searchResolvedCollections(client, cfg, userId, sessionId, queryText, k);
+        : await searchResolvedCollections(client, cfg, userId, sessionId, queryText, k, searchCorpus);
       const filteredResults =
         minScore === undefined
           ? result.results
@@ -193,8 +196,9 @@ async function searchResolvedCollections(
   sessionId: string | undefined,
   queryText: string,
   k: number,
+  corpus: "all" | "memory" | "sessions",
 ): Promise<{ results: ProtoSearchResult[] }> {
-  const collections = resolveSearchCollections(cfg, userId, sessionId);
+  const collections = resolveSearchCollections(cfg, userId, sessionId, corpus);
   if (collections.length === 0) {
     return { results: [] };
   }
@@ -212,18 +216,30 @@ async function searchResolvedCollections(
       });
 }
 
-function resolveSearchCollections(cfg: PluginConfig, userId: string, sessionId?: string): string[] {
+function resolveSearchCollections(
+  cfg: PluginConfig,
+  userId: string,
+  sessionId: string | undefined,
+  corpus: "all" | "memory" | "sessions",
+): string[] {
+  if (corpus === "sessions") {
+    return sessionId ? [resolveSessionSearchCollection(cfg, sessionId)] : [];
+  }
+
+  const durableCollections = [resolveUserCollection(userId), "global"];
+  if (corpus === "memory") {
+    return durableCollections;
+  }
+
   if (cfg.crossSessionRecall === false) {
     return sessionId ? [resolveSessionSearchCollection(cfg, sessionId)] : [];
   }
 
-  const collections = [resolveUserCollection(userId), "global"];
   if (!sessionId) {
-    return collections;
+    return durableCollections;
   }
 
-  collections.unshift(resolveSessionSearchCollection(cfg, sessionId));
-  return collections;
+  return [resolveSessionSearchCollection(cfg, sessionId), ...durableCollections];
 }
 
 function resolveSessionSearchCollection(cfg: PluginConfig, sessionId: string): string {
@@ -247,6 +263,10 @@ function firstString(...values: Array<string | undefined>): string | undefined {
     }
   }
   return undefined;
+}
+
+function normalizeSearchCorpus(value: unknown): "all" | "memory" | "sessions" {
+  return value === "memory" || value === "sessions" ? value : "all";
 }
 
 function parseMetadataJson(item: { metadataJson?: Uint8Array }): Record<string, unknown> {

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -146,7 +146,7 @@ export function createLibraVdbMemoryTools(
         name: "memory_search",
         label: "Memory Search",
         description:
-          "Mandatory LibraVDB recall step: semantically search durable memory and session recall before answering questions about prior work, decisions, dates, people, preferences, todos, or history. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+          "Mandatory fresh LibraVDB recall step: semantically search durable memory and session recall before answering questions about prior work, decisions, dates, people, preferences, todos, or history. Do not reuse prior transcript claims or older memory_search results for a new memory lookup. For earliest/oldest questions, request enough results and compare timestamps in snippets. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
         parameters: MEMORY_SEARCH_SCHEMA,
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -1,0 +1,334 @@
+import type { ClientGetter } from "./plugin-runtime.js";
+import { formatError } from "./format-error.js";
+import { buildMemoryRuntimeBridge } from "./memory-runtime.js";
+import type { LoggerLike, PluginConfig } from "./types.js";
+
+type MemoryRuntimeBridge = ReturnType<typeof buildMemoryRuntimeBridge>;
+type MemoryManagerContext = Awaited<ReturnType<MemoryRuntimeBridge["getMemorySearchManager"]>>;
+type MemorySearchManager = MemoryManagerContext["manager"];
+
+type MemoryToolContext = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+};
+
+type ToolContent = {
+  type: "text";
+  text: string;
+};
+
+type ToolResult<TDetails> = {
+  content: ToolContent[];
+  details: TDetails;
+};
+
+type AgentTool = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute(toolCallId: string, params: unknown): Promise<ToolResult<unknown>>;
+};
+
+type MemorySearchResult = {
+  path: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  snippet: string;
+  source: "memory" | "sessions" | string;
+  citation?: string;
+};
+
+type MemoryCorpus = "memory" | "wiki" | "all" | "sessions";
+
+type MemoryGetCorpus = "memory" | "wiki" | "all";
+
+type MemorySearchToolDetails = {
+  results: MemorySearchResult[];
+  provider?: unknown;
+  model?: unknown;
+  backend?: unknown;
+  disabled?: true;
+  error?: string;
+};
+
+type MemoryGetToolDetails = {
+  path: string;
+  text: string;
+  disabled?: true;
+  error?: string;
+};
+
+const MEMORY_SEARCH_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: {
+      type: "string",
+      description: "Semantic recall query for prior work, preferences, decisions, dates, people, todos, or session context.",
+    },
+    maxResults: {
+      type: "number",
+      minimum: 1,
+      maximum: 50,
+      description: "Maximum number of memory hits to return.",
+    },
+    minScore: {
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+      description: "Minimum similarity score for returned hits.",
+    },
+    corpus: {
+      type: "string",
+      enum: ["memory", "wiki", "all", "sessions"],
+      description: "Corpus filter. LibraVDB serves memory/session hits; wiki is unsupported unless another plugin owns wiki tools.",
+    },
+  },
+  required: ["query"],
+} as const;
+
+const MEMORY_GET_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    path: {
+      type: "string",
+      description: "A path returned by memory_search.",
+    },
+    from: {
+      type: "number",
+      minimum: 1,
+      description: "1-based starting line.",
+    },
+    lines: {
+      type: "number",
+      minimum: 1,
+      description: "Maximum number of lines to read.",
+    },
+    corpus: {
+      type: "string",
+      enum: ["memory", "wiki", "all"],
+      description: "Corpus filter. LibraVDB reads paths returned by memory_search.",
+    },
+  },
+  required: ["path"],
+} as const;
+
+export function createLibraVdbMemoryTools(
+  getClient: ClientGetter,
+  cfg: PluginConfig,
+  logger: LoggerLike = console,
+) {
+  const bridge = buildMemoryRuntimeBridge(getClient, cfg);
+  const managers = new Map<string, Promise<MemorySearchManager>>();
+
+  async function getManager(ctx: MemoryToolContext, purpose: string): Promise<MemorySearchManager> {
+    const key = managerCacheKey(ctx);
+    let manager = managers.get(key);
+    if (!manager) {
+      manager = bridge
+        .getMemorySearchManager({
+          agentId: normalizeOptionalString(ctx.agentId),
+          purpose,
+        })
+        .then((result) => result.manager);
+      managers.set(key, manager);
+    }
+    return await manager;
+  }
+
+  return {
+    createSearchTool(ctx: MemoryToolContext = {}): AgentTool {
+      return {
+        name: "memory_search",
+        label: "Memory Search",
+        description:
+          "Mandatory LibraVDB recall step: semantically search durable memory and session recall before answering questions about prior work, decisions, dates, people, preferences, todos, or history. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+        parameters: MEMORY_SEARCH_SCHEMA,
+        execute: async (_toolCallId, rawParams) => {
+          const params = asToolParamsRecord(rawParams);
+          const query = readRequiredStringParam(params, "query");
+          const corpus = readMemoryCorpus(params.corpus);
+          const maxResults = readNumberParam(params, "maxResults", { integer: true });
+          const minScore = readNumberParam(params, "minScore");
+
+          if (corpus === "wiki") {
+            return jsonToolResult<MemorySearchToolDetails>({
+              results: [],
+              disabled: true,
+              error: "LibraVDB memory_search does not provide the wiki corpus; use corpus=memory, corpus=sessions, or corpus=all.",
+            });
+          }
+
+          try {
+            const manager = await getManager(ctx, "tool-search");
+            const rawResults = await manager.search({
+              query,
+              ...(maxResults !== undefined ? { maxResults } : {}),
+              ...(minScore !== undefined ? { minScore } : {}),
+              ...buildSearchContext(ctx),
+            }) as MemorySearchResult[];
+            const results = filterResultsByCorpus(rawResults, corpus);
+            const status = manager.status();
+            return jsonToolResult<MemorySearchToolDetails>({
+              results,
+              provider: status.provider,
+              model: status.model,
+              backend: status.backend,
+            });
+          } catch (error) {
+            logger.warn?.(`LibraVDB memory_search failed: ${formatError(error)}`);
+            return jsonToolResult<MemorySearchToolDetails>({
+              results: [],
+              disabled: true,
+              error: formatError(error),
+            });
+          }
+        },
+      };
+    },
+    createGetTool(ctx: MemoryToolContext = {}): AgentTool {
+      return {
+        name: "memory_get",
+        label: "Memory Get",
+        description:
+          "Read a bounded exact excerpt from a LibraVDB memory path returned by memory_search. Use this after memory_search when a hit needs exact wording or more context.",
+        parameters: MEMORY_GET_SCHEMA,
+        execute: async (_toolCallId, rawParams) => {
+          const params = asToolParamsRecord(rawParams);
+          const relPath = readRequiredStringParam(params, "path");
+          const corpus = readMemoryGetCorpus(params.corpus);
+          const from = readNumberParam(params, "from", { integer: true });
+          const lines = readNumberParam(params, "lines", { integer: true });
+
+          if (corpus === "wiki") {
+            return jsonToolResult<MemoryGetToolDetails>({
+              path: relPath,
+              text: "",
+              disabled: true,
+              error: "LibraVDB memory_get does not provide the wiki corpus; use paths returned by LibraVDB memory_search.",
+            });
+          }
+
+          try {
+            const manager = await getManager(ctx, "tool-get");
+            const result = await manager.readFile({
+              relPath,
+              ...(from !== undefined ? { from } : {}),
+              ...(lines !== undefined ? { lines } : {}),
+            });
+            return jsonToolResult<MemoryGetToolDetails>(result);
+          } catch (error) {
+            logger.warn?.(`LibraVDB memory_get failed: ${formatError(error)}`);
+            return jsonToolResult<MemoryGetToolDetails>({
+              path: relPath,
+              text: "",
+              disabled: true,
+              error: formatError(error),
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+function buildSearchContext(ctx: MemoryToolContext) {
+  const agentId = normalizeOptionalString(ctx.agentId);
+  const sessionId = normalizeOptionalString(ctx.sessionId);
+  const sessionKey = normalizeOptionalString(ctx.sessionKey);
+  return {
+    ...(agentId ? { agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    context: {
+      ...(agentId ? { agentId } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(sessionKey ? { sessionKey } : {}),
+    },
+  };
+}
+
+function filterResultsByCorpus(results: MemorySearchResult[], corpus: MemoryCorpus): MemorySearchResult[] {
+  if (corpus === "sessions") {
+    return results.filter((result) => result.source === "sessions");
+  }
+  if (corpus === "memory") {
+    return results.filter((result) => result.source === "memory");
+  }
+  return results;
+}
+
+function managerCacheKey(ctx: MemoryToolContext): string {
+  return [
+    normalizeOptionalString(ctx.agentId) ?? "",
+    normalizeOptionalString(ctx.sessionId) ?? "",
+    normalizeOptionalString(ctx.sessionKey) ?? "",
+  ].join("\0");
+}
+
+function asToolParamsRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function readRequiredStringParam(params: Record<string, unknown>, key: string): string {
+  const value = normalizeOptionalString(params[key]);
+  if (!value) {
+    throw new Error(`memory tool requires ${key}`);
+  }
+  return value;
+}
+
+function readNumberParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { integer?: boolean } = {},
+): number | undefined {
+  const value = params[key];
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : undefined;
+  if (parsed === undefined || !Number.isFinite(parsed)) {
+    return undefined;
+  }
+  return options.integer ? Math.max(1, Math.floor(parsed)) : parsed;
+}
+
+function readMemoryCorpus(value: unknown): MemoryCorpus {
+  return value === "memory" || value === "wiki" || value === "all" || value === "sessions"
+    ? value
+    : "all";
+}
+
+function readMemoryGetCorpus(value: unknown): MemoryGetCorpus {
+  return value === "memory" || value === "wiki" || value === "all" ? value : "memory";
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function jsonToolResult<TDetails>(details: TDetails): ToolResult<TDetails> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(details, null, 2),
+      },
+    ],
+    details,
+  };
+}

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -134,7 +134,11 @@ export function createLibraVdbMemoryTools(
           agentId: normalizeOptionalString(ctx.agentId),
           purpose,
         })
-        .then((result) => result.manager);
+        .then((result) => result.manager)
+        .catch((error) => {
+          managers.delete(key);
+          throw error;
+        });
       managers.set(key, manager);
     }
     return await manager;
@@ -167,6 +171,7 @@ export function createLibraVdbMemoryTools(
             const manager = await getManager(ctx, "tool-search");
             const rawResults = await manager.search({
               query,
+              corpus,
               ...(maxResults !== undefined ? { maxResults } : {}),
               ...(minScore !== undefined ? { minScore } : {}),
               ...buildSearchContext(ctx),

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -55,6 +55,37 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
 
   type PluginRegistrationMode = string;
 
+  interface OpenClawPluginToolContext {
+    config?: OpenClawConfig;
+    runtimeConfig?: OpenClawConfig;
+    workspaceDir?: string;
+    agentDir?: string;
+    agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    sandboxed?: boolean;
+  }
+
+  interface OpenClawPluginToolResult {
+    content: Array<{
+      type: "text";
+      text: string;
+    }>;
+    details?: unknown;
+  }
+
+  interface OpenClawPluginTool {
+    name: string;
+    label?: string;
+    description: string;
+    parameters: unknown;
+    execute(toolCallId: string, params: unknown): OpenClawPluginToolResult | Promise<OpenClawPluginToolResult>;
+  }
+
+  type OpenClawPluginToolFactory = (
+    ctx: OpenClawPluginToolContext,
+  ) => OpenClawPluginTool | OpenClawPluginTool[] | null | undefined;
+
   export interface OpenClawPluginApi {
     id: string;
     name: string;
@@ -71,6 +102,14 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       info?(message: string): void;
       warn?(message: string): void;
     };
+    registerTool(
+      tool: OpenClawPluginTool | OpenClawPluginToolFactory,
+      opts?: {
+        name?: string;
+        names?: string[];
+        optional?: boolean;
+      },
+    ): void;
     registerContextEngine(id: string, factory: () => unknown): void;
     registerMemoryCapability(id: string, capability: {
       promptBuilder?: MemoryPromptSectionBuilder;

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -18,6 +18,7 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);
+  assert.deepEqual(manifest.contracts.tools, ["memory_search", "memory_get"]);
 
   assert.equal(pkg.main, "./dist/index.js");
   assert.equal(pkg.types, "./dist/index.d.ts");
@@ -94,6 +95,8 @@ test("source checklist invariants are present in host code", async () => {
   assert.match(indexTs, /export const MEMORY_ID = "libravdb-memory"/);
   assert.match(indexTs, /registerContextEngine\(\s*MEMORY_ID/s);
   assert.match(indexTs, /registerMemoryCapability\(MEMORY_ID/);
+  assert.match(indexTs, /registerTool\?\.\(\(ctx\) => memoryTools\.createSearchTool\(ctx\)/);
+  assert.match(indexTs, /registerTool\?\.\(\(ctx\) => memoryTools\.createGetTool\(ctx\)/);
   assert.match(indexTs, /api\.config\?\.plugins\?\.slots\?\.memory/);
   assert.match(indexTs, /api\.on\("before_reset"/);
   assert.match(indexTs, /api\.on\("session_end"/);

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -6,6 +6,12 @@ import path from "node:path";
 
 import { createMarkdownIngestionHandle } from "../../src/markdown-ingest.js";
 
+type FsDirentLike = {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+};
+
 class FakeRpcClient {
   calls: Array<{ method: string; params: unknown }> = [];
   documents = new Map<string, { text: string; tokenizerId: string; coreDoc: boolean; sourceMeta: Record<string, unknown> }>();

--- a/test/unit/memory-provider.test.ts
+++ b/test/unit/memory-provider.test.ts
@@ -51,7 +51,7 @@ test("memory prompt section stays synchronous and does not perform rpc lookups",
 
   const memorySection = buildMemoryPromptSection(getRpc, cfg);
   const result = memorySection({
-    availableTools: new Set(["memory_search"]),
+    availableTools: new Set(["memory_search", "memory_get"]),
   });
 
   assert.doesNotThrow(() => [...result], "host spreads the returned section immediately");
@@ -60,18 +60,21 @@ test("memory prompt section stays synchronous and does not perform rpc lookups",
   assert.equal(rpc.calls.get("search_text") ?? 0, 0, "should not perform search_text calls");
 });
 
-test("memory prompt section returns the static header even when messages exist", async () => {
+test("memory prompt section guides memory tool use when memory_search is available", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { topK: 8, alpha: 0.7, beta: 0.2, gamma: 0.1 };
   const getRpc = async () => rpc as never;
 
   const memorySection = buildMemoryPromptSection(getRpc, cfg);
   const result = memorySection({
-    availableTools: new Set(["memory_search"]),
+    availableTools: new Set(["memory_search", "memory_get"]),
   });
 
   const resultText = result.join("\n");
   assert.ok(resultText.includes("LibraVDB persistent memory is configured"), "should include memory header");
+  assert.ok(resultText.includes("call `memory_search` first"), "should guide explicit recall through memory_search");
+  assert.ok(resultText.includes("call `memory_get`"), "should guide exact recall through memory_get");
+  assert.ok(resultText.includes("missing `MEMORY.md` file"), "should prevent file-backed missing-memory fallback");
   assert.ok(!resultText.includes("recalled_memories"), "should not inject recalled memories directly");
   assert.ok(!resultText.includes("user recall") && !resultText.includes("global recall"), "should not render recall items");
   assert.equal(rpc.calls.get("search_text") ?? 0, 0, "should not perform search_text calls");

--- a/test/unit/memory-provider.test.ts
+++ b/test/unit/memory-provider.test.ts
@@ -73,6 +73,8 @@ test("memory prompt section guides memory tool use when memory_search is availab
   const resultText = result.join("\n");
   assert.ok(resultText.includes("LibraVDB persistent memory is configured"), "should include memory header");
   assert.ok(resultText.includes("call `memory_search` first"), "should guide explicit recall through memory_search");
+  assert.ok(resultText.includes("perform a fresh `memory_search`"), "should prevent stale transcript reuse");
+  assert.ok(resultText.includes("compare timestamps"), "should guide earliest-memory questions through timestamps");
   assert.ok(resultText.includes("call `memory_get`"), "should guide exact recall through memory_get");
   assert.ok(resultText.includes("missing `MEMORY.md` file"), "should prevent file-backed missing-memory fallback");
   assert.ok(!resultText.includes("recalled_memories"), "should not inject recalled memories directly");

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -170,6 +170,42 @@ test("memory runtime bridge keeps the legacy string search shape", async () => {
   assert.equal(result.results[0]?.content, "remembered item");
 });
 
+test("memory runtime bridge falls back to metadata text when search result text is blank", async () => {
+  const metadataText = "Conversation info\n\n@Spartacus earliest remembered channel turn";
+  const rpc = new FakeRpc();
+  rpc.searchTextCollections = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchTextCollections", params });
+    return {
+      results: [
+        {
+          id: "turn-1",
+          score: 0.88,
+          text: "",
+          metadata: { collection: "session:s1" },
+          metadataJson: new TextEncoder().encode(JSON.stringify({
+            collection: "session:s1",
+            text: metadataText,
+          })),
+        },
+      ],
+    };
+  };
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "earliest remembered channel turn", sessionId: "s1" }) as Array<{
+    path: string;
+    snippet: string;
+    source: string;
+  }>;
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.snippet, metadataText);
+  assert.equal(result[0]?.source, "sessions");
+
+  const loaded = await manager.readFile({ relPath: result[0]?.path ?? "", from: 1, lines: 20 });
+  assert.equal(loaded.text, metadataText);
+});
+
 test("memory runtime bridge does not authorize hidden paths from legacy search results", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});

--- a/test/unit/memory-tools.test.ts
+++ b/test/unit/memory-tools.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createLibraVdbMemoryTools } from "../../src/memory-tools.js";
+import type { PluginConfig } from "../../src/types.js";
+
+const silentLogger = {
+  error(_message: string) {},
+  warn(_message: string) {},
+  info(_message: string) {},
+};
+
+class FakeRpc {
+  public calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+  async status() {
+    this.calls.push({ method: "status", params: {} });
+    return {
+      ok: true,
+      message: "ok",
+      turnCount: 2,
+      memoryCount: 1,
+      embeddingProfile: "nomic-embed-text-v1.5",
+    };
+  }
+
+  async searchTextCollections(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchTextCollections", params });
+    const collections = params.collections as string[] | undefined;
+    const encoder = new TextEncoder();
+    return {
+      results: [
+        {
+          id: "m1",
+          score: 0.92,
+          text: "first interaction was in Discord",
+          metadataJson: encoder.encode(JSON.stringify({ collection: collections?.[0] ?? "user:u1" })),
+        },
+        {
+          id: "m2",
+          score: 0.82,
+          text: "durable project preference",
+          metadataJson: encoder.encode(JSON.stringify({ collection: collections?.[1] ?? "user:u1" })),
+        },
+      ],
+    };
+  }
+
+  async searchText(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchText", params });
+    const encoder = new TextEncoder();
+    return {
+      results: [
+        {
+          id: "m1",
+          score: 0.92,
+          text: "single collection result",
+          metadataJson: encoder.encode(JSON.stringify({ collection: String(params.collection) })),
+        },
+      ],
+    };
+  }
+}
+
+test("LibraVDB memory tools expose memory_search and memory_get through the runtime bridge", async () => {
+  const rpc = new FakeRpc();
+  const cfg: PluginConfig = { userId: "u1", topK: 4 };
+  const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
+  const ctx = { agentId: "spartacus", sessionId: "discord-session", sessionKey: "discord-key" };
+  const searchTool = tools.createSearchTool(ctx);
+  const getTool = tools.createGetTool(ctx);
+
+  assert.equal(searchTool.name, "memory_search");
+  assert.equal(getTool.name, "memory_get");
+
+  const search = await searchTool.execute("call-1", {
+    query: "earliest memory",
+    maxResults: 2,
+  });
+  const searchDetails = search.details as {
+    results: Array<{ path: string; snippet: string; source: string }>;
+    provider?: string;
+    model?: string;
+    backend?: string;
+  };
+
+  assert.equal(searchDetails.results.length, 2);
+  assert.equal(searchDetails.results[0]?.snippet, "first interaction was in Discord");
+  assert.equal(searchDetails.results[0]?.source, "sessions");
+  assert.equal(searchDetails.provider, "libravdb");
+  assert.equal(searchDetails.model, "nomic-embed-text-v1.5");
+  assert.equal(searchDetails.backend, "builtin");
+  assert.equal(rpc.calls[0]?.method, "status");
+  assert.equal(rpc.calls[1]?.method, "searchTextCollections");
+  assert.deepEqual(rpc.calls[1]?.params.collections, [
+    "session:discord-session",
+    "user:u1",
+    "global",
+  ]);
+
+  const get = await getTool.execute("call-2", {
+    path: searchDetails.results[0]?.path,
+    from: 1,
+    lines: 1,
+  });
+  assert.deepEqual(get.details, {
+    path: searchDetails.results[0]?.path,
+    text: "first interaction was in Discord",
+  });
+});
+
+test("LibraVDB memory_search supports sessions corpus filtering without memory-core", async () => {
+  const rpc = new FakeRpc();
+  const cfg: PluginConfig = { userId: "u1" };
+  const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
+  const searchTool = tools.createSearchTool({
+    agentId: "spartacus",
+    sessionId: "discord-session",
+    sessionKey: "discord-key",
+  });
+
+  const search = await searchTool.execute("call-1", {
+    query: "discord",
+    corpus: "sessions",
+  });
+  const details = search.details as { results: Array<{ source: string; snippet: string }> };
+
+  assert.deepEqual(
+    details.results.map((result) => result.source),
+    ["sessions"],
+  );
+  assert.equal(details.results[0]?.snippet, "first interaction was in Discord");
+});
+
+test("LibraVDB memory_get reports unknown paths as disabled instead of reading arbitrary files", async () => {
+  const rpc = new FakeRpc();
+  const tools = createLibraVdbMemoryTools(async () => rpc as never, { userId: "u1" }, silentLogger);
+  const getTool = tools.createGetTool({ agentId: "spartacus" });
+
+  const get = await getTool.execute("call-1", {
+    path: "user%3Au1::crafted",
+  });
+
+  assert.deepEqual(get.details, {
+    path: "user%3Au1::crafted",
+    text: "",
+    disabled: true,
+    error: "LibraVDB memory path was not returned by this search manager",
+  });
+});

--- a/test/unit/memory-tools.test.ts
+++ b/test/unit/memory-tools.test.ts
@@ -62,6 +62,38 @@ class FakeRpc {
   }
 }
 
+class CorpusPriorityRpc extends FakeRpc {
+  override async searchTextCollections(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchTextCollections", params });
+    const encoder = new TextEncoder();
+    return {
+      results: [
+        {
+          id: "durable-top",
+          score: 0.99,
+          text: "durable memory outranks the session hit",
+          metadataJson: encoder.encode(JSON.stringify({ collection: "user:u1" })),
+        },
+      ],
+    };
+  }
+
+  override async searchText(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchText", params });
+    const encoder = new TextEncoder();
+    return {
+      results: [
+        {
+          id: "session-hit",
+          score: 0.72,
+          text: "session hit below durable memory",
+          metadataJson: encoder.encode(JSON.stringify({ collection: String(params.collection) })),
+        },
+      ],
+    };
+  }
+}
+
 test("LibraVDB memory tools expose memory_search and memory_get through the runtime bridge", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { userId: "u1", topK: 4 };
@@ -125,11 +157,75 @@ test("LibraVDB memory_search supports sessions corpus filtering without memory-c
   });
   const details = search.details as { results: Array<{ source: string; snippet: string }> };
 
+  assert.equal(rpc.calls[1]?.method, "searchText");
+  assert.equal(rpc.calls[1]?.params.collection, "session:discord-session");
   assert.deepEqual(
     details.results.map((result) => result.source),
     ["sessions"],
   );
-  assert.equal(details.results[0]?.snippet, "first interaction was in Discord");
+  assert.equal(details.results[0]?.snippet, "single collection result");
+});
+
+test("LibraVDB memory_search constrains sessions corpus before top-k ranking", async () => {
+  const rpc = new CorpusPriorityRpc();
+  const cfg: PluginConfig = { userId: "u1" };
+  const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
+  const searchTool = tools.createSearchTool({
+    agentId: "spartacus",
+    sessionId: "discord-session",
+    sessionKey: "discord-key",
+  });
+
+  const search = await searchTool.execute("call-1", {
+    query: "needle",
+    corpus: "sessions",
+    maxResults: 1,
+  });
+  const details = search.details as { results: Array<{ source: string; snippet: string }> };
+
+  assert.equal(rpc.calls[1]?.method, "searchText");
+  assert.equal(rpc.calls[1]?.params.collection, "session:discord-session");
+  assert.equal(
+    rpc.calls.some((call) => call.method === "searchTextCollections"),
+    false,
+    "sessions corpus must not search mixed durable collections before filtering",
+  );
+  assert.deepEqual(details.results, [
+    {
+      path: "session%3Adiscord-session::session-hit",
+      startLine: 1,
+      endLine: 1,
+      score: 0.72,
+      snippet: "session hit below durable memory",
+      source: "sessions",
+      citation: "session:discord-session:session-hit",
+    },
+  ]);
+});
+
+test("LibraVDB memory_search constrains memory corpus before top-k ranking", async () => {
+  const rpc = new FakeRpc();
+  const cfg: PluginConfig = { userId: "u1" };
+  const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
+  const searchTool = tools.createSearchTool({
+    agentId: "spartacus",
+    sessionId: "discord-session",
+    sessionKey: "discord-key",
+  });
+
+  const search = await searchTool.execute("call-1", {
+    query: "durable",
+    corpus: "memory",
+    maxResults: 1,
+  });
+  const details = search.details as { results: Array<{ source: string; snippet: string }> };
+
+  assert.equal(rpc.calls[1]?.method, "searchTextCollections");
+  assert.deepEqual(rpc.calls[1]?.params.collections, ["user:u1", "global"]);
+  assert.deepEqual(
+    details.results.map((result) => result.source),
+    ["memory", "memory"],
+  );
 });
 
 test("LibraVDB memory_get reports unknown paths as disabled instead of reading arbitrary files", async () => {

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -15,6 +15,7 @@ type InstrumentedApi = OpenClawPluginApi & {
     memoryCapabilities: string[];
     contextEngines: string[];
     embeddingProviders: string[];
+    tools: string[];
     runtimeLifecycles: string[];
     services: string[];
     hooks: string[];
@@ -30,6 +31,7 @@ function makeFakeApi(overrides: {
     memoryCapabilities: [],
     contextEngines: [],
     embeddingProviders: [],
+    tools: [],
     runtimeLifecycles: [],
     services: [],
     hooks: [],
@@ -55,6 +57,16 @@ function makeFakeApi(overrides: {
     },
     registerMemoryCapability(id: string, _cap: unknown) {
       registrations.memoryCapabilities.push(id);
+    },
+    registerTool(tool: unknown, opts?: { name?: string; names?: string[] }) {
+      const toolNames = opts?.names ?? (opts?.name ? [opts.name] : []);
+      if (toolNames.length > 0) {
+        registrations.tools.push(...toolNames);
+        return;
+      }
+      if (tool && typeof tool === "object" && "name" in tool) {
+        registrations.tools.push(String((tool as { name: unknown }).name));
+      }
     },
     registerContextEngine(id: string, _factory: () => unknown) {
       registrations.contextEngines.push(id);
@@ -86,6 +98,7 @@ test("slot check — ours: register succeeds", () => {
     "libravdb-bundled",
     "libravdb-onnx",
   ]);
+  assert.deepEqual(api.registrations.tools, ["memory_search", "memory_get"]);
   assert.deepEqual(api.registrations.services, [
     "libravdb-markdown-ingestion",
     "libravdb-dream-promotion",
@@ -124,6 +137,7 @@ test("slot check — unset: register succeeds with warning", () => {
     "libravdb-bundled",
     "libravdb-onnx",
   ]);
+  assert.deepEqual(api.registrations.tools, ["memory_search", "memory_get"]);
   assert.deepEqual(api.registrations.services, [
     "libravdb-markdown-ingestion",
     "libravdb-dream-promotion",
@@ -143,6 +157,7 @@ test("slot check — 'none': register succeeds", () => {
   assert.deepEqual(api.registrations.memoryCapabilities, []);
   assert.deepEqual(api.registrations.contextEngines, []);
   assert.deepEqual(api.registrations.embeddingProviders, []);
+  assert.deepEqual(api.registrations.tools, []);
   assert.deepEqual(api.registrations.services, []);
   assert.deepEqual(api.registrations.runtimeLifecycles, []);
   assert.deepEqual(api.registrations.hooks, []);

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -200,6 +200,6 @@ test("combined — cli-metadata with conflicting slot: mode gate blocks before s
 test("runtime lifecycle cleanup preserves context-engine runtime on disable", () => {
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("disable"), false);
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("reset"), false);
+  assert.equal(shouldShutdownRuntimeForLifecycleCleanup("restart"), false);
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("delete"), true);
-  assert.equal(shouldShutdownRuntimeForLifecycleCleanup("restart"), true);
 });

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -137,7 +137,7 @@ test("slot check — unset: register succeeds with warning", () => {
     "libravdb-bundled",
     "libravdb-onnx",
   ]);
-  assert.deepEqual(api.registrations.tools, ["memory_search", "memory_get"]);
+  assert.deepEqual(api.registrations.tools, []);
   assert.deepEqual(api.registrations.services, [
     "libravdb-markdown-ingestion",
     "libravdb-dream-promotion",


### PR DESCRIPTION
## Summary
- register LibraVDB-owned `memory_search` and `memory_get` tools backed by the existing runtime bridge
- declare the tool contracts in `openclaw.plugin.json` so installation/tool discovery can see them without enabling `memory-core`
- add coverage for search/get registration, session corpus filtering, and safe rejection of unreturned paths
- add the missing markdown-ingest test-only `FsDirentLike` type so the full test TypeScript compile passes

## Verification
- `npm run build`
- `./node_modules/.bin/tsc -p tsconfig.tests.json --pretty false`
- `node --test .ts-build/test/unit/*.test.js`
- `node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/markdown-ingest.test.js`
- `node_modules/.bin/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute`

## Notes
- Plugin Inspector passes with its existing P2 inspector-gap suggestion: isolated cold import requires dependency installation.
- The broader integration command including `host-flow.test.js` still has pre-existing host-flow expectation failures unrelated to this tool registration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory tools (memory_search, memory_get) are now available and routed through the LibraVDB-backed daemon for direct use.
  * Memory-related guidance now prompts using memory_search first, then memory_get.

* **Documentation**
  * Highlights updated to reflect the new memory tools integration.

* **Reliability**
  * Search results and excerpt reads now fall back to metadata-derived text when backend text is missing, improving result accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->