### PR TITLE
fix: cap compaction threshold at compactSessionTokenBudget to prevent Codex Runtime blowout

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   "dependencies": {
     "@connectrpc/connect": "^1.7.0",
     "@connectrpc/connect-node": "^1.7.0",
-    "@xdarkicex/libravdb-contracts": "^2.0.19"
+    "@xdarkicex/libravdb-contracts": "^2.0.20"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(@bufbuild/protobuf@1.7.2)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.7.2))
       '@xdarkicex/libravdb-contracts':
-        specifier: ^2.0.19
-        version: 2.0.19
+        specifier: ^2.0.20
+        version: 2.0.20
     devDependencies:
       '@bufbuild/protobuf':
         specifier: 1.7.2
@@ -1518,7 +1518,7 @@ packages:
   '@wasm-audio-decoders/common@9.0.7':
     resolution: {integrity: sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==}
 
-  '@xdarkicex/libravdb-contracts@2.0.19':
+  '@xdarkicex/libravdb-contracts@2.0.20':
     resolution: {integrity: sha512-ncYwRFK010biHXEe1NbpuBNj2iCU8dv8Y54z7C4JsN3wsIucF8WTWkbiq3SIyWSSVFTDMnCtojvrrC0LHpmRDA==}
     engines: {node: '>=22'}
 
@@ -5319,7 +5319,7 @@ snapshots:
       '@eshaz/web-worker': 1.2.2
       simple-yenc: 1.0.4
 
