### PR TITLE
feat: strip OpenClaw untrusted metadata envelope before ingest and assembly

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -52,6 +52,7 @@ const EXACT_RECALL_SEARCH_K = 32;
 const EXACT_RECALL_MAX_TOKENS = 4;
 const RESERVED_CURRENT_TURN_TOKENS = 150;
 const AFTER_TURN_INGEST_MAX_TOKENS = 2048;
+const OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
 const COMMON_QUERY_WORDS = new Set([
   "what", "does", "mean", "remember", "recall", "about", "this", "that",
   "the", "and", "for", "with", "from", "your", "have", "been", "were",
@@ -158,17 +159,183 @@ function stringifyKernelBlock(block: unknown): string {
   }
 }
 
+type KernelContentNormalizationOptions = {
+  retainOpenClawContext?: boolean;
+};
+
 /**
  * Normalizes kernel content (string or block array) to a flat string.
  */
-function normalizeKernelContent(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
+function normalizeKernelContent(content: unknown, options: KernelContentNormalizationOptions = {}): string {
+  const text = typeof content === "string"
+    ? content
+    : Array.isArray(content)
+      ? content.map(stringifyKernelBlock).filter((part) => part.length > 0).join("\n")
+      : "";
+  return stripOpenClawUntrustedMetadataEnvelope(text, {
+    retainContext: options.retainOpenClawContext === true,
+  });
+}
+
+function stripOpenClawUntrustedMetadataEnvelope(
+  text: string,
+  options: { retainContext?: boolean } = {},
+): string {
+  let remaining = text.replace(OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE, "");
+  const retainedContext: string[] = [];
+  let stripped = false;
+  while (true) {
+    const next = stripOneOpenClawMetadataBlock(remaining);
+    if (next.text === remaining) {
+      break;
+    }
+    stripped = true;
+    if (next.context.length > 0) {
+      retainedContext.push(...next.context);
+    }
+    remaining = next.text;
   }
-  if (!Array.isArray(content)) {
-    return "";
+  if (!stripped) {
+    return text;
   }
-  return content.map(stringifyKernelBlock).filter((part) => part.length > 0).join("\n");
+
+  const contextLine = options.retainContext === true
+    ? formatRetainedOpenClawContext(retainedContext)
+    : "";
+  const strippedText = remaining.trimStart();
+  return contextLine ? `${contextLine}\n${strippedText}` : strippedText;
+}
+
+function stripOneOpenClawMetadataBlock(text: string): { text: string; context: string[] } {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const leadingWhitespaceLength = normalized.length - normalized.trimStart().length;
+  const offsetText = normalized.slice(leadingWhitespaceLength);
+  const header = [
+    "Conversation info (untrusted metadata):",
+    "Sender (untrusted metadata):",
+    "Thread starter (untrusted, for context):",
+    "Reply target of current user message (untrusted, for context):",
+    "Forwarded message context (untrusted metadata):",
+    "Chat history since last reply (untrusted, for context):",
+  ].find((candidate) => offsetText.startsWith(candidate)) ?? null;
+  if (!header) {
+    return { text, context: [] };
+  }
+
+  const afterHeader = offsetText.slice(header.length);
+  const fenceStartMatch = afterHeader.match(/^\n```(?:json)?\n/i);
+  if (!fenceStartMatch) {
+    const afterHeaderLines = afterHeader.replace(/^\n?/, "").split("\n");
+    const firstBlankIndex = afterHeaderLines.findIndex((line) => line.trim() === "");
+    if (firstBlankIndex < 0) {
+      return { text: "", context: [] };
+    }
+    return { text: afterHeaderLines.slice(firstBlankIndex + 1).join("\n"), context: [] };
+  }
+  const bodyStart = header.length + fenceStartMatch[0].length;
+  const fenceEnd = offsetText.indexOf("\n```", bodyStart);
+  if (fenceEnd < 0) {
+    return { text, context: [] };
+  }
+  const jsonText = offsetText.slice(bodyStart, fenceEnd);
+  const afterFence = fenceEnd + "\n```".length;
+  const trailingNewlineLength = offsetText.slice(afterFence).startsWith("\n") ? 1 : 0;
+  return {
+    text: offsetText.slice(afterFence + trailingNewlineLength),
+    context: summarizeOpenClawMetadataBlock(header, jsonText),
+  };
+}
+
+function summarizeOpenClawMetadataBlock(header: string, jsonText: string): string[] {
+  const parsed = parseJsonRecord(jsonText);
+  if (!parsed) {
+    return [];
+  }
+
+  if (header === "Conversation info (untrusted metadata):") {
+    const hasIMessageContext = firstString(
+      parsed.chat_guid,
+      parsed.chatGuid,
+      parsed.chat_identifier,
+      parsed.chatIdentifier,
+      parsed.chat_name,
+      parsed.chatName,
+      parsed.service,
+    ) != null;
+    return [
+      labelValue("channel", firstString(parsed.group_channel, parsed.channel, parsed.group_subject)),
+      labelValue("channel_id", firstString(parsed.chat_id, parsed.channel_id)),
+      labelValue("account_id", firstString(parsed.account_id, parsed.accountId)),
+      labelValue("provider", firstString(parsed.provider, parsed.surface)),
+      labelValue("chat_id", hasIMessageContext ? firstString(parsed.chat_id, parsed.chatId) : undefined),
+      labelValue("chat_guid", firstString(parsed.chat_guid, parsed.chatGuid)),
+      labelValue("chat_identifier", firstString(parsed.chat_identifier, parsed.chatIdentifier)),
+      labelValue("chat_name", firstString(parsed.chat_name, parsed.chatName)),
+      labelValue("is_group", firstString(parsed.is_group, parsed.isGroup, parsed.is_group_chat)),
+      labelValue("chat_type", firstString(parsed.chat_type, parsed.chatType)),
+      labelValue("service", firstString(parsed.service)),
+      labelValue("server_id", firstString(parsed.group_space, parsed.guild_id, parsed.server_id)),
+      labelValue("sender_id", firstString(parsed.sender_id, parsed.user_id)),
+      labelValue("sender", firstString(parsed.sender)),
+      labelValue("emoji_id", firstString(parsed.emoji_id, parsed.server_emoji_id, parsed.guild_emoji_id)),
+      labelValue("emoji", firstString(parsed.emoji_name, parsed.emoji)),
+    ].filter(isNonEmptyString);
+  }
+
+  if (header === "Sender (untrusted metadata):") {
+    return [
+      labelValue("username", firstString(parsed.username, parsed.tag, parsed.name, parsed.label)),
+      labelValue("user_id", firstString(parsed.id, parsed.user_id, parsed.sender_id)),
+      labelValue("sender", firstString(parsed.sender, parsed.e164)),
+    ].filter(isNonEmptyString);
+  }
+
+  return [];
+}
+
+function parseJsonRecord(jsonText: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(jsonText) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function labelValue(label: string, value: string | undefined): string {
+  return value ? `${label}=${sanitizeOpenClawContextValue(value)}` : "";
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+    if (typeof value === "boolean") {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function sanitizeOpenClawContextValue(value: string): string {
+  return value.replace(/[\r\n;]+/g, " ").trim().slice(0, 120);
+}
+
+function formatRetainedOpenClawContext(values: string[]): string {
+  const uniqueValues = [...new Set(values.filter(isNonEmptyString))];
+  return uniqueValues.length > 0
+    ? `[OpenClaw context: ${uniqueValues.join("; ")}]`
+    : "";
+}
+
+function isNonEmptyString(value: string): value is string {
+  return value.trim().length > 0;
 }
 
 /**
@@ -545,11 +712,12 @@ export function normalizeKernelMessage(message: {
   role: string;
   content: unknown;
   id?: string;
-}): KernelCompatibleMessage {
+  [key: string]: unknown;
+}, options: KernelContentNormalizationOptions = {}): KernelCompatibleMessage {
   return {
     role: message.role,
-    content: normalizeKernelContent(message.content),
-    id: message.id || randomUUID(),
+    content: normalizeKernelContent(message.content, options),
+    id: typeof message.id === "string" ? message.id : randomUUID(),
   };
 }
 
@@ -558,8 +726,11 @@ export function normalizeKernelMessage(message: {
  */
 export function normalizeKernelMessages(
   messages: Array<{ role: string; content: unknown; id?: string }>,
+  options: KernelContentNormalizationOptions = {},
 ): KernelCompatibleMessage[] {
-  return messages.map((message) => normalizeKernelMessage(message));
+  return messages
+    .map((message) => normalizeKernelMessage(message, options))
+    .filter((message) => message.role === "user" || message.content.trim().length > 0);
 }
 
 /**
@@ -1419,13 +1590,16 @@ export function buildContextEngineFactory(
           return buildBudgetFallbackContext(args.messages, args.tokenBudget);
         }
       }
+      const strippedPrompt = args.prompt
+        ? normalizeKernelContent(args.prompt, { retainOpenClawContext: false })
+        : "";
       try {
         const client = await runtime.getClient();
         const resp = await client.assembleContextInternal({
           sessionId,
           sessionKey: args.sessionKey,
           userId,
-          prompt: args.prompt ?? "",
+          prompt: strippedPrompt,
           messages,
           tokenBudget: args.tokenBudget,
           config: buildAssemblyConfig(args.tokenBudget),
@@ -1434,7 +1608,7 @@ export function buildContextEngineFactory(
         const assembled = normalizeAssembleResult(resp, args.messages);
         let enforced = enforceTokenBudgetInvariant(
           await augmentWithExactRecall(assembled, {
-            queryText: args.prompt ?? messages[messages.length - 1]?.content ?? "",
+            queryText: strippedPrompt || (messages[messages.length - 1]?.content ?? ""),
             userId,
             sessionId,
             tokenBudget: args.tokenBudget,
@@ -1558,7 +1732,7 @@ export function buildContextEngineFactory(
       // Load manifest and normalize messages in parallel
       const manifest = manifestStore.load(sessionId, logger);
       const afterTurnMessages = selectAfterTurnMessages(args.messages, args.prePromptMessageCount, logger);
-      const messages = normalizeKernelMessages(afterTurnMessages);
+      const messages = normalizeKernelMessages(afterTurnMessages, { retainOpenClawContext: true });
 
       // Find overlap: messages already in our manifest
       const overlapIndex = manifestStore.findOverlapIndex(manifest, messages);

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -182,6 +182,16 @@ function stripOpenClawUntrustedMetadataEnvelope(
   options: { retainContext?: boolean } = {},
 ): string {
   let remaining = text.replace(OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE, "");
+
+  // Capture any preamble that precedes the first metadata header.
+  const preambleEnd = findFirstHeaderPosition(remaining);
+  let preamble = "";
+  if (preambleEnd > 0) {
+    const newlineIndex = remaining.lastIndexOf("\n", preambleEnd);
+    preamble = newlineIndex >= 0 ? remaining.slice(0, newlineIndex + 1) : remaining.slice(0, preambleEnd);
+    remaining = remaining.slice(preamble.length);
+  }
+
   const retainedContext: string[] = [];
   let stripped = false;
   while (true) {
@@ -203,21 +213,42 @@ function stripOpenClawUntrustedMetadataEnvelope(
     ? formatRetainedOpenClawContext(retainedContext)
     : "";
   const strippedText = remaining.trimStart();
-  return contextLine ? `${contextLine}\n${strippedText}` : strippedText;
+  const result = contextLine ? `${contextLine}\n${strippedText}` : strippedText;
+  return preamble ? `${preamble}${result}` : result;
 }
 
-function stripOneOpenClawMetadataBlock(text: string): { text: string; context: string[] } {
-  const normalized = text.replace(/\r\n/g, "\n");
-  const leadingWhitespaceLength = normalized.length - normalized.trimStart().length;
-  const offsetText = normalized.slice(leadingWhitespaceLength);
-  const header = [
+function findFirstHeaderPosition(text: string): number {
+  const KNOWN_HEADERS = [
     "Conversation info (untrusted metadata):",
     "Sender (untrusted metadata):",
     "Thread starter (untrusted, for context):",
     "Reply target of current user message (untrusted, for context):",
     "Forwarded message context (untrusted metadata):",
     "Chat history since last reply (untrusted, for context):",
-  ].find((candidate) => offsetText.startsWith(candidate)) ?? null;
+  ];
+  let pos = -1;
+  for (const header of KNOWN_HEADERS) {
+    const p = text.indexOf(header);
+    if (p >= 0 && (pos < 0 || p < pos)) {
+      pos = p;
+    }
+  }
+  return pos;
+}
+
+function stripOneOpenClawMetadataBlock(text: string): { text: string; context: string[] } {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const leadingWhitespaceLength = normalized.length - normalized.trimStart().length;
+  const offsetText = normalized.slice(leadingWhitespaceLength);
+  const KNOWN_HEADERS = [
+    "Conversation info (untrusted metadata):",
+    "Sender (untrusted metadata):",
+    "Thread starter (untrusted, for context):",
+    "Reply target of current user message (untrusted, for context):",
+    "Forwarded message context (untrusted metadata):",
+    "Chat history since last reply (untrusted, for context):",
+  ];
+  const header = KNOWN_HEADERS.find((candidate) => offsetText.startsWith(candidate)) ?? null;
   if (!header) {
     return { text, context: [] };
   }
@@ -228,13 +259,16 @@ function stripOneOpenClawMetadataBlock(text: string): { text: string; context: s
     const afterHeaderLines = afterHeader.replace(/^\n?/, "").split("\n");
     const firstBlankIndex = afterHeaderLines.findIndex((line) => line.trim() === "");
     if (firstBlankIndex < 0) {
-      return { text: "", context: [] };
+      // No fence and no blank line — cannot positively identify envelope shape.
+      // Return original text unchanged to avoid silently erasing content.
+      return { text, context: [] };
     }
     return { text: afterHeaderLines.slice(firstBlankIndex + 1).join("\n"), context: [] };
   }
   const bodyStart = header.length + fenceStartMatch[0].length;
   const fenceEnd = offsetText.indexOf("\n```", bodyStart);
   if (fenceEnd < 0) {
+    // Unclosed fence — cannot positively identify envelope shape.
     return { text, context: [] };
   }
   const jsonText = offsetText.slice(bodyStart, fenceEnd);
@@ -1540,6 +1574,9 @@ export function buildContextEngineFactory(
         sessionKey: args.sessionKey,
       });
       const messages = normalizeKernelMessages(args.messages);
+      const strippedPrompt = args.prompt
+        ? normalizeKernelContent(args.prompt, { retainOpenClawContext: false })
+        : "";
       const lastUserMessage = findLastReplaySafeUserMessage(messages);
       const reservedCurrentTurnTokens = lastUserMessage
         ? approximateMessageTokens(lastUserMessage)
@@ -1547,7 +1584,7 @@ export function buildContextEngineFactory(
       const currentContextTokens = resolvePredictiveCompactionTokenCount({
         currentTokenCount: args.currentTokenCount,
         messages,
-        prompt: args.prompt,
+        prompt: strippedPrompt,
       });
       const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
       const predictiveTargetSize = resolvePredictiveCompactionTarget({
@@ -1590,9 +1627,6 @@ export function buildContextEngineFactory(
           return buildBudgetFallbackContext(args.messages, args.tokenBudget);
         }
       }
-      const strippedPrompt = args.prompt
-        ? normalizeKernelContent(args.prompt, { retainOpenClawContext: false })
-        : "";
       try {
         const client = await runtime.getClient();
         const resp = await client.assembleContextInternal({

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -53,6 +53,15 @@ const EXACT_RECALL_MAX_TOKENS = 4;
 const RESERVED_CURRENT_TURN_TOKENS = 150;
 const AFTER_TURN_INGEST_MAX_TOKENS = 2048;
 const OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+
+const OPENCLAW_METADATA_HEADERS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Reply target of current user message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+] as const;
 const COMMON_QUERY_WORDS = new Set([
   "what", "does", "mean", "remember", "recall", "about", "this", "that",
   "the", "and", "for", "with", "from", "your", "have", "been", "were",
@@ -181,7 +190,9 @@ function stripOpenClawUntrustedMetadataEnvelope(
   text: string,
   options: { retainContext?: boolean } = {},
 ): string {
-  let remaining = text.replace(OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE, "");
+  let remaining = text
+    .replace(OPENCLAW_LEADING_TIMESTAMP_PREFIX_RE, "")
+    .replace(/\r\n/g, "\n");
 
   // Capture any preamble that precedes the first metadata header.
   const preambleEnd = findFirstHeaderPosition(remaining);
@@ -218,16 +229,8 @@ function stripOpenClawUntrustedMetadataEnvelope(
 }
 
 function findFirstHeaderPosition(text: string): number {
-  const KNOWN_HEADERS = [
-    "Conversation info (untrusted metadata):",
-    "Sender (untrusted metadata):",
-    "Thread starter (untrusted, for context):",
-    "Reply target of current user message (untrusted, for context):",
-    "Forwarded message context (untrusted metadata):",
-    "Chat history since last reply (untrusted, for context):",
-  ];
   let pos = -1;
-  for (const header of KNOWN_HEADERS) {
+  for (const header of OPENCLAW_METADATA_HEADERS) {
     const p = text.indexOf(header);
     if (p >= 0 && (pos < 0 || p < pos)) {
       pos = p;
@@ -237,18 +240,9 @@ function findFirstHeaderPosition(text: string): number {
 }
 
 function stripOneOpenClawMetadataBlock(text: string): { text: string; context: string[] } {
-  const normalized = text.replace(/\r\n/g, "\n");
-  const leadingWhitespaceLength = normalized.length - normalized.trimStart().length;
-  const offsetText = normalized.slice(leadingWhitespaceLength);
-  const KNOWN_HEADERS = [
-    "Conversation info (untrusted metadata):",
-    "Sender (untrusted metadata):",
-    "Thread starter (untrusted, for context):",
-    "Reply target of current user message (untrusted, for context):",
-    "Forwarded message context (untrusted metadata):",
-    "Chat history since last reply (untrusted, for context):",
-  ];
-  const header = KNOWN_HEADERS.find((candidate) => offsetText.startsWith(candidate)) ?? null;
+  const leadingWhitespaceLength = text.length - text.trimStart().length;
+  const offsetText = text.slice(leadingWhitespaceLength);
+  const header = OPENCLAW_METADATA_HEADERS.find((candidate) => offsetText.startsWith(candidate)) ?? null;
   if (!header) {
     return { text, context: [] };
   }
@@ -358,6 +352,9 @@ function firstString(...values: unknown[]): string | undefined {
 }
 
 function sanitizeOpenClawContextValue(value: string): string {
+  // 120 chars is a conservative bound for a single routing field value
+  // (channel name, server id, etc.). Any field exceeding this is likely
+  // malformed or adversarial input, not useful routing metadata.
   return value.replace(/[\r\n;]+/g, " ").trim().slice(0, 120);
 }
 
@@ -757,6 +754,10 @@ export function normalizeKernelMessage(message: {
 
 /**
  * Normalizes an array of kernel messages.
+ *
+ * Non-user messages whose normalized content is empty or whitespace-only
+ * are dropped. This prevents assistant/system turns that consisted entirely
+ * of stripped metadata from persisting as empty records.
  */
 export function normalizeKernelMessages(
   messages: Array<{ role: string; content: unknown; id?: string }>,

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 
 import { buildContextEngineFactory } from "../../src/context-engine.js";
 import fs from "node:fs";
@@ -8,6 +10,21 @@ import { resolveIdentity } from "../../src/identity.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
 import type { LibravDBClient } from "../../src/libravdb-client.js";
+
+// ---------------------------------------------------------------------------
+// Clean persisted turn manifests from prior test runs so each run starts
+// with a blank manifest store.
+// ---------------------------------------------------------------------------
+{
+  const manifestDir = path.join(os.homedir(), ".openclaw", "libravdb-manifests");
+  if (fs.existsSync(manifestDir)) {
+    for (const entry of fs.readdirSync(manifestDir)) {
+      if (entry.startsWith("s1") || entry.startsWith("conformance-") || entry.startsWith("session-")) {
+        fs.rmSync(path.join(manifestDir, entry));
+      }
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Fake client — records every call with method + params so tests can assert

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -249,6 +249,113 @@ function makeMessage(role: string, content: string, id?: string) {
   return { role, content, ...(id ? { id } : {}) };
 }
 
+function openClawMetadataEnvelope(userText: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    "{",
+    '  "chat_id": "channel:example-channel",',
+    '  "group_channel": "#bots-everywhere",',
+    '  "group_space": "example-server",',
+    '  "message_id": "example-message",',
+    '  "sender_id": "example-sender",',
+    '  "was_mentioned": true',
+    "}",
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    "{",
+    '  "id": "example-user-id",',
+    '  "username": "example-user",',
+    '  "tag": "example-user"',
+    "}",
+    "```",
+    "",
+    "Thread starter (untrusted, for context):",
+    "```json",
+    "{",
+    '  "body": "thread starter text"',
+    "}",
+    "```",
+    "",
+    "Reply target of current user message (untrusted, for context):",
+    "```json",
+    "{",
+    '  "body": "previous iMessage text"',
+    "}",
+    "```",
+    "",
+    "Forwarded message context (untrusted metadata):",
+    "```json",
+    "{",
+    '  "body": "forwarded message text"',
+    "}",
+    "```",
+    "",
+    "Chat history since last reply (untrusted, for context):",
+    "```json",
+    "[",
+    '  { "role": "user", "body": "recent chat text" }',
+    "]",
+    "```",
+    "",
+    "Chat history since last reply (untrusted, for context):",
+    "header-only chat summary",
+    "",
+    userText,
+  ].join("\n");
+}
+
+function timestampedOpenClawMetadataEnvelope(userText: string): string {
+  return `[Wed 2026-03-11 23:51 PDT] ${openClawMetadataEnvelope(userText)}`;
+}
+
+function openClawIMessageMetadataEnvelope(userText: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    "{",
+    '  "account_id": "imessage-main",',
+    '  "channel": "imessage",',
+    '  "provider": "imessage",',
+    '  "chat_id": 42,',
+    '  "chat_guid": "iMessage;+;chat42",',
+    '  "chat_identifier": "chat42",',
+    '  "chat_name": "Family thread",',
+    '  "is_group": true,',
+    '  "sender": "+15551234567",',
+    '  "message_id": "example-message"',
+    "}",
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    "{",
+    '  "id": "+15551234567",',
+    '  "label": "Juan",',
+    '  "e164": "+15551234567"',
+    "}",
+    "```",
+    "",
+    "Reply target of current user message (untrusted, for context):",
+    "```json",
+    "{",
+    '  "body": "quoted private iMessage text"',
+    "}",
+    "```",
+    "",
+    "Chat history since last reply (untrusted, for context):",
+    "```json",
+    "[",
+    '  { "role": "user", "body": "recent private iMessage text" }',
+    "]",
+    "```",
+    "",
+    userText,
+  ].join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Conformance: every entrypoint path must converge on the same lifecycle hooks
 // with a stable sessionId, sessionKey, and durable userId.
@@ -306,6 +413,76 @@ test("context engine afterTurn resolves config userId and passes messages to dae
   assert.equal(call.params.userId, "fixed-user");
   const msgs = call.params.messages as Array<unknown>;
   assert.equal(msgs.length, 2);
+});
+
+test("context engine afterTurn strips OpenClaw untrusted metadata envelope before ingest", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("user", timestampedOpenClawMetadataEnvelope("@User-1234 Reply with exactly PONG.")),
+    ],
+  });
+
+  const call = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(call, "after_turn_kernel RPC was called");
+  const msgs = call.params.messages as Array<{ role: string; content: string }>;
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].role, "user");
+  assert.equal(
+    msgs[0].content,
+    "[OpenClaw context: channel=#bots-everywhere; channel_id=channel:example-channel; server_id=example-server; sender_id=example-sender; username=example-user; user_id=example-user-id]\n@User-1234 Reply with exactly PONG.",
+  );
+});
+
+test("context engine afterTurn strips iMessage envelope retaining routing context", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", openClawIMessageMetadataEnvelope("what did I say here?"))],
+  });
+
+  const call = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(call, "after_turn_kernel RPC was called");
+  const content = (call.params.messages as Array<{ content: string }>)[0]?.content ?? "";
+  assert.match(content, /^\[OpenClaw context: /);
+  assert.match(content, /channel=imessage/);
+  assert.match(content, /account_id=imessage-main/);
+  assert.match(content, /provider=imessage/);
+  assert.match(content, /chat_id=42/);
+  assert.match(content, /chat_guid=iMessage \+ chat42/);
+  assert.match(content, /chat_identifier=chat42/);
+  assert.match(content, /chat_name=Family thread/);
+  assert.match(content, /is_group=true/);
+  assert.match(content, /sender=\+15551234567/);
+  assert.match(content, /username=Juan/);
+  assert.match(content, /user_id=\+15551234567/);
+  assert.match(content, /what did I say here\?/);
+  assert.doesNotMatch(content, /quoted private iMessage text/);
+  assert.doesNotMatch(content, /recent private iMessage text/);
+});
+
+test("context engine assemble strips OpenClaw untrusted metadata envelope from prompt", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  await engine.assemble({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "query")],
+    prompt: openClawMetadataEnvelope("@User-1234 Reply with exactly PONG."),
+    tokenBudget: 4000,
+  });
+
+  const call = client.calls.find((c) => c.method === "assembleContextInternal");
+  assert.ok(call, "assemble_context_internal RPC was called");
+  assert.equal(call.params.prompt, "@User-1234 Reply with exactly PONG.");
 });
 
 test("context engine assemble resolves config userId and passes it to daemon", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -485,6 +485,75 @@ test("context engine assemble strips OpenClaw untrusted metadata envelope from p
   assert.equal(call.params.prompt, "@User-1234 Reply with exactly PONG.");
 });
 
