### PR TITLE
fix: make memory prompt header actionable, remove MEMORY.md negative prompt

### DIFF
--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -4,8 +4,9 @@ import type { ClientGetter } from "./plugin-runtime.js";
 
 const MEMORY_PROMPT_HEADER = [
   "## Memory",
-  "LibraVDB persistent memory is configured. Recalled memories may appear",
-  "in context via the context-engine assembler when available and relevant.",
+  "LibraVDB persistent memory is configured. When asked about past",
+  "conversations, facts, preferences, decisions, or anything a user",
+  "might have told you before — actively retrieve it.",
   "",
 ] as const;
 
@@ -13,20 +14,17 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
   if (!availableTools?.has("memory_search")) {
     return [];
   }
-  const lines = [
-    "For explicit memory lookup requests, call `memory_search` first.",
-    "Use it for prior turns, remembered facts, earliest interactions, and channel history.",
-    "Do not answer memory lookup requests from prior transcript claims or earlier `memory_search` results; perform a fresh `memory_search` for the current request.",
-    "For earliest or oldest memory questions, request enough results, compare timestamps in the returned snippets, and use `memory_get` if the snippet is not enough.",
-  ];
-  if (availableTools.has("memory_get")) {
-    lines.push("After a `memory_search` hit, call `memory_get` when exact wording or more context is needed.");
-  }
-  lines.push(
-    "Do not treat a missing `MEMORY.md` file as missing memory; LibraVDB memory is vector-backed and retrieved through the memory tools.",
+  return [
+    "Call `memory_search` for prior turns, remembered facts, earliest interactions,",
+    "and channel history. Do not answer memory questions from prior transcript",
+    "claims or stale `memory_search` results — perform a fresh search every time.",
+    "For earliest or oldest questions, request enough results and compare timestamps.",
+    ...(availableTools.has("memory_get")
+      ? ["After a `memory_search` hit, call `memory_get` when exact wording or more context is needed."]
+      : []),
+    "LibraVDB memory is vector-backed and retrieved through tools, not files.",
     "",
-  );
-  return lines;
+  ];
 }
 
 export function buildMemoryPromptSection(

--- a/test/unit/memory-provider.test.ts
+++ b/test/unit/memory-provider.test.ts
@@ -72,11 +72,12 @@ test("memory prompt section guides memory tool use when memory_search is availab
 
   const resultText = result.join("\n");
   assert.ok(resultText.includes("LibraVDB persistent memory is configured"), "should include memory header");
-  assert.ok(resultText.includes("call `memory_search` first"), "should guide explicit recall through memory_search");
-  assert.ok(resultText.includes("perform a fresh `memory_search`"), "should prevent stale transcript reuse");
+  assert.ok(resultText.includes("actively retrieve it"), "should guide active memory retrieval");
+  assert.ok(resultText.includes("Call `memory_search`"), "should guide explicit recall through memory_search");
+  assert.ok(resultText.includes("fresh search"), "should prevent stale transcript reuse");
   assert.ok(resultText.includes("compare timestamps"), "should guide earliest-memory questions through timestamps");
   assert.ok(resultText.includes("call `memory_get`"), "should guide exact recall through memory_get");
-  assert.ok(resultText.includes("missing `MEMORY.md` file"), "should prevent file-backed missing-memory fallback");
+  assert.ok(resultText.includes("vector-backed"), "should describe memory as vector-backed");
   assert.ok(!resultText.includes("recalled_memories"), "should not inject recalled memories directly");
   assert.ok(!resultText.includes("user recall") && !resultText.includes("global recall"), "should not render recall items");
   assert.equal(rpc.calls.get("search_text") ?? 0, 0, "should not perform search_text calls");


### PR DESCRIPTION
## Summary

The static memory prompt header told the agent "memories may appear in context" — passive voice implying the agent has no active role in memory retrieval. When `memory_search` wasn't registered as a tool (pre-PR #271, or if the slot is misconfigured), the agent had zero guidance to actively search. Combined with the negative instruction "Do not treat a missing MEMORY.md file as missing memory" — which paradoxically planted the MEMORY.md concept — the agent fell back to mentioning file-based memory instead of querying the vector database.

## Changes

- **Header now directs the agent to actively retrieve**: "When asked about past conversations, facts, preferences, decisions, or anything a user might have told you before — actively retrieve it."
- **Removed all references to MEMORY.md**: negative instructions plant ideas. Replaced with "vector-backed and retrieved through tools, not files."
- **Simplified tool guidance**: "Call `memory_search`" instead of the wordier "For explicit memory lookup requests, call `memory_search` first."

## Test plan

- [x] All 172 unit tests pass
- [x] memory-provider tests updated for new prompt text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory retrieval accuracy to ensure fresh searches and prevent reliance on stale cached results
  * Enhanced handling of past conversation references with better timestamp-based comparisons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->