### PR TITLE
[AI-assisted] Fix invalid subagent expansion budgets

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1665,6 +1665,12 @@ function subagentKey(sessionKey: string): string {
   return sessionKey.trim();
 }
 
+function normalizeSubagentTokenBudget(value: unknown): number {
+  if (typeof value !== "number") return 8000;
+  if (!Number.isFinite(value) || value < 0) return 8000;
+  return Math.floor(value);
+}
+
 // consumeSubagentBudget deducts tokens from the subagent's budget.
 // Returns the granted budget, or -1 if no budget exists (not a subagent).
 export function consumeSubagentBudget(sessionKey: string, tokens: number): number {
@@ -1682,7 +1688,14 @@ export function consumeSubagentBudget(sessionKey: string, tokens: number): numbe
   const budget = subagentBudgets.get(subagentKey(sessionKey));
   if (!budget) return -1; // not a subagent — no budget cap
 
-  const granted = Math.min(tokens, budget.remaining);
+  const requested = Math.floor(tokens);
+  if (!Number.isFinite(requested) || requested <= 0) return 0;
+  if (!Number.isFinite(budget.remaining) || budget.remaining <= 0) {
+    budget.remaining = 0;
+    return 0;
+  }
+
+  const granted = Math.min(requested, budget.remaining);
   budget.remaining = Math.max(0, budget.remaining - granted);
   return granted;
 }
@@ -2734,9 +2747,7 @@ export function buildContextEngineFactory(
       // Grant the subagent a token budget for memory expansion.
       // Default 8000 tokens — enough for a focused expansion,
       // small enough to prevent context window destruction.
-      const budget = typeof cfg.subagentTokenBudget === "number"
-        ? cfg.subagentTokenBudget
-        : 8000;
+      const budget = normalizeSubagentTokenBudget(cfg.subagentTokenBudget);
       const seconds = typeof params.ttlMs === "number" && params.ttlMs > 0
         ? Math.ceil(params.ttlMs / 1000)
         : 120;

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildContextEngineFactory } from "../../src/context-engine.js";
+import { buildContextEngineFactory, consumeSubagentBudget } from "../../src/context-engine.js";
 import { createMemoryDescribeTool, createMemoryExpandTool, createMemoryGrepTool } from "../../src/tools/memory-recall.js";
 import type { LibravDBClient } from "../../src/libravdb-client.js";
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
@@ -143,4 +143,30 @@ test("memory_expand uses remaining subagent budget instead of dropping the first
   assert.equal((result.details as { exceededBudget: boolean }).exceededBudget, false);
   assert.match((result.details as { text: string }).text, /expanded summary text/);
   assert.equal(client.calls[0]?.method, "expandSummary");
+});
+
+test("subagent spawn sanitizes invalid numeric expansion budgets", async () => {
+  for (const [index, subagentTokenBudget] of [
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    -1,
+  ].entries()) {
+    const client = new FakeRecallClient();
+    const engine = buildContextEngineFactory(
+      fakeRuntime(client),
+      { userId: "u1", subagentTokenBudget },
+      silentLogger,
+    );
+    const childSessionKey = `child-invalid-budget-${index}`;
+
+    await engine.prepareSubagentSpawn({
+      parentSessionKey: "parent",
+      childSessionKey,
+    });
+
+    assert.equal(consumeSubagentBudget(childSessionKey, 100), 100);
+    assert.equal(consumeSubagentBudget(childSessionKey, 10_000), 7_900);
+    await engine.onSubagentEnded({ childSessionKey, reason: "test" });
+  }
 });


### PR DESCRIPTION
﻿## Summary

- Problem: invalid numeric `subagentTokenBudget` values such as `NaN`, `Infinity`, `-Infinity`, or negative numbers could enter the subagent memory-expansion budget path.
- Solution: sanitize configured subagent expansion budgets before storing them and guard budget consumption against non-finite or non-positive requested grants.
- What changed: `prepareSubagentSpawn` now falls back to the default `8000` token budget for invalid numeric config values, and `consumeSubagentBudget` no longer returns invalid or negative grants.
- What did NOT change (scope boundary): no daemon, storage, schema, dependency, lockfile, network, API-contract, compaction, ranking, auth, or cross-session recall behavior changed.

## Motivation

Subagent expansion budgets are intended to keep `memory_expand` from blowing a child agent's context window. If an invalid numeric budget is accepted, the budget accounting can stop behaving like a bounded token grant and the subagent path can become effectively unclamped.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: self-found during LibraVDB beta-readiness review of subagent spawning and memory recall expansion.
- Related: #293 is adjacent but already merged and fixes the `memory_expand` active-session fallback, not invalid subagent budgets.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: invalid subagent expansion budgets now fall back to the default bounded `8000` token budget instead of producing `NaN`, negative, or unbounded grants.
- Real environment tested: Linux throwaway test-server checkout of unmodified remote `main` (`9da818d`) plus this patch, using Node `v24.15.0` and `pnpm@9.15.9`.
- Exact steps or command run after this patch:

```bash
corepack pnpm@9 install --frozen-lockfile --store-dir "$RUN/.pnpm-store"
corepack pnpm@9 exec tsc -p tsconfig.tests.json
node --test .ts-build/test/unit/memory-recall.test.js
node --test .ts-build/test/unit/memory-tools.test.js .ts-build/test/unit/memory-runtime.test.js .ts-build/test/unit/before-turn.test.js
node --test .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/markdown-ingest.test.js
corepack pnpm@9 exec tsc --noEmit
corepack pnpm@9 run build
git diff --check
```