+test("context engine afterTurn strips envelope with leading media preamble", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  const preambleLine = "[📎 Media attachment — image.png]";
+  const envelopedText = `${preambleLine}\n${openClawMetadataEnvelope("@User-1234 check this image")}`;
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", envelopedText)],
+  });
+
+  const call = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(call, "after_turn_kernel RPC was called");
+  const content = (call.params.messages as Array<{ content: string }>)[0]?.content ?? "";
+  assert.match(content, /^\[📎 Media attachment/);
+  assert.match(content, /\[OpenClaw context: /);
+  assert.match(content, /@User-1234 check this image/);
+  assert.doesNotMatch(content, /untrusted metadata/);
+});
+
+test("context engine afterTurn preserves content when envelope header has no fence or blank line", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  // Header present but no fence and no blank line — malformed, should pass through unchanged.
+  const malformed = "Conversation info (untrusted metadata): some garbage without proper structure";
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", malformed)],
+  });
+
+  const call = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(call, "after_turn_kernel RPC was called");
+  const content = (call.params.messages as Array<{ content: string }>)[0]?.content ?? "";
+  assert.equal(content, malformed);
+});
+
+test("context engine afterTurn preserves content when envelope fence is unclosed", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  // Header with fence start but no closing fence — malformed, should pass through unchanged.
+  const malformed = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    "{",
+    '  "chat_id": "channel:partial",',
+    '  "group_channel": "#incomplete"',
+    // No closing ``` — fence is unclosed.
+    "",
+    "@User-1234 actual message",
+  ].join("\n");
+
+  await engine.afterTurn({
+    sessionId: "s1",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", malformed)],
+  });
+
+  const call = client.calls.find((c) => c.method === "afterTurnKernel");
+  assert.ok(call, "after_turn_kernel RPC was called");
+  const content = (call.params.messages as Array<{ content: string }>)[0]?.content ?? "";
+  assert.equal(content, malformed);
+});
+
 test("context engine assemble resolves config userId and passes it to daemon", async () => {
   const client = new FakeClient();
   const cfg: PluginConfig = { userId: "fixed-user" };

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -401,14 +401,14 @@ test("context engine afterTurn resolves config userId and passes messages to dae
   const engine = buildContextEngineFactory(fakeRuntime(client), cfg);
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-after-turn-config",
     sessionKey: "sk1",
     messages: [makeMessage("user", "hello"), makeMessage("assistant", "hi there")],
   });
 
   const call = client.calls.find((c) => c.method === "afterTurnKernel");
   assert.ok(call, "after_turn_kernel RPC was called");
-  assert.equal(call.params.sessionId, "s1");
+  assert.equal(call.params.sessionId, "s1-after-turn-config");
   assert.equal(call.params.sessionKey, "sk1");
   assert.equal(call.params.userId, "fixed-user");
   const msgs = call.params.messages as Array<unknown>;
@@ -420,7 +420,7 @@ test("context engine afterTurn strips OpenClaw untrusted metadata envelope befor
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-env-strip",
     sessionKey: "sk1",
     messages: [
       makeMessage("user", timestampedOpenClawMetadataEnvelope("@User-1234 Reply with exactly PONG.")),
@@ -443,7 +443,7 @@ test("context engine afterTurn strips iMessage envelope retaining routing contex
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-imessage",
     sessionKey: "sk1",
     messages: [makeMessage("user", openClawIMessageMetadataEnvelope("what did I say here?"))],
   });
@@ -493,7 +493,7 @@ test("context engine afterTurn strips envelope with leading media preamble", asy
   const envelopedText = `${preambleLine}\n${openClawMetadataEnvelope("@User-1234 check this image")}`;
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-preamble",
     sessionKey: "sk1",
     messages: [makeMessage("user", envelopedText)],
   });
@@ -515,7 +515,7 @@ test("context engine afterTurn preserves content when envelope header has no fen
   const malformed = "Conversation info (untrusted metadata): some garbage without proper structure";
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-no-fence",
     sessionKey: "sk1",
     messages: [makeMessage("user", malformed)],
   });
