### PR TITLE
chore: patch release v1.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - Guarded against undefined `session_id` in continuity fallback text.
 - Reduced exact recall search breadth from 32 to 10.
 - Requires daemon v1.8.8.
+


### PR DESCRIPTION
Triggering patch release for merged PRs:

- #304 feat: instruct model to use pre-loaded memory context before searching
- #268 fix: run integration suite in default check  
- #306 chore: update vulnerable dev dependencies (9 CVEs, minHostVersion → 2026.4.23)