### PR TITLE
feat: inject previous session summary as continuity context on assemble

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2109,6 +2109,48 @@ export function buildContextEngineFactory(
     };
   }
 
+  async function injectContinuityContext(params: {
+    client: Awaited<ReturnType<typeof runtime.getClient>>;
+    userId: string;
+    sessionId: string;
+    logger: LoggerLike;
+    tokenBudget?: number;
+    systemPromptAddition: string;
+  }): Promise<string | null> {
+    try {
+      const continuityHits = await params.client.searchTextCollections({
+        collections: [resolveUserCollection(params.userId)],
+        text: "__session_continuity__",
+        k: 1,
+        excludeByCollection: {},
+      });
+      const continuityHit = continuityHits.results?.find(
+        (r) => r.id === "__session_continuity__"
+      );
+      if (!continuityHit) return null;
+
+      let meta: Record<string, unknown> = {};
+      if (continuityHit.metadataJson && (continuityHit.metadataJson as Uint8Array).length > 0) {
+        try {
+          meta = JSON.parse(new TextDecoder().decode(continuityHit.metadataJson as Uint8Array));
+        } catch { /* metadata parse failed, use empty */ }
+      }
+      const summaryId = meta.summary_id as string | undefined;
+      if (!summaryId) return null;
+
+      const expanded = await params.client.expandSummary({
+        sessionId: (meta.session_id as string) ?? params.sessionId,
+        summaryId,
+        maxDepth: 2,
+      });
+      if (!expanded.text) return null;
+
+      return '<continuity_context>\nThe following is a summary of the previous session. Use it for context about what was discussed before the reset.\n' + expanded.text + '\n</continuity_context>';
+    } catch {
+      return null;
+    }
+  }
+
   async function runCompaction(args: {
     sessionId: string;
     force?: boolean;
@@ -2386,8 +2428,19 @@ export function buildContextEngineFactory(
           emitDebug: true,
         });
         const assembled = normalizeAssembleResult(resp, args.messages);
+        const continuityContext = await injectContinuityContext({
+          client,
+          userId,
+          sessionId,
+          logger,
+          tokenBudget: args.tokenBudget,
+          systemPromptAddition: assembled.systemPromptAddition,
+        });
+        const withContinuity: OpenClawCompatibleAssembleResult = continuityContext
+          ? { ...assembled, systemPromptAddition: appendSystemPromptAddition(assembled.systemPromptAddition, continuityContext) }
+          : assembled;
         let enforced = enforceTokenBudgetInvariant(
-          await augmentWithExactRecall(assembled, {
+          await augmentWithExactRecall(withContinuity, {
             queryText: strippedPrompt || (messages[messages.length - 1]?.content ?? ""),
             userId,
             sessionId,


### PR DESCRIPTION
## Summary

After `/reset`, the daemon writes a `__session_continuity__` pointer to `user:<userId>` during compaction (daemon v1.8.7). On the next session's first `assemble()`, the plugin reads this pointer, expands the summary via the DAG, and injects it as a `<continuity_context>` block in the system prompt.

The model sees previous session context immediately — no `memory_search` required, no 60-second delay.

## How it works

1. Compaction writes `__session_continuity__` → `user:<userId>` with summary ID and metadata
2. `assemble()` calls `injectContinuityContext()` after `assembleContextInternal` returns
3. Searches `user:<userId>` for the pointer, parses metadata, calls `expandSummary` with the summary ID
4. Wraps expanded text in `<continuity_context>` and appends to system prompt
5. Silently returns null on any failure — non-blocking

## Test plan
- [ ] `/reset` → ask "what did we talk about last session" → model answers from injected context immediately
- [ ] No additional RPC latency on sessions without a continuity pointer
- [ ] Gracefully handles missing pointer, missing summary, and expand failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced session context continuity for more coherent conversations across interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->