-  '@xdarkicex/libravdb-contracts@2.0.19':
+  '@xdarkicex/libravdb-contracts@2.0.20':
     dependencies:
       '@bufbuild/protobuf': 1.7.2
 

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -102,10 +102,32 @@ function requireSessionId(sessionId: string | undefined, operation: string): str
  */
 function normalizeCompactResult(
   response: Partial<CompactSessionResponse> | undefined,
-  options: { tokensBefore?: number; threshold?: number } = {},
+  options: { tokensBefore?: number; threshold?: number; logger?: LoggerLike } = {},
 ): OpenClawCompatibleCompactResult {
   const didCompact = response?.didCompact === true;
   const tokensBefore = normalizeCurrentTokenCount(options.tokensBefore) ?? 0;
+  const lastCompactedTurn =
+    typeof response?.lastCompactedTurn === "bigint" ? response.lastCompactedTurn : undefined;
+  const tokenAccumulatorAfter =
+    typeof response?.tokenAccumulatorAfter === "number" ? response.tokenAccumulatorAfter : undefined;
+  const totalTurns = typeof response?.totalTurns === "bigint" ? response.totalTurns : undefined;
+  const skippedNoNewTurns =
+    typeof response?.skippedNoNewTurns === "boolean" ? response.skippedNoNewTurns : undefined;
+
+  if (
+    lastCompactedTurn != null ||
+    tokenAccumulatorAfter != null ||
+    totalTurns != null ||
+    skippedNoNewTurns != null
+  ) {
+    options.logger?.info?.(
+      `[compact:trace] daemon state lastCompactedTurn=${lastCompactedTurn?.toString() ?? "unknown"} ` +
+        `tokenAccumulatorAfter=${tokenAccumulatorAfter ?? "unknown"} ` +
+        `totalTurns=${totalTurns?.toString() ?? "unknown"} ` +
+        `skippedNoNewTurns=${skippedNoNewTurns ?? "unknown"}`,
+    );
+  }
+
   const details = {
     clustersFormed:
       typeof response?.clustersFormed === "number" ? response.clustersFormed : undefined,
@@ -122,6 +144,10 @@ function normalizeCompactResult(
       typeof response?.summaryText === "string" && response.summaryText.length > 0
         ? response.summaryText
         : undefined,
+    ...(lastCompactedTurn != null ? { lastCompactedTurn: lastCompactedTurn.toString() } : {}),
+    ...(tokenAccumulatorAfter != null ? { tokenAccumulatorAfter } : {}),
+    ...(totalTurns != null ? { totalTurns: totalTurns.toString() } : {}),
+    ...(skippedNoNewTurns != null ? { skippedNoNewTurns } : {}),
   };
 
   // When the engine owns compaction but refuses to compact while the session
@@ -493,13 +519,17 @@ function resolveDynamicCompactThreshold(
   compactThreshold: number | undefined,
   compactionThresholdFraction: number | undefined,
   compactSessionTokenBudget?: number,
+  logger?: LoggerLike,
 ): number | undefined {
   // Explicit compactThreshold always wins.
   if (typeof compactThreshold === "number" && Number.isFinite(compactThreshold) && compactThreshold > 0) {
-    return Math.max(1, Math.floor(compactThreshold));
+    const val = Math.max(1, Math.floor(compactThreshold));
+    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=explicit tokenBudget=${tokenBudget} compactThreshold=${compactThreshold} → ${val}`);
+    return val;
   }
   const normalizedBudget = normalizeTokenBudget(tokenBudget);
   if (normalizedBudget == null) {
+    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=null_budget tokenBudget=${tokenBudget} → undefined`);
     return undefined;
   }
   const fraction = normalizeThresholdFraction(compactionThresholdFraction);
@@ -510,8 +540,11 @@ function resolveDynamicCompactThreshold(
   const withBounds = Math.max(2000, Math.min(16000, derived));
   // User-configured compactSessionTokenBudget overrides the ceiling.
   if (typeof compactSessionTokenBudget === "number" && compactSessionTokenBudget > 0) {
-    return Math.min(withBounds, compactSessionTokenBudget);
+    const capped = Math.min(withBounds, compactSessionTokenBudget);
+    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=user_cap tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} cap=${compactSessionTokenBudget} → ${capped}`);
+    return capped;
   }
+  logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=clamped tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} → ${withBounds}`);
   return withBounds;
 }
 
@@ -1760,6 +1793,7 @@ export function buildContextEngineFactory(
       const threshold = getDynamicCompactThreshold(args.tokenBudget);
       return normalizeCompactResult(await client.compactSession(request), {
         tokensBefore: args.currentTokenCount,
+        logger,
         ...(threshold != null ? { threshold } : {}),
       });
     } catch (error) {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -492,7 +492,9 @@ function resolveDynamicCompactThreshold(
   tokenBudget: number | undefined,
   compactThreshold: number | undefined,
   compactionThresholdFraction: number | undefined,
+  compactSessionTokenBudget?: number,
 ): number | undefined {
+  // Explicit compactThreshold always wins.
   if (typeof compactThreshold === "number" && Number.isFinite(compactThreshold) && compactThreshold > 0) {
     return Math.max(1, Math.floor(compactThreshold));
   }
@@ -501,7 +503,16 @@ function resolveDynamicCompactThreshold(
     return undefined;
   }
   const fraction = normalizeThresholdFraction(compactionThresholdFraction);
-  return Math.max(1, Math.floor(normalizedBudget * fraction));
+  const derived = Math.max(1, Math.floor(normalizedBudget * fraction));
+  // Clamp to a safe range so the threshold is never absurdly low (not
+  // enough turns to compact) or absurdly high (Codex Runtime 1M tokens
+  // would produce an unreachable 800k threshold).
+  const withBounds = Math.max(2000, Math.min(16000, derived));
+  // User-configured compactSessionTokenBudget overrides the ceiling.
+  if (typeof compactSessionTokenBudget === "number" && compactSessionTokenBudget > 0) {
+    return Math.min(withBounds, compactSessionTokenBudget);
+  }
+  return withBounds;
 }
 
 function resolvePredictiveCompactionTarget(params: {
@@ -1556,6 +1567,7 @@ export function buildContextEngineFactory(
       tokenBudget,
       cfg.compactThreshold,
       cfg.compactionThresholdFraction,
+      cfg.compactSessionTokenBudget,
     );
 
   const buildAssemblyConfig = (tokenBudget: number | undefined) => ({


### PR DESCRIPTION
## Bug

Codex Runtime passes a large `tokenBudget` (100k+) to `assemble()`. The dynamic compaction threshold becomes `0.8 * 100k = 80k tokens` — far above the configured `compactSessionTokenBudget` (default 2000). The session never triggers auto-compaction because it can't reach the inflated threshold.

## Fix

Cap the derived threshold at `compactSessionTokenBudget` in `resolveDynamicCompactThreshold`. Explicit `compactThreshold` config still wins when set.

## Test plan
- [ ] Session over 2000 tokens with `compactSessionTokenBudget=2000` triggers auto-compact
- [ ] Codex Runtime with `tokenBudget=100000` still caps threshold at 2000
- [ ] Explicit `compactThreshold=5000` overrides the cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version for contracts library

* **Refactor**
  * Enhanced internal tracing and logging capabilities for compaction operations, including daemon state visibility and dynamic threshold configuration with budget capping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->