### PR TITLE
[AI-assisted] Fix memory_grep default session recall

### DIFF
--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -255,7 +255,7 @@ function resultCollection(meta: Record<string, unknown>, fallback = ""): string 
 function isSummaryResult(result: GrepSearchResult, meta: Record<string, unknown>, collection: string): boolean {
   return (
     collection.startsWith("session_summary:") ||
-    result.id.startsWith("sum") ||
+    result.id.startsWith("sum_") ||
     typeof meta.eviction_cue === "string" ||
     typeof meta.compaction_generation === "number"
   );
@@ -507,7 +507,7 @@ export function createMemoryGrepTool(
           }
           const meta = parseResultMetadata(r);
           const collection = resultCollection(meta);
-          const dedupKey = `${collection}:${r.id}`;
+          const dedupKey = r.id;
           if (seen.has(dedupKey)) continue;
           seen.add(dedupKey);
           const summaryResult = isSummaryResult(r, meta, collection);
@@ -517,8 +517,7 @@ export function createMemoryGrepTool(
             if (summaries.length >= limit) continue;
             if (!safeMatch(r.text, pattern, mode)) continue;
             totalMatches++;
-            let evictionCue: string | undefined;
-            evictionCue = typeof meta.eviction_cue === "string" ? meta.eviction_cue : undefined;
+            const evictionCue = typeof meta.eviction_cue === "string" ? meta.eviction_cue : undefined;
             const snippet = truncateSnippet(r.text);
             summaries.push({ summaryId: r.id, snippet, score: r.score, evictionCue });
             totalChars += snippet.length;
@@ -529,8 +528,7 @@ export function createMemoryGrepTool(
             if (!safeMatch(r.text, pattern, mode)) continue;
             totalMatches++;
             const snippet = truncateSnippet(r.text);
-            let role = "unknown";
-            role = typeof meta.role === "string" ? meta.role : "unknown";
+            const role = typeof meta.role === "string" ? meta.role : "unknown";
             turns.push({ turnId: r.id, snippet, role, score: r.score });
             totalChars += snippet.length;
           }

--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -57,6 +57,13 @@ const MAX_GREP_RESULTS = 50;
 const MAX_GREP_CHARS = 40000;
 const MAX_SNIPPET_CHARS = 200;
 
+type GrepSearchResult = {
+  id: string;
+  score: number;
+  text: string;
+  metadataJson?: Uint8Array;
+};
+
 // ── Schemas ──
 
 const MEMORY_DESCRIBE_SCHEMA = {
@@ -181,6 +188,85 @@ function safeMatch(text: string, pattern: string, mode: "regex" | "text"): boole
   } catch {
     return text.toLowerCase().includes(pattern.toLowerCase());
   }
+}
+
+function uniqueCollections(collections: string[]): string[] {
+  return [...new Set(collections.filter((collection) => collection.length > 0))];
+}
+
+function buildGrepCollections(sessionId: string, scope: "messages" | "summaries" | "both"): string[] {
+  const collections: string[] = [];
+  if (scope === "summaries" || scope === "both") {
+    collections.push(`session_summary:${sessionId}`);
+  }
+  if (scope === "messages" || scope === "both") {
+    collections.push(`session_raw:${sessionId}`);
+  }
+  if (sessionId.length > 0) {
+    // Keep memory_grep aligned with memory_search's default session recall collection.
+    // Older or default runtimes store session hits under session:<id> rather than
+    // the experimental session_summary/session_raw split.
+    collections.push(`session:${sessionId}`);
+  }
+  return uniqueCollections(collections);
+}
+
+async function searchGrepCollections(
+  client: Awaited<ReturnType<ClientGetter>>,
+  collections: string[],
+  pattern: string,
+  k: number,
+): Promise<GrepSearchResult[]> {
+  if (collections.length === 0) {
+    return [];
+  }
+  if (collections.length === 1) {
+    const result = await client.searchText({
+      collection: collections[0],
+      text: pattern,
+      k,
+    });
+    return result.results ?? [];
+  }
+  const result = await client.searchTextCollections({
+    collections,
+    text: pattern,
+    k,
+    excludeByCollection: {},
+  });
+  return result.results ?? [];
+}
+
+function parseResultMetadata(result: GrepSearchResult): Record<string, unknown> {
+  if (result.metadataJson && result.metadataJson.length > 0) {
+    try {
+      return JSON.parse(new TextDecoder().decode(result.metadataJson)) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function resultCollection(meta: Record<string, unknown>, fallback = ""): string {
+  return typeof meta.collection === "string" ? meta.collection : fallback;
+}
+
+function isSummaryResult(result: GrepSearchResult, meta: Record<string, unknown>, collection: string): boolean {
+  return (
+    collection.startsWith("session_summary:") ||
+    result.id.startsWith("sum") ||
+    typeof meta.eviction_cue === "string" ||
+    typeof meta.compaction_generation === "number"
+  );
+}
+
+function isTurnResult(_result: GrepSearchResult, meta: Record<string, unknown>, collection: string): boolean {
+  return (
+    collection.startsWith("session_raw:") ||
+    collection.startsWith("session:") ||
+    typeof meta.role === "string"
+  );
 }
 
 // ── Tool factories ──
@@ -403,51 +489,48 @@ export function createMemoryGrepTool(
         let totalChars = 0;
         let totalMatches = 0;
 
-        if (scope === "summaries" || scope === "both") {
-          const searchK = Math.min(limit * 3, 200);
-          const summaryResults = await client.searchText({
-            collection: `session_summary:${sessionId}`,
-            text: pattern,
-            k: searchK,
-          });
-          for (const r of (summaryResults.results ?? [])) {
-            if (summaries.length >= limit || totalChars >= MAX_GREP_CHARS) break;
+        const searchK = Math.min(limit * 3, 200);
+        const grepResults = await searchGrepCollections(
+          client,
+          buildGrepCollections(sessionId, scope),
+          pattern,
+          searchK,
+        );
+        const seen = new Set<string>();
+
+        for (const r of grepResults) {
+          if (
+            (summaries.length >= limit && turns.length >= limit) ||
+            totalChars >= MAX_GREP_CHARS
+          ) {
+            break;
+          }
+          const meta = parseResultMetadata(r);
+          const collection = resultCollection(meta);
+          const dedupKey = `${collection}:${r.id}`;
+          if (seen.has(dedupKey)) continue;
+          seen.add(dedupKey);
+          const summaryResult = isSummaryResult(r, meta, collection);
+          const turnResult = isTurnResult(r, meta, collection);
+
+          if ((scope === "summaries" || scope === "both") && summaryResult) {
+            if (summaries.length >= limit) continue;
             if (!safeMatch(r.text, pattern, mode)) continue;
             totalMatches++;
             let evictionCue: string | undefined;
-            if (r.metadataJson && r.metadataJson.length > 0) {
-              try {
-                const decoder = new TextDecoder();
-                const meta = JSON.parse(decoder.decode(r.metadataJson)) as Record<string, unknown>;
-                evictionCue = typeof meta.eviction_cue === "string" ? meta.eviction_cue : undefined;
-              } catch { /* best-effort */ }
-            }
+            evictionCue = typeof meta.eviction_cue === "string" ? meta.eviction_cue : undefined;
             const snippet = truncateSnippet(r.text);
             summaries.push({ summaryId: r.id, snippet, score: r.score, evictionCue });
             totalChars += snippet.length;
+            continue;
           }
-        }
-
-        if (scope === "messages" || scope === "both") {
-          const searchK = Math.min(limit * 3, 200);
-          const turnResults = await client.searchText({
-            collection: `session_raw:${sessionId}`,
-            text: pattern,
-            k: searchK,
-          });
-          for (const r of (turnResults.results ?? [])) {
-            if (turns.length >= limit || totalChars >= MAX_GREP_CHARS) break;
+          if ((scope === "messages" || scope === "both") && (turnResult || !summaryResult)) {
+            if (turns.length >= limit) continue;
             if (!safeMatch(r.text, pattern, mode)) continue;
             totalMatches++;
             const snippet = truncateSnippet(r.text);
             let role = "unknown";
-            if (r.metadataJson && r.metadataJson.length > 0) {
-              try {
-                const decoder = new TextDecoder();
-                const meta = JSON.parse(decoder.decode(r.metadataJson)) as Record<string, unknown>;
-                role = typeof meta.role === "string" ? meta.role : "unknown";
-              } catch { /* best-effort */ }
-            }
+            role = typeof meta.role === "string" ? meta.role : "unknown";
             turns.push({ turnId: r.id, snippet, role, score: r.score });
             totalChars += snippet.length;
           }

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -63,18 +63,36 @@ class FakeRecallClient {
 }
 
 class DefaultSessionRecallClient extends FakeRecallClient {
+  constructor(private readonly includeDuplicateRawHit = false) {
+    super();
+  }
+
   override async searchTextCollections(params: Record<string, unknown>) {
     this.calls.push({ method: "searchTextCollections", params });
+    const duplicateRawHit = this.includeDuplicateRawHit
+      ? [{
+          id: "turn-1",
+          score: 0.71,
+          text: "needle inside duplicate raw collection",
+          metadataJson: new TextEncoder().encode(JSON.stringify({
+            collection: "session_raw:active-session",
+            role: "user",
+          })),
+        }]
+      : [];
     return {
-      results: [{
-        id: "turn-1",
-        score: 0.88,
-        text: "needle inside default session collection",
-        metadataJson: new TextEncoder().encode(JSON.stringify({
-          collection: "session:active-session",
-          role: "user",
-        })),
-      }],
+      results: [
+        ...duplicateRawHit,
+        {
+          id: "turn-1",
+          score: 0.88,
+          text: "needle inside default session collection",
+          metadataJson: new TextEncoder().encode(JSON.stringify({
+            collection: "session:active-session",
+            role: "user",
+          })),
+        },
+      ],
     };
   }
 }
@@ -144,6 +162,30 @@ test("memory_grep searches the default active session collection", async () => {
     snippet: "needle inside default session collection",
     role: "user",
     score: 0.88,
+  }]);
+});
+
+test("memory_grep deduplicates the same turn across raw and default session collections", async () => {
+  const client = new DefaultSessionRecallClient(true);
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; role: string }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(client.calls[0]?.params.collections, [
+    "session_raw:active-session",
+    "session:active-session",
+  ]);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle inside duplicate raw collection",
+    role: "user",
+    score: 0.71,
   }]);
 });
 

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -43,6 +43,40 @@ class FakeRecallClient {
       }],
     };
   }
