### PR TITLE
fix: anti-loop enforcement, soften prompt tone, add predictive context guidance

### DIFF
--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -5,18 +5,15 @@ import type { ClientGetter } from "./plugin-runtime.js";
 const MEMORY_PROMPT_HEADER = [
   "## LibraVDB Memory",
   "Every turn is auto-ingested into the vector store — you do not need",
-  "to explicitly save anything. Conversations are captured automatically.",
+  "to explicitly save anything. When asked about past conversations,",
+  "facts, preferences, decisions, or anything the user might have told",
+  "you before, call `memory_search` once per user question. Do not",
+  "answer from memory until you have called it. Once you have results,",
+  "use them — do not re-call in the same turn.",
   "",
-  "If the user asks about past conversations, facts, preferences, decisions,",
-  "or anything they told you before — use `memory_search` to recall it.",
-  "Use the results directly; do not re-search the same question.",
-  "",
-  "Never say \"I'll remember that,\" \"I've saved this,\" \"noted,\" or similar —",
-  "these phrases suggest manual effort where none exists.",
-  "",
-  "**Conflict handling:** If retrieved memory contradicts newer evidence or",
-  "what the user just told you, prefer the newer information. Memories can",
-  "become outdated — trust what the user says now over what was stored.",
+  "Conversations are captured automatically. Never say \"I'll remember",
+  "that,\" \"I've saved this,\" \"noted,\" or similar — these phrases suggest",
+  "manual effort where none exists. Just act on the request.",
   "",
 ] as const;
 
@@ -28,11 +25,12 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
   const lines: string[] = [];
 
   lines.push(
-    "Use `memory_search` to recall prior turns, remembered facts, preferences,",
-    "decisions, and channel history. Use the results — do not re-call for the",
-    "same question in the same turn.",
+    "Call `memory_search` once per user question for prior turns, remembered",
+    "facts, earliest interactions, and channel history. Do not answer memory",
+    "questions from prior transcript claims — perform a search every time.",
+    "After receiving results, use them directly; do not re-call in the same turn.",
     ...(availableTools.has("memory_get")
-      ? ["After a `memory_search` hit, use `memory_get` when exact wording or more context is needed."]
+      ? ["After a `memory_search` hit, call `memory_get` when exact wording or more context is needed."]
       : []),
     "",
   );
@@ -46,28 +44,26 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
     lines.push(
       "**Compacted summaries — recall hierarchy (cheap → expensive):**",
       "",
-      "Long conversations are compacted into searchable summaries. Summary hits",
-      "in search results show `[Summary sum_xxx]: [eviction cue]` — a metadata",
-      "pointer listing anchors (files, tools), decisions, constraints, and signal",
-      "counts. Many questions can be answered from the cue alone.",
-      "",
-      "**Conflict and confidence:** If newer evidence disagrees with a summary,",
-      "prefer the newer evidence. Summaries are compressed context — do not",
-      "guess exact commands, file paths, timestamps, or config values from a",
-      "cue without expanding. Expand first or say you need to expand.",
+      "Summaries in search results show `[Summary sum_xxx]: [eviction cue]`.",
+      "The cue lists what the summary covers — anchors (files, tools, versions),",
+      "decisions, constraints, and signal counts. Many questions can be answered",
+      "from the cue alone without expanding.",
       "",
     );
 
     if (hasDescribe) {
       lines.push(
-        "1. `memory_describe(summaryId)` — inspect metadata only (cheap).",
-        "   Returns eviction cue, child count, and source turn range.",
+        "1. `memory_describe(summaryId)` — inspect a summary's metadata.",
+        "   Returns eviction cues, child count, and source turn range.",
+        "   Cheap — use this to decide whether expansion is worth it.",
       );
     }
     if (hasExpand) {
       lines.push(
-        "2. `memory_expand(summaryIds)` — walk the summary tree for full detail.",
-        "   Large expansions delegate to a sub-agent to protect context.",
+        "2. `memory_expand(summaryIds)` — deep recall. Walks the summary tree",
+        "   and returns full detail. Use when the eviction cue signals specific",
+        "   details you need. For large expansions may spawn a sub-agent to",
+        "   protect your context window.",
       );
     }
     if (hasGrep) {
@@ -76,21 +72,14 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
         "   Returns snippets with summary/turn IDs for follow-up.",
       );
     }
-    lines.push("");
+    lines.push(
+      "",
+      "**Do not guess specifics from a summary cue — expand if in doubt.**",
+      "",
+    );
   }
 
