### PR TITLE
fix: correct lockfile grep pattern for pnpm v9 importers format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           PLUGIN_DECLARED=$(node -p "require('./openclaw-memory-libravdb/package.json').dependencies['@xdarkicex/libravdb-contracts']")
           echo "plugin declares: $PLUGIN_DECLARED"
 
-          LOCKED_VERSION=$(grep -A1 '@xdarkicex/libravdb-contracts@' openclaw-memory-libravdb/pnpm-lock.yaml | grep 'version:' | awk '{print $2}' | tr -d '"' | head -1)
+          LOCKED_VERSION=$(grep -A2 "'@xdarkicex/libravdb-contracts':" openclaw-memory-libravdb/pnpm-lock.yaml | grep 'version:' | awk '{print $2}' | tr -d '"' | head -1)
           echo "lockfile resolves to: ${LOCKED_VERSION:-none}"
 
           if [ -z "${LOCKED_VERSION}" ]; then


### PR DESCRIPTION
## Summary
The publish workflow's version alignment gate used `grep -A1 '@xdarkicex/libravdb-contracts@'` which matched the `packages:` section of pnpm v9 lockfile where the version is embedded in the key name, not on a separate `version:` line. The inner `grep 'version:'` always returned empty, causing every tag publish to fail with "Could not resolve version from lockfile."

## Fix
Changed pattern to `grep -A2 "'@xdarkicex/libravdb-contracts':"` which matches the `importers:` section where `version:` appears on its own line two lines below the package key.

## Test plan
- [ ] Push a tag — publish-npm passes the version alignment gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)