### PR TITLE
fix: remove duplicate markdown ingest test type

### DIFF
--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -6,12 +6,6 @@ import path from "node:path";
 
 import { createMarkdownIngestionHandle, type FsDirentLike } from "../../src/markdown-ingest.js";
 
-type FsDirentLike = {
-  name: string;
-  isDirectory(): boolean;
-  isFile(): boolean;
-};
-
 class FakeRpcClient {
   calls: Array<{ method: string; params: unknown }> = [];
   documents = new Map<string, { text: string; tokenizerId: string; coreDoc: boolean; sourceMeta: Record<string, unknown> }>();


### PR DESCRIPTION
## Summary

- Removes the duplicate local `FsDirentLike` declaration from the markdown ingestion integration test.
- Uses the exported `FsDirentLike` type from `src/markdown-ingest.ts` as the single test seam.

Fixes #308.

## Verification

- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json` — PASS
- `pnpm check` — FAILS after this fix reaches unit tests; current upstream has unrelated unit failures in `context-engine`, `memory-provider`, and `slot-conflict` tests.
- `npm run test:integration` — FAILS after this fix reaches integration tests; current upstream has unrelated host-flow/checklist assertion failures.

– Vale