+
+  async searchTextCollections(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchTextCollections", params });
+    const collections = params.collections as string[] | undefined;
+    return {
+      results: [{
+        id: "sum-1",
+        score: 0.9,
+        text: "needle inside summary text",
+        metadataJson: new TextEncoder().encode(JSON.stringify({
+          collection: collections?.[0] ?? "session_summary:active-session",
+          role: "assistant",
+          eviction_cue: "summary cue",
+        })),
+      }],
+    };
+  }
+}
+
+class DefaultSessionRecallClient extends FakeRecallClient {
+  override async searchTextCollections(params: Record<string, unknown>) {
+    this.calls.push({ method: "searchTextCollections", params });
+    return {
+      results: [{
+        id: "turn-1",
+        score: 0.88,
+        text: "needle inside default session collection",
+        metadataJson: new TextEncoder().encode(JSON.stringify({
+          collection: "session:active-session",
+          role: "user",
+        })),
+      }],
+    };
+  }
 }
 
 function fakeRuntime(client: FakeRecallClient): PluginRuntime {
@@ -82,8 +116,35 @@ test("memory_grep defaults to the active session id", async () => {
   const result = await tool.execute("call-1", { pattern: "needle", scope: "summaries" });
 
   assert.equal((result.details as { totalMatches: number }).totalMatches, 1);
-  assert.equal(client.calls[0]?.method, "searchText");
-  assert.equal(client.calls[0]?.params.collection, "session_summary:active-session");
+  assert.equal(client.calls[0]?.method, "searchTextCollections");
+  assert.deepEqual(client.calls[0]?.params.collections, [
+    "session_summary:active-session",
+    "session:active-session",
+  ]);
+});
+
+test("memory_grep searches the default active session collection", async () => {
+  const client = new DefaultSessionRecallClient();
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; role: string }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(client.calls[0]?.params.collections, [
+    "session_raw:active-session",
+    "session:active-session",
+  ]);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle inside default session collection",
+    role: "user",
+    score: 0.88,
+  }]);
 });
 
 test("memory_expand defaults to the active session id", async () => {


### PR DESCRIPTION
﻿## Summary

- Problem: `memory_grep` only searched the experimental `session_summary:<id>` and `session_raw:<id>` collections, so it could miss active-session recall stored in LibraVDB's default `session:<id>` collection.
- Solution: include the default `session:<id>` collection in `memory_grep` collection selection while preserving the summary/raw split when those collections exist.
- What changed: `memory_grep` now searches a scoped collection set with `searchTextCollections` when needed, classifies summary vs turn hits from collection/metadata, and deduplicates results.
- What did NOT change (scope boundary): no daemon, manifest, activation, lifecycle, dependency, lockfile, storage schema, auth, migration, `memory_search`, or `memory_expand` behavior changed.

## Motivation

`memory_grep` is the exact-match fallback for active-session recall. After the recall tools were exposed, it still did not search the same default active-session collection used by normal session recall. That made the tool look available but unreliable for exact keys or text that lived under `session:<id>`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: self-found during LibraVDB beta-readiness review of recall tool wiring and active-session grep behavior.
- Related: #294 declares the recall tools in the manifest; this PR fixes the runtime search collections used by `memory_grep`.
- Related: #301 is adjacent `memory_search` metadata surfacing and does not change `memory_grep` collection routing.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: `memory_grep` now finds exact active-session hits stored under the default `session:<id>` collection.
- Real environment tested: Linux throwaway test-server checkout of unmodified remote `main` (`944bbbd`) plus this patch, using Node `v24.15.0` and `pnpm@9.15.9`.
- Exact steps or command run after this patch:

```bash
corepack pnpm@9 install --frozen-lockfile --store-dir "$RUN/.pnpm-store"
corepack pnpm@9 exec tsc -p tsconfig.tests.json
node memory-grep-runtime-proof.mjs patched
node --test .ts-build/test/unit/memory-recall.test.js
node --test .ts-build/test/unit/memory-tools.test.js .ts-build/test/unit/memory-runtime.test.js .ts-build/test/unit/before-turn.test.js
node --test .ts-build/test/unit/*.test.js
node --test .ts-build/test/integration/host-flow.test.js
corepack pnpm@9 exec tsc --noEmit
corepack pnpm@9 run build
corepack pnpm@9 run plugin:ci
git diff --check
```

- Evidence after fix:

```text
RUNTIME_PROOF_PATCHED_FINDS_DEFAULT_SESSION=1
calls=[{"method":"searchTextCollections","params":{"collections":["session_raw:active-session","session:active-session"],"text":"needle","k":150,"excludeByCollection":{}}}]
details.totalMatches=1
details.turns[0].snippet="needle inside default session collection"
```

- Observed result after fix: the default-session hit is returned as a turn result with role `user`, score `0.88`, and the expected snippet.
- What was not tested: production daemon data with a live OpenClaw packaged host session, external hosted providers, GitHub Actions completion, and maintainer-hosted production runtime.
- Before evidence:

```text
BASE_HEAD=944bbbd9b3b5899f8e3b07c25cf265a4ccc6b244
RUNTIME_PROOF_BASE_MISSES_DEFAULT_SESSION=1
calls=[{"method":"searchText","params":{"collection":"session_raw:active-session","text":"needle","k":150}}]
details.totalMatches=0
```

## Root Cause

- Root cause: `memory_grep` hard-coded `session_summary:<id>` for summaries and `session_raw:<id>` for messages, but the default session recall path can store/search hits under `session:<id>`.
- Missing detection / guardrail: existing `memory_grep` coverage only asserted the experimental summary collection, not the default session collection used by ordinary active-session recall.
- Contributing context (if known): the manifest/tool wiring fix made `memory_grep` callable, which exposed that its collection routing was narrower than `memory_search` session recall.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/memory-recall.test.ts`
- Scenario the test should lock in: `memory_grep` with `scope=messages` searches both `session_raw:<id>` and default `session:<id>`, and returns the default-session hit.
- Why this is the smallest reliable guardrail: the bug is in plugin-side collection selection before daemon search, so a focused fake-client unit test can assert the outgoing collection set and returned result shape.
- Existing test that already covers this (if any): none before this patch.
- If no new test is added, why not: N/A; focused regression coverage was added.

## User-visible / Behavior Changes

`memory_grep` can now find exact active-session text stored in the default session recall collection. Existing summary/raw collection behavior remains available.

## Diagram

```text
Before:
memory_grep(scope=messages) -> session_raw:<id> only -> default session hit missed

After:
memory_grep(scope=messages) -> session_raw:<id> + session:<id> -> default session hit returned
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No; the added collection is the same active-session namespace already used by LibraVDB session recall.
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux throwaway test-server checkout
- Runtime/container: Node `v24.15.0`, `pnpm@9.15.9`
- Model/provider: N/A
- Integration/channel (if any): LibraVDB recall tool path, fake daemon client for deterministic collection routing
- Relevant config (redacted): no credentials, tokens, private runtime config, or external provider account used

### Steps

1. Clone unmodified remote `main` at `944bbbd`.
2. Compile test artifacts with `corepack pnpm@9 exec tsc -p tsconfig.tests.json`.
3. Run a deterministic runtime proof where the only hit is in `session:active-session`.
4. Confirm unpatched `memory_grep` searches only `session_raw:active-session` and returns zero matches.
5. Apply this patch.
6. Confirm patched `memory_grep` searches `session_raw:active-session` plus `session:active-session` and returns the hit.
7. Run targeted, adjacent, TypeScript, build, broad baseline comparison, and plugin-inspector baseline comparison gates.

### Expected

- Unpatched `main` misses the default-session hit.
- Patched branch returns the default-session hit.
- Targeted/adjacent memory tests pass.
- TypeScript and build pass.
- Any broad-suite or inspector failures are either green or proven baseline-identical.

### Actual

- Unpatched `main` missed the default-session hit.
- Patched branch returned the hit.
- Targeted and adjacent memory tests passed.
- TypeScript and build passed.
- Broad unit, `host-flow`, and `plugin:ci` remained red on both base and patched with baseline-identical exits/output class.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Targeted memory-recall after patch: tests 7, pass 7, fail 0
Adjacent memory/runtime/before-turn after patch: tests 34, pass 34, fail 0
tsc -p tsconfig.tests.json: pass
tsc --noEmit: pass
pnpm run build: pass
git diff --check: pass

Broad unit comparison:
base exit: 1
patched exit: 1
representative baseline failure class: slot-conflict expectations around recall tools

Host-flow comparison:
base exit: 1
patched exit: 1
representative baseline failure class: existing assembly/compaction expectation drift

Plugin inspector comparison:
base exit: 1
patched exit: 1
baseline output: plugin-inspector runtime capture failed for 1 entrypoints
```

## Human Verification

- Verified scenarios: default `session:<id>` message hit, existing summary collection search, scoped `messages` routing, targeted recall tools, adjacent memory/runtime/before-turn units, TypeScript, production build, whitespace diff check, and baseline comparisons for known red broad gates.
- Edge cases checked: multi-collection search, deduped collection list, summary vs turn classification from collection and metadata, default active session ID fallback, and no dependency/lockfile changes.
- What you did **not** verify: live packaged OpenClaw host session, external hosted providers, GitHub Actions completion, and maintainer-hosted production daemon behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot or reviewer conversations exist yet for this draft PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: searching one additional active-session collection could return duplicate hits when a daemon indexes both raw and default session collections.
  - Mitigation: the patch deduplicates by collection and result ID while preserving separate summary and turn result buckets.
- Risk: default-session results may not include rich summary metadata.
  - Mitigation: default-session hits are classified as turn results unless summary metadata/IDs indicate a summary.
- Risk: broad repository gates are already red and could be mistaken for this patch.
  - Mitigation: base-vs-patched comparison showed the same exit state/output class for broad unit, `host-flow`, and `plugin:ci`; targeted/adjacent/TypeScript/build gates passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded memory search to query across multiple storage collections with improved result deduplication and organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->