- Evidence after fix:

```text
Focused memory-recall: tests 6, pass 6, fail 0
Adjacent memory/runtime/before-turn: tests 34, pass 34, fail 0
Selected integration: tests 22, pass 22, fail 0
tsc -p tsconfig.tests.json: pass
tsc --noEmit: pass
build: pass
git diff --check: pass
```

- Observed result after fix:

```text
NaN budget -> first grant 100, second grant 7900
negative budget -> first grant 100, second grant 7900
Infinity budget -> first grant 100, second grant 7900
```

- What was not tested: live packaged OpenClaw host session, external hosted providers, GitHub Actions CI completion, and a maintainer-hosted production daemon.
- Before evidence:

```text
Unpatched main:
NaN budget -> first grant NaN, second grant NaN
negative budget -> first grant -1, second grant 0
Infinity budget -> first grant 100, second grant 10000
```

## Root Cause

- Root cause: `prepareSubagentSpawn` accepted any JavaScript `number` for `cfg.subagentTokenBudget`, including non-finite and negative values, and stored it directly as the child session budget.
- Missing detection / guardrail: existing `memory_expand` coverage proved remaining-budget clamping for a valid budget, but did not cover invalid numeric budget configuration or invalid requested grants.
- Contributing context (if known): `memory_expand` only treats a granted budget of exactly `0` as exhausted and only clamps when the grant is positive and lower than the requested max, so invalid grants could skip the intended clamp path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/memory-recall.test.ts`
- Scenario the test should lock in: subagent spawn sanitizes `NaN`, `Infinity`, `-Infinity`, and negative expansion budgets to the default bounded budget.
- Why this is the smallest reliable guardrail: the bug is in plugin-side budget accounting, so a focused unit test can assert the exact grants without depending on a daemon or provider.
- Existing test that already covers this (if any): none before this patch.
- If no new test is added, why not: N/A; focused regression coverage was added.

## User-visible / Behavior Changes

Subagents using `memory_expand` now get a bounded default expansion budget when invalid numeric budget config is supplied. Valid positive budgets keep the existing behavior.

## Diagram

```text
Before:
invalid subagentTokenBudget -> stored as child budget -> invalid grant -> memory_expand can skip clamp

After:
invalid subagentTokenBudget -> default 8000 budget -> bounded grant -> memory_expand remains capped
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux throwaway test-server checkout
- Runtime/container: Node `v24.15.0`, `pnpm@9.15.9`
- Model/provider: N/A
- Integration/channel (if any): LibraVDB memory recall tool path and subagent budget path
- Relevant config (redacted): no credentials, tokens, or private runtime config used

### Steps

1. Compare unpatched remote `main` against the patched checkout with a direct subagent-budget probe for `NaN`, negative, and `Infinity` budgets.
2. Build test artifacts with `corepack pnpm@9 exec tsc -p tsconfig.tests.json`.
3. Run focused `memory-recall` coverage.
4. Run adjacent memory/runtime/before-turn unit coverage.
5. Run selected integration coverage for dream promotion and markdown ingestion.
6. Run TypeScript noEmit, production build, and `git diff --check`.
7. Compare broad unit and built `plugin:ci` results against unmodified remote `main`.

### Expected

- Invalid numeric subagent budgets fall back to the default bounded budget.
- Existing valid subagent budget behavior remains unchanged.
- Focused and adjacent memory tests pass.
- Any broad-suite or inspector failures are either green or proven baseline-identical.

### Actual

- Invalid numeric subagent budgets were normalized to the default budget after the patch.
- Focused, adjacent, selected integration, TypeScript, build, and diff checks passed.
- Broad unit failures were baseline-identical.
- Built `plugin:ci` runtime-capture failure was baseline-identical.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Broad unit comparison:
base:    tests 210, pass 194, fail 16
patched: tests 211, pass 195, fail 16
normalized failing test names: identical
patch-introduced broad-unit failures: 0

Plugin Inspector comparison after building both checkouts:
base:    plugin:ci exit 1
patched: plugin:ci exit 1

The built plugin-inspector runtime-capture failure is baseline-identical and was not introduced by this patch.
```

## Human Verification

- Verified scenarios: `NaN`, `Infinity`, `-Infinity`, and negative subagent budgets; existing oversized valid-budget `memory_expand` behavior; focused memory recall; adjacent memory/runtime/before-turn coverage; selected integration coverage; TypeScript; production build; diff whitespace.
- Edge cases checked: invalid configured budgets, non-positive requested grants, non-finite requested grants through the guarded consumption path, and baseline comparison for broader red layers.
- What you did **not** verify: live packaged OpenClaw host/channel behavior, external hosted providers, GitHub Actions CI completion, and production daemon behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot or reviewer conversations exist yet for this draft PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: invalid numeric budget values that previously produced invalid grants now use the default `8000` token budget instead.
  - Mitigation: this restores the documented bounded-subagent behavior and only changes invalid config values.
- Risk: broader repository tests could be mistaken for this patch.
  - Mitigation: broad unit and built `plugin:ci` were compared against unmodified remote `main` and shown to be baseline-identical.
- Risk: a future caller could pass invalid requested token counts directly to `consumeSubagentBudget`.
  - Mitigation: `consumeSubagentBudget` now returns `0` for non-finite or non-positive requested grants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to validate subagent token budget behavior under edge cases with invalid numeric values.

* **Chores**
  * Enhanced subagent token budget management with improved normalization logic for more defensive and reliable token allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->