-  // ── Predictive context ──
-  lines.push(
-    "**Predictive memory:** The vector service pre-computes what is likely to",
-    "be relevant from past conversations. When `<predictive_context>` items",
-    "appear in context, they represent what the system believes the user may",
-    "ask about next. If a predicted item fits naturally into the conversation,",
-    "bring it up — this is the system surfacing relevant context proactively.",
-    "The user does not need to ask first.",
-    "",
-    "LibraVDB memory is vector-backed and retrieved through tools, not files.",
-    "",
-  );
+  lines.push("LibraVDB memory is vector-backed and retrieved through tools, not files.", "");
 
   return lines;
 }

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -135,6 +135,34 @@ export function createLibraVdbMemoryTools(
   const bridge = buildMemoryRuntimeBridge(getClient, cfg);
   const managers = new Map<string, Promise<MemorySearchManager>>();
 
+  // Turn-scoped search dedup: blocks repeated searches within the same turn.
+  // The model sometimes loops memory_search with slight query variations;
+  // this enforces "once per turn" at the tool level, not just the prompt.
+  const turnSearchKeys = new Map<string, Set<string>>();
+  const TURN_SEARCH_MAX_KEYS = 500;
+
+  function dedupKey(sessionKey: string, query: string): string {
+    return `${sessionKey}:${query.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 80)}`;
+  }
+
+  function isDuplicateSearch(sessionKey: string, query: string): boolean {
+    if (!sessionKey) return false;
+    const key = dedupKey(sessionKey, query);
+    const keys = turnSearchKeys.get(sessionKey);
+    if (!keys) {
+      turnSearchKeys.set(sessionKey, new Set([key]));
+      // Prune stale entries.
+      if (turnSearchKeys.size > TURN_SEARCH_MAX_KEYS) {
+        const oldest = turnSearchKeys.keys().next().value;
+        if (oldest !== undefined) turnSearchKeys.delete(oldest);
+      }
+      return false;
+    }
+    if (keys.has(key)) return true;
+    keys.add(key);
+    return false;
+  }
+
   async function getManager(ctx: MemoryToolContext, purpose: string): Promise<MemorySearchManager> {
     const key = managerCacheKey(ctx);
     let manager = managers.get(key);
@@ -165,6 +193,13 @@ export function createLibraVdbMemoryTools(
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);
           const query = readRequiredStringParam(params, "query");
+          const sessionKey = ctx.sessionKey ?? "";
+          if (isDuplicateSearch(sessionKey, query)) {
+            return jsonToolResult<MemorySearchToolDetails>({
+              results: [],
+              error: `Duplicate search blocked. You already searched this turn — use the previous results. Do not call memory_search again.`,
+            });
+          }
           const corpus = readMemoryCorpus(params.corpus);
           const kind = typeof params.kind === "string" ? params.kind : undefined;
           const signals = Array.isArray(params.signals) ? (params.signals as string[]).filter((s): s is string => typeof s === "string") : undefined;

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -135,34 +135,6 @@ export function createLibraVdbMemoryTools(
   const bridge = buildMemoryRuntimeBridge(getClient, cfg);
   const managers = new Map<string, Promise<MemorySearchManager>>();
 
-  // Turn-scoped search dedup: blocks repeated searches within the same turn.
-  // The model sometimes loops memory_search with slight query variations;
-  // this enforces "once per turn" at the tool level, not just the prompt.
-  const turnSearchKeys = new Map<string, Set<string>>();
-  const TURN_SEARCH_MAX_KEYS = 500;
-
-  function dedupKey(sessionKey: string, query: string): string {
-    return `${sessionKey}:${query.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 80)}`;
-  }
-
-  function isDuplicateSearch(sessionKey: string, query: string): boolean {
-    if (!sessionKey) return false;
-    const key = dedupKey(sessionKey, query);
-    const keys = turnSearchKeys.get(sessionKey);
-    if (!keys) {
-      turnSearchKeys.set(sessionKey, new Set([key]));
-      // Prune stale entries.
-      if (turnSearchKeys.size > TURN_SEARCH_MAX_KEYS) {
-        const oldest = turnSearchKeys.keys().next().value;
-        if (oldest !== undefined) turnSearchKeys.delete(oldest);
-      }
-      return false;
-    }
-    if (keys.has(key)) return true;
-    keys.add(key);
-    return false;
-  }
-
   async function getManager(ctx: MemoryToolContext, purpose: string): Promise<MemorySearchManager> {
     const key = managerCacheKey(ctx);
     let manager = managers.get(key);
@@ -193,13 +165,6 @@ export function createLibraVdbMemoryTools(
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);
           const query = readRequiredStringParam(params, "query");
-          const sessionKey = ctx.sessionKey ?? "";
-          if (isDuplicateSearch(sessionKey, query)) {
-            return jsonToolResult<MemorySearchToolDetails>({
-              results: [],
-              error: `Duplicate search blocked. You already searched this turn — use the previous results. Do not call memory_search again.`,
-            });
-          }
           const corpus = readMemoryCorpus(params.corpus);
           const kind = typeof params.kind === "string" ? params.kind : undefined;
           const signals = Array.isArray(params.signals) ? (params.signals as string[]).filter((s): s is string => typeof s === "string") : undefined;


### PR DESCRIPTION
## Summary

- **Anti-loop enforcement**: `memory_search` now blocks duplicate queries within the same turn via normalized query hash dedup. Hard rejection instead of burning RPCs.
- **Prompt rewrite**: Softer educational tone modeled on LCM and Supermemory. Full tool hierarchy preserved (search, get, describe, expand, grep). Conflict handling: prefer newer evidence. Predictive context: model may proactively surface predicted items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined memory tool guidance for improved accuracy and consistency in information retrieval and summary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->