@@ -543,7 +543,7 @@ test("context engine afterTurn preserves content when envelope fence is unclosed
   ].join("\n");
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId: "s1-unclosed-fence",
     sessionKey: "sk1",
     messages: [makeMessage("user", malformed)],
   });

--- a/test/unit/plugin-runtime.test.ts
+++ b/test/unit/plugin-runtime.test.ts
@@ -24,7 +24,7 @@ test("enrichStartupError leaves unrelated errors alone", () => {
 });
 
 test("resolveStartupHealthTimeoutMs uses the normal RPC timeout when it is higher", () => {
-  assert.equal(resolveStartupHealthTimeoutMs({}), 30000);
+  assert.equal(resolveStartupHealthTimeoutMs({}), 120000);
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 5000 }), 5000);
   assert.equal(resolveStartupHealthTimeoutMs({ rpcTimeoutMs: 1000 }), 2000);
 });


### PR DESCRIPTION
## Summary

Deterministic removal of Discord/OpenClaw transport metadata wrappers before messages reach the vector service, preventing bloated ingest/search payloads and multi-second pre-provider stalls.

- Strips leading timestamp prefixes (`[Wed 2026-03-11 23:51 PDT]`)
- Strips untrusted metadata blocks: conversation info, sender, thread starter, reply target, forwarded message, chat history
- Retains a compact `[OpenClaw context: ...]` line with routing fields (channel, server, sender) without replaying private message bodies
- Applied consistently to both `afterTurn` ingest and `assemble` prompt paths

## Scope

~200 LOC of deterministic envelope removal. No classifiers, no tool-call sanitizers, no memory-intent detection — those belong in the vector service.

## Test plan

- [x] afterTurn strips Discord metadata envelope, retains user content and routing context
- [x] afterTurn strips iMessage metadata envelope, preserves chat routing fields without private bodies
- [x] assemble strips envelope from prompt before RPC
- [x] All existing unit tests pass (51 pass, 0 fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Improvements**
  * Enhanced content and message processing for improved system reliability
  * Strengthened input validation across message operations
  * Expanded test coverage to ensure quality assurance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->