### PR TITLE
fix: skip duplicate afterTurn ingestion

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -128,9 +128,10 @@ function normalizeCompactResult(
   const overBudget = threshold != null && tokensBefore >= threshold;
   const engineRefused = !didCompact && overBudget;
 
+  const compactMetrics = response as (Partial<CompactSessionResponse> & { tokensAfter?: unknown }) | undefined;
   const tokensAfter =
-    didCompact && typeof response?.tokensAfter === "number" && response.tokensAfter > 0
-      ? response.tokensAfter
+    didCompact && typeof compactMetrics?.tokensAfter === "number" && compactMetrics.tokensAfter > 0
+      ? compactMetrics.tokensAfter
       : undefined;
 
   return {
@@ -1812,6 +1813,14 @@ export function buildContextEngineFactory(
         `prePromptMessageCount=${args.prePromptMessageCount ?? "unknown"} ` +
         `heartbeat=${args.isHeartbeat ?? false}`,
       );
+
+      if (newMessages.length === 0) {
+        logger.info?.(
+          `LibraVDB afterTurn skipped sessionId=${sessionId} reason=no-new-messages ` +
+          `messageCount=${messages.length} overlapIndex=${overlapIndex}`,
+        );
+        return { ok: true, skipped: true, reason: "no-new-messages" };
+      }
 
       try {
         const client = await runtime.getClient();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -432,6 +432,35 @@ test("context engine afterTurn resolves config userId and passes messages to dae
   assert.equal(msgs.length, 2);
 });
 
+test("context engine afterTurn is idempotent when manifest has already ACKed every forwarded message", async () => {
+  const client = new FakeClient();
+  const cfg: PluginConfig = { userId: "fixed-user" };
+  const engine = buildContextEngineFactory(fakeRuntime(client), cfg);
+  const sessionId = `s1-after-turn-idempotent-${process.pid}`;
+  const messages = [
+    makeMessage("user", "stale edit request"),
+    makeMessage("assistant", "edit failed because old text did not match"),
+  ];
+
+  await engine.afterTurn({
+    sessionId,
+    sessionKey: "sk1",
+    messages,
+  });
+  const firstCallCount = client.calls.filter((c) => c.method === "afterTurnKernel").length;
+
+  const result = await engine.afterTurn({
+    sessionId,
+    sessionKey: "sk1",
+    messages,
+  });
+
+  const secondCallCount = client.calls.filter((c) => c.method === "afterTurnKernel").length;
+  assert.equal(firstCallCount, 1);
+  assert.equal(secondCallCount, 1, "duplicate afterTurn should not call daemon again");
+  assert.deepEqual(result, { ok: true, skipped: true, reason: "no-new-messages" });
+});
+
 test("context engine afterTurn strips OpenClaw untrusted metadata envelope before ingest", async () => {
   const client = new FakeClient();
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
@@ -781,15 +810,16 @@ test("context engine skips predictive context when it cannot fit within the toke
     ],
   };
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const sessionId = `s1-predictive-escape-${process.pid}`;
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "remember this")],
   });
 
   const assembled = await engine.assemble({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "continue")],
     prompt: "continue",
@@ -1499,15 +1529,16 @@ test("context engine escapes predictive context text before injecting it into th
     ],
   };
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const sessionId = `s1-predictive-budget-${process.pid}`;
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "remember this")],
   });
 
   const assembled = await engine.assemble({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "continue")],
     prompt: "continue",
@@ -1630,15 +1661,16 @@ test("predictive context injects items item-by-item, dropping tail items when bu
     ],
   };
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const sessionId = `s1-predictive-truncate-${process.pid}`;
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "remember this")],
   });
 
   const assembled = await engine.assemble({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "continue")],
     prompt: "continue",
@@ -1668,15 +1700,16 @@ test("predictive context inner-truncates an oversized prediction with [truncated
     ],
   };
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const sessionId = `s1-predictive-oversized-${process.pid}`;
 
   await engine.afterTurn({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "remember this")],
   });
 
   const assembled = await engine.assemble({
-    sessionId: "s1",
+    sessionId,
     sessionKey: "sk1",
     messages: [makeMessage("user", "continue")],
     prompt: "continue",


### PR DESCRIPTION
## Summary

- Fixes #280 by making context-engine `afterTurn` idempotent when the local turn manifest already ACKed every forwarded message.
- Skips the daemon `afterTurnKernel` call and predictive side effects when `newMessages.length === 0`, preventing repeated zero-new-message after-turn work from feeding a loop.
- Adds a regression test that calls `afterTurn` twice with the same forwarded messages and asserts the second call returns a no-op result without another daemon call.
- Keeps predictive-context tests on fresh session ids so the new duplicate-turn guard does not depend on cross-test manifest state.
- Includes a narrow compatibility cast for legacy `tokensAfter` reads because current generated compact response types no longer expose that field and otherwise block TypeScript gates.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec tsc -p tsconfig.tests.json && node --test --test-name-pattern "afterTurn is idempotent" .ts-build/test/unit/context-engine.test.js`
- `pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js`
- `git diff --check HEAD~1..HEAD`

Blocked / existing failures observed:

- `pnpm run check` currently fails during `plugin-inspector ci --runtime` with `entrypoint-import-error: TypeError: os.homedir is not a function` while importing `dist/index.js`. The unit suite above passes after direct TypeScript compilation.
- `node --test .ts-build/test/integration/host-flow.test.js` has current-upstream failures unrelated to this patch, including `prePromptMessageCount` leaking to the daemon, compact response shape mismatches, and preserved message `id` differences.

– Vale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token calculations now accurately reflect compaction operation success status.

* **Tests**
  * Added idempotency tests for message processing when no new updates arrive.
  * Improved test isolation for context prediction tests using unique session identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xDarkicex/openclaw-memory-libravdb/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->