### PR TITLE
fix: declare memory recall tools in manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -12,7 +12,10 @@
     "contextEngine": true,
     "tools": [
       "memory_search",
-      "memory_get"
+      "memory_get",
+      "memory_describe",
+      "memory_expand",
+      "memory_grep"
     ]
   },
   "activation": {

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -18,7 +18,13 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   );
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);
-  assert.deepEqual(manifest.contracts.tools, ["memory_search", "memory_get"]);
+  assert.deepEqual(manifest.contracts.tools, [
+    "memory_search",
+    "memory_get",
+    "memory_describe",
+    "memory_expand",
+    "memory_grep",
+  ]);
 
   assert.equal(pkg.main, "./dist/index.js");
   assert.equal(pkg.types, "./dist/index.d.ts");


### PR DESCRIPTION
## Summary
- Add memory_describe, memory_expand, and memory_grep to the plugin manifest contracts.tools list.
- Update the checklist validation test so the manifest must declare all registered memory recall tools.

## Verification
- PASS: ./node_modules/.bin/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
- PASS: node --test --test-name-pattern 'manifest and package metadata satisfy checklist structure' .ts-build/test/integration/checklist-validation.test.js
- NOTE: Full checklist-validation.test.js has an unrelated existing source-string assertion failure looking for /context-engine assembler/ in src/memory-provider.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded plugin's declared capabilities to include additional memory operations: describe, expand, and grep tools alongside existing functionality.

* **Tests**
  * Updated integration tests to validate the plugin's expanded tool declarations and ensure manifest compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->