### PR TITLE
feat: forward post-compaction token estimate to OpenClaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   "dependencies": {
     "@connectrpc/connect": "^1.7.0",
     "@connectrpc/connect-node": "^1.7.0",
-    "@xdarkicex/libravdb-contracts": "^2.0.12"
+    "@xdarkicex/libravdb-contracts": "^2.0.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(@bufbuild/protobuf@1.7.2)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.7.2))
       '@xdarkicex/libravdb-contracts':
-        specifier: ^2.0.12
-        version: 2.0.12
+        specifier: ^2.0.13
+        version: 2.0.13
     devDependencies:
       '@bufbuild/protobuf':
         specifier: 1.7.2
@@ -1424,8 +1424,8 @@ packages:
     resolution: {integrity: sha512-oBN+msHzPnm1M5DDx3wVD7iBwpNXFUtkh2MrAbUJu0OhKjliLChi28hq++mu1+qdMpAVQO5JKAvQQxYVbyneiw==}
     engines: {node: '>= 10'}
 
-  '@swc/helpers@0.5.21':
-    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@telegraf/types@7.1.0':
     resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
@@ -1485,6 +1485,9 @@ packages:
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
@@ -1515,8 +1518,8 @@ packages:
   '@wasm-audio-decoders/common@9.0.7':
     resolution: {integrity: sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==}
 
-  '@xdarkicex/libravdb-contracts@2.0.12':
-    resolution: {integrity: sha512-VITvuPehmqh3+F2IKhFZJotuDnNgpf9ktRIHG0M5Q1U/EGQpDVSDNtLKXvA9eSsedn47BkI5G9fiHmFsAA0kLg==}
+  '@xdarkicex/libravdb-contracts@2.0.13':
+    resolution: {integrity: sha512-K7lWxkTcHWJ0oph8WDf9WXE3nXQn3UMYKdSniW31n9M1rmsiDJwdgua/NDjg1NEsMPw7bbC1J8Z3/DYF/9NI8Q==}
     engines: {node: '>=22'}
 
   abbrev@1.1.1:
@@ -5202,7 +5205,7 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@swc/helpers@0.5.21':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -5228,7 +5231,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
 
   '@types/bun@1.3.11':
     dependencies:
@@ -5241,13 +5244,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
 
   '@types/events@3.0.3': {}
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -5275,6 +5278,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -5291,12 +5298,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5312,7 +5319,7 @@ snapshots:
       '@eshaz/web-worker': 1.2.2
       simple-yenc: 1.0.4
 
-  '@xdarkicex/libravdb-contracts@2.0.12':
+  '@xdarkicex/libravdb-contracts@2.0.13':
     dependencies:
       '@bufbuild/protobuf': 1.7.2
 
@@ -5366,10 +5373,10 @@ snapshots:
 
   apache-arrow@18.1.0:
     dependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
       command-line-args: 5.2.1
       command-line-usage: 7.0.4
       flatbuffers: 24.12.23

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -128,12 +128,18 @@ function normalizeCompactResult(
   const overBudget = threshold != null && tokensBefore >= threshold;
   const engineRefused = !didCompact && overBudget;
 
+  const tokensAfter =
+    didCompact && typeof response?.tokensAfter === "number" && response.tokensAfter > 0
+      ? response.tokensAfter
+      : undefined;
+
   return {
     ok: !engineRefused,
     compacted: didCompact,
     ...(didCompact ? {} : { reason: engineRefused ? "overbudget_not_compacted" : "not_compacted" }),
     result: {
       tokensBefore,
+      ...(tokensAfter != null ? { tokensAfter } : {}),
       ...(details.summaryMethod ? { summary: details.summaryMethod } : {}),
       ...(details.summaryText ? { summaryText: details.summaryText } : {}),
       details: { ...details, ...(threshold != null ? { threshold } : {}) },


### PR DESCRIPTION
## Summary

- Reads `tokensAfter` from the daemon's `CompactSessionResponse` (v2.0.13 proto) and includes it in the normalized compact result returned to OpenClaw
- Bumps `@xdarkicex/libravdb-contracts` to `^2.0.13` for the new field

## Why

When `ownsCompaction: true`, OpenClaw delegates all compaction to this plugin and trusts the result to update its session token snapshot. Previously, successful compaction returned no `tokensAfter` — OpenClaw's session store stayed stale, keeping the session flagged as over budget. On the next message turn, preflight demanded compaction again, the daemon had nothing left to compact, and the plugin returned `overbudget_not_compacted`, aborting dispatch.

With `tokensAfter`, OpenClaw receives a trustworthy post-compaction token count and updates its session snapshot. The preflight loop ends.

Paired with libravdbd v1.4.98.

## Test plan

- [ ] Over-budget session compacted by daemon → plugin returns `tokensAfter` in result
- [ ] Below-threshold session compacted → `tokensAfter` present
- [ ] Compaction refused (`didCompact: false`) → `tokensAfter` absent (undefined)
- [ ] Daemon on older version without `tokensAfter` field → no regression (undefined, handled gracefully)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies and improved internal token budget and compaction handling logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->