### PR TITLE
fix: signal hard failure when owning engine refuses compaction over budget

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -98,7 +98,7 @@ function requireSessionId(sessionId: string | undefined, operation: string): str
  */
 function normalizeCompactResult(
   response: Partial<CompactSessionResponse> | undefined,
-  options: { tokensBefore?: number } = {},
+  options: { tokensBefore?: number; threshold?: number } = {},
 ): OpenClawCompatibleCompactResult {
   const didCompact = response?.didCompact === true;
   const tokensBefore = normalizeCurrentTokenCount(options.tokensBefore) ?? 0;
@@ -119,15 +119,24 @@ function normalizeCompactResult(
         ? response.summaryText
         : undefined,
   };
+
+  // When the engine owns compaction but refuses to compact while the session
+  // exceeds the threshold, this is not a successful skip — it's a failure.
+  // Signal ok:false so OpenClaw falls back to normal transcript compaction
+  // instead of accepting a bloated session.
+  const threshold = options.threshold;
+  const overBudget = threshold != null && tokensBefore >= threshold;
+  const engineRefused = !didCompact && overBudget;
+
   return {
-    ok: true,
+    ok: !engineRefused,
     compacted: didCompact,
-    ...(didCompact ? {} : { reason: "not_compacted" }),
+    ...(didCompact ? {} : { reason: engineRefused ? "overbudget_not_compacted" : "not_compacted" }),
     result: {
       tokensBefore,
       ...(details.summaryMethod ? { summary: details.summaryMethod } : {}),
       ...(details.summaryText ? { summaryText: details.summaryText } : {}),
-      details,
+      details: { ...details, ...(threshold != null ? { threshold } : {}) },
     },
   };
 }
@@ -1447,8 +1456,10 @@ export function buildContextEngineFactory(
     const request = buildCompactSessionRequest(args);
     try {
       const client = await runtime.getClient();
+      const threshold = getDynamicCompactThreshold(args.tokenBudget);
       return normalizeCompactResult(await client.compactSession(request), {
         tokensBefore: args.currentTokenCount,
+        ...(threshold != null ? { threshold } : {}),
       });
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary

- When ownsCompaction is true but the daemon returns not_compacted while the session exceeds the compaction threshold, return ok:false instead of ok:true
- This lets OpenClaw fall back to normal transcript compaction rather than accepting a bloated session
- Paired with libravdbd commit which fixes the root-cause compaction starvation bug in the daemon

## Details

Previously normalizeCompactResult always returned ok:true regardless of budget state. Since the plugin advertises ownsCompaction:true, OpenClaw treated every not_compacted as a successful engine-handled skip and never fell back to transcript compaction.

Now when didCompact is false and tokensBefore >= threshold, the result carries ok:false with reason overbudget_not_compacted. Below-threshold skips remain ok:true with reason not_compacted.

## Test plan

- [ ] Over-budget session with daemon refusing compaction returns ok:false → OpenClaw falls back
- [ ] Below-threshold session with daemon refusing compaction returns ok:true (no regression)
- [ ] Successful compaction returns ok:true, compacted:true (no regression)
- [ ] Edge case: no threshold available → behaves as before (no false positive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token budget handling in the context engine. The system now better detects when compression fails due to budget limitations and applies more appropriate fallback strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->