### PR TITLE
fix: remove Mandatory trigger word from memory_search, add anti-loop guard

### DIFF
--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -4,9 +4,12 @@ import type { ClientGetter } from "./plugin-runtime.js";
 
 const MEMORY_PROMPT_HEADER = [
   "## Memory",
-  "LibraVDB persistent memory is configured. When asked about past",
-  "conversations, facts, preferences, decisions, or anything a user",
-  "might have told you before — actively retrieve it.",
+  "LibraVDB persistent memory is configured. Every turn is auto-ingested",
+  "into the vector store — you do not need to explicitly save anything.",
+  "When asked about past conversations, facts, preferences, decisions,",
+  "or anything the user might have told you before, call `memory_search`",
+  "once per user question. Do not answer from memory until you have",
+  "called it. Once you have results, use them — do not re-call.",
   "",
 ] as const;
 
@@ -15,9 +18,10 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
     return [];
   }
   return [
-    "Call `memory_search` for prior turns, remembered facts, earliest interactions,",
-    "and channel history. Do not answer memory questions from prior transcript",
-    "claims or stale `memory_search` results — perform a fresh search every time.",
+    "Call `memory_search` once per user question for prior turns, remembered",
+    "facts, earliest interactions, and channel history. Do not answer memory",
+    "questions from prior transcript claims — perform a search every time.",
+    "After receiving results, use them directly; do not re-call in the same turn.",
     "For earliest or oldest questions, request enough results and compare timestamps.",
     ...(availableTools.has("memory_get")
       ? ["After a `memory_search` hit, call `memory_get` when exact wording or more context is needed."]

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -150,7 +150,7 @@ export function createLibraVdbMemoryTools(
         name: "memory_search",
         label: "Memory Search",
         description:
-          "Mandatory fresh LibraVDB recall step: semantically search durable memory and session recall before answering questions about prior work, decisions, dates, people, preferences, todos, or history. Do not reuse prior transcript claims or older memory_search results for a new memory lookup. For earliest/oldest questions, request enough results and compare timestamps in snippets. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+          "Search LibraVDB durable memory and session recall for prior work, decisions, dates, people, preferences, todos, or history. Call once per user question — after receiving results, use them directly. Do not re-call in the same turn. For earliest/oldest questions, request enough results and compare timestamps. If disabled=true, memory is unavailable.",
         parameters: MEMORY_SEARCH_SCHEMA,
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);


### PR DESCRIPTION
## Summary
- Removes "Mandatory fresh" from `memory_search` tool description — the word "Mandatory" caused the agent to re-call the tool before every response, looping indefinitely. "Fresh" implied prior results were already stale.
- Adds explicit anti-loop guard: "Call once per user question — after receiving results, use them directly. Do not re-call in the same turn."
- Clarifies that every turn is auto-ingested so the agent stops hallucinating about "scheduling reminders" to save memory
- Strengthens prompt from passive "actively retrieve it" to concrete "call `memory_search` once per user question. Do not answer from memory until you have called it."

## Root cause
Two bugs observed in Telegram agent:
1. Agent skipped `memory_search` entirely when asked a memory question — prompt was too passive
2. When finally prompted to search, agent looped calling `memory_search` repeatedly — "Mandatory" + "fresh" created a compulsion loop where every potential response triggered another search

## Test plan
- [ ] Build passes
- [ ] Agent calls `memory_search` exactly once when asked a memory question
- [ ] Agent uses results directly without re-calling
- [ ] Agent no longer mentions "scheduling reminders" for memory storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory search instructions to ensure fresh retrieval for each user question
  * Improved handling of memory search tool behavior and messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->