### PR TITLE
[AI-assisted] Fix memory_expand active-session fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,8 @@ export function register(api: OpenClawPluginApi) {
     api.registerTool?.((ctx) => {
       const getClient = runtimeOrNull.getClient;
       const getSessionKey = () => (ctx as Record<string, unknown>).sessionKey as string | undefined;
-      return createMemoryExpandTool(getClient, getSessionKey, logger);
+      const getSessionId = () => (ctx as Record<string, unknown>).sessionId as string | undefined;
+      return createMemoryExpandTool(getClient, getSessionKey, logger, getSessionId);
     }, { names: ["memory_expand"] });
     api.registerTool?.((ctx) => {
       const getClient = runtimeOrNull.getClient;

--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -256,6 +256,7 @@ export function createMemoryExpandTool(
   getClient: ClientGetter,
   getSessionKey: () => string | undefined,
   logger: LoggerLike = console,
+  getSessionId: () => string | undefined = () => undefined,
 ) {
   return {
     name: "memory_expand",
@@ -274,7 +275,7 @@ export function createMemoryExpandTool(
 
       const maxDepth = readNum(params, "maxDepth", { integer: true, min: 0 }) ?? 1;
       let maxTokens = readNum(params, "maxTokens", { integer: true }) ?? MAX_EXPAND_TOKENS;
-      const sessionId = readStr(params, "sessionId") ?? "";
+      const sessionId = readStr(params, "sessionId") ?? getSessionId() ?? "";
 
       // Subagent budget gate: if this is a subagent, check remaining expansion budget.
       const sessionKey = getSessionKey();

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -86,6 +86,45 @@ test("memory_grep defaults to the active session id", async () => {
   assert.equal(client.calls[0]?.params.collection, "session_summary:active-session");
 });
 
+test("memory_expand defaults to the active session id", async () => {
+  const client = new FakeRecallClient();
+  const tool = createMemoryExpandTool(
+    async () => client as unknown as LibravDBClient,
+    () => undefined,
+    silentLogger,
+    () => "active-session",
+  );
+
+  const result = await tool.execute("call-1", { summaryIds: ["sum-1"] });
+
+  assert.equal((result.details as { summaryId: string }).summaryId, "sum-1");
+  assert.deepEqual(client.calls[0], {
+    method: "expandSummary",
+    params: { sessionId: "active-session", summaryId: "sum-1", maxDepth: 1 },
+  });
+});
+
+test("memory_expand explicit session id takes precedence over active session id", async () => {
+  const client = new FakeRecallClient();
+  const tool = createMemoryExpandTool(
+    async () => client as unknown as LibravDBClient,
+    () => undefined,
+    silentLogger,
+    () => "active-session",
+  );
+
+  const result = await tool.execute("call-1", {
+    summaryIds: ["sum-1"],
+    sessionId: "explicit-session",
+  });
+
+  assert.equal((result.details as { summaryId: string }).summaryId, "sum-1");
+  assert.deepEqual(client.calls[0], {
+    method: "expandSummary",
+    params: { sessionId: "explicit-session", summaryId: "sum-1", maxDepth: 1 },
+  });
+});
+
 test("memory_expand uses remaining subagent budget instead of dropping the first oversized request", async () => {
   const client = new FakeRecallClient();
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "u1", subagentTokenBudget: 1000 }, silentLogger);


### PR DESCRIPTION
## Summary

- Problem: `memory_expand` documented `sessionId` as optional/current-session scoped, but omitted `sessionId` was sent to the daemon as an empty string.
- Solution: pass the active OpenClaw tool-context `sessionId` into `createMemoryExpandTool` and use it as the fallback when callers omit `sessionId`.
- What changed: `src/index.ts` now wires `ctx.sessionId` into `memory_expand`; `src/tools/memory-recall.ts` now accepts an optional active-session resolver; focused regression coverage proves omitted and explicit `sessionId` behavior.
- What did NOT change (scope boundary): no schema, dependency, daemon, storage, ranking, compaction, auth, network, or cross-session recall behavior changed.

## Motivation

- Compacted-summary recall is a core LibraVDB memory path. If `memory_expand` expands against `sessionId=""`, active-session summary recall can look empty or inconsistent even though `memory_describe` and `memory_grep` already use the active session.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: self-found during LibraVDB memory recall beta-readiness review
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `memory_expand` without `sessionId` now resolves the active OpenClaw session id before calling `expandSummary`, instead of using an empty session id.
- Real environment tested: throwaway Linux test-server checkout of unmodified `v1.8.6` plus the local patch, using Node `v24.15.0` and CI-parity `pnpm@9`.
- Exact steps or command run after this patch:

```bash
corepack pnpm@9 install --frozen-lockfile --store-dir "$RUN/.pnpm-store"
corepack pnpm@9 exec tsc -p tsconfig.tests.json
node --test .ts-build/test/unit/memory-recall.test.js
node --test .ts-build/test/unit/memory-tools.test.js .ts-build/test/unit/memory-runtime.test.js .ts-build/test/unit/before-turn.test.js
node --test .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/markdown-ingest.test.js
corepack pnpm@9 exec tsc --noEmit
corepack pnpm@9 run build
git diff --check
```

- Evidence after fix:

```text
memory_expand defaults to the active session id: pass
memory_expand explicit session id takes precedence over active session id: pass
memory_expand uses remaining subagent budget instead of dropping the first oversized request: pass

Focused memory recall run:
tests 5
pass 5
fail 0

Adjacent memory/runtime/before-turn run:
tests 34
pass 34
fail 0

Selected integration green subset:
tests 22
pass 22
fail 0

TypeScript noEmit: pass
Production build: pass
git diff --check: pass
```

- Observed result after fix: omitted `sessionId` produced an `expandSummary` call with `sessionId: "active-session"`, while explicit `sessionId: "explicit-session"` still took precedence.
- What was not tested: live packaged OpenClaw host session, user-facing channel delivery, external hosted providers, and GitHub Actions CI.
- Before evidence:

```text
Before this patch, createMemoryExpandTool had no active-session resolver and used:
readStr(params, "sessionId") ?? ""

That meant omitted sessionId reached expandSummary as an empty session id.
```

## Root Cause (if applicable)

- Root cause: `createMemoryExpandTool` only accepted `getSessionKey`, so it had no way to resolve the active session id from the OpenClaw tool context.
- Missing detection / guardrail: existing recall coverage proved active-session fallback for `memory_describe` and `memory_grep`, but did not cover omitted `sessionId` for `memory_expand`.
- Contributing context (if known): `src/index.ts` already passed active session ids into `memory_describe` and `memory_grep`; `memory_expand` was the inconsistent recall tool.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/memory-recall.test.ts`
- Scenario the test should lock in: omitted `sessionId` uses the active session fallback, while explicit `sessionId` still takes precedence.
- Why this is the smallest reliable guardrail: the bug is in the recall tool's parameter-to-daemon request mapping, so the focused tool test directly asserts the `expandSummary` request payload.
- Existing test that already covers this (if any): none for `memory_expand` omitted-session behavior before this patch.
- If no new test is added, why not: N/A; focused regression tests were added.

## User-visible / Behavior Changes

`memory_expand` now follows its documented current-session default. Users asking for compacted-summary detail in the active conversation should get expansion from the active session instead of an empty-session lookup.

## Diagram (if applicable)

```text
Before:
memory_expand({ summaryIds }) -> sessionId "" -> expandSummary(empty session)

After:
memory_expand({ summaryIds }) -> active ctx.sessionId -> expandSummary(active session)
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux throwaway test-server checkout
- Runtime/container: Node `v24.15.0`, `pnpm@9.15.9`
- Model/provider: N/A
- Integration/channel (if any): LibraVDB memory recall tool path
- Relevant config (redacted): no credentials or private runtime config used

### Steps

1. Build test artifacts with `corepack pnpm@9 exec tsc -p tsconfig.tests.json`.
2. Run the focused `memory-recall` test file.
3. Run adjacent memory/runtime/before-turn unit coverage.
4. Run selected integration files that were green on the patched branch.
5. Run TypeScript noEmit, production build, and `git diff --check`.
6. Compare broader unit and selected integration failures against an unmodified `v1.8.6` baseline.
7. Build patched and unmodified `v1.8.6` before comparing the plugin-inspector runtime-capture result.

### Expected

- Omitted `sessionId` uses the active session id.
- Explicit `sessionId` overrides the active session fallback.
- Adjacent memory/runtime behavior remains green.
- Any broader red tests should either pass or be proven baseline-existing.

### Actual

- Focused and adjacent proof passed.
- The new omitted-session regression called `expandSummary` with `sessionId: "active-session"`.
- The explicit-session regression called `expandSummary` with `sessionId: "explicit-session"`.
- Broader unit and selected integration failures reproduced on unmodified `v1.8.6` with the same failing test names.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Direct all-unit patched run:
tests 210
pass 196
fail 14

Direct all-unit unmodified v1.8.6 baseline:
tests 208
pass 194
fail 14

The 14 failing unit test names were identical on patched and baseline runs.

Selected integration patched run:
tests 46
pass 33
fail 13

Selected integration unmodified v1.8.6 baseline:
tests 46
pass 33
fail 13

The selected integration failures were baseline-existing and not introduced by this patch.

plugin-inspector after building patched and unmodified v1.8.6:
entrypoint-import-error: TypeError: os2.homedir is not a function

The plugin-inspector runtime-capture failure reproduced identically on patched and baseline builds.
```

## Human Verification (required)

- Verified scenarios: omitted `sessionId` fallback, explicit `sessionId` precedence, existing subagent budget behavior, adjacent memory/runtime unit behavior, selected integration green subset, TypeScript noEmit, production build, and diff whitespace.
- Edge cases checked: explicit `sessionId` still wins over active session fallback; baseline comparison was run for broader red unit/integration layers; plugin-inspector was compared fairly after building both patched and unmodified `v1.8.6`.
- What you did **not** verify: live packaged OpenClaw host/channel behavior, external hosted providers, and GitHub Actions CI completion.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot or reviewer conversations exist yet for this draft PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: changing the implicit session used by `memory_expand` when callers omit `sessionId`.
  - Mitigation: the new fallback matches the documented current-session behavior and the existing `memory_describe` / `memory_grep` pattern; focused tests cover omitted and explicit paths.
- Risk: broader repo test failures could be mistaken for this patch.
  - Mitigation: direct all-unit, selected integration, and plugin-inspector failures were compared against unmodified `v1.8.6` and shown to be baseline-existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory expansion tool now supports automatic session ID resolution, with fallback to an active session when not explicitly provided.

* **Tests**
  * Added unit tests verifying session ID resolution behavior and the precedence of explicit session IDs in memory expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->