### PR TITLE
feat: add INFO logs for predictive context pipeline visibility

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1701,6 +1701,11 @@ export function buildContextEngineFactory(
               ),
               estimatedTokens: enforced.estimatedTokens + section.tokens,
             };
+            logger.info?.(
+              `LibraVDB predictive context injected sessionId=${sessionId} ` +
+              `items=${section.injectedCount}/${predictions.length} ` +
+              `tokens=${section.tokens}`,
+            );
           }
         }
         enforced = enforceTokenBudgetInvariant(enforced, args.tokenBudget);
@@ -1878,6 +1883,14 @@ export function buildContextEngineFactory(
             if (oldest !== undefined) predictiveContextCache.delete(oldest);
           }
           predictiveContextCache.set(sessionId, predictions);
+          logger.info?.(
+            `LibraVDB predictive graph returned predictions sessionId=${sessionId} ` +
+            `count=${predictions.length}`,
+          );
+        } else {
+          logger.info?.(
+            `LibraVDB predictive graph returned no predictions sessionId=${sessionId}`,
+          );
         }
         return result;
       } catch (error) {


### PR DESCRIPTION
## Summary
- Adds INFO-level log lines at both ends of the predictive context pipeline: when the daemon returns predictions from the causal graph (`afterTurn`), and when those predictions are injected into context (`assemble`)
- Previously both ends were silent, making it impossible to verify the predictive causal graph was operational without inspecting raw system prompt additions

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] After restart, observe `LibraVDB predictive graph returned predictions sessionId=... count=N` in logs after each turn
- [ ] On the following turn, observe `LibraVDB predictive context injected sessionId=... items=N/M tokens=...` 
- [ ] Verify "returned no predictions" log appears when causal graph has no topology edges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for predictive context handling and prediction tracking to support system monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->