### PR TITLE
fix: improve continuity pointer search query and k value

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2118,10 +2118,14 @@ export function buildContextEngineFactory(
     systemPromptAddition: string;
   }): Promise<string | null> {
     try {
+      // Use a natural-language query that semantically matches the
+      // pointer record text ("Previous session continuity — ...").
+      // Fetch enough results so the exact ID match isn't crowded out
+      // by stronger semantic hits in the user collection.
       const continuityHits = await params.client.searchTextCollections({
         collections: [resolveUserCollection(params.userId)],
-        text: "__session_continuity__",
-        k: 1,
+        text: "previous session context continuity",
+        k: 8,
         excludeByCollection: {},
       });
       const continuityHit = continuityHits.results?.find(


### PR DESCRIPTION
The original k=1 with search text "__session_continuity__" produced a weak semantic match that could be crowded out by stronger hits in the user collection. Switch to natural language query "previous session context continuity" with k=8, then exact ID match among results.