### PR TITLE
fix: reconcile empty dream promotion sources

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -212,14 +212,6 @@ export function createDreamPromotionHandle(
 
     const text = textDecoder.decode(bytes);
     const candidates = parseDreamPromotionCandidates(text);
-    if (candidates.length === 0) {
-      lastFileState = {
-        size: stat.size,
-        mtimeMs: stat.mtimeMs,
-        fileHash,
-      };
-      return;
-    }
 
     const client = await getClient();
     await client.promoteDreamEntries({

--- a/test/integration/dream-promotion.test.ts
+++ b/test/integration/dream-promotion.test.ts
@@ -125,6 +125,22 @@ test("dream promotion handle reads diary bullets and forwards them to the sideca
     await delay(25);
 
     assert.equal(client.calls.filter((call) => call.method === "promoteDreamEntries").length, 1);
+
+    await fsp.writeFile(
+      diaryPath,
+      [
+        "# DREAMS",
+        "",
+        "## Deep Sleep",
+        "- No longer a candidate",
+      ].join("\n"),
+    );
+    fsApi.callbacks.get(path.dirname(diaryPath))?.[0]?.("change", path.basename(diaryPath));
+    await delay(25);
+
+    const promoteCalls = client.calls.filter((call) => call.method === "promoteDreamEntries");
+    assert.equal(promoteCalls.length, 2);
+    assert.deepEqual((promoteCalls[1]?.params as { entries: unknown[] }).entries, []);
   } finally {
     await handle?.stop();
     if (previousStateDir === undefined) {

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -6,12 +6,6 @@ import path from "node:path";
 
 import { createMarkdownIngestionHandle, type FsDirentLike } from "../../src/markdown-ingest.js";
 
-type FsDirentLike = {
-  name: string;
-  isDirectory(): boolean;
-  isFile(): boolean;
-};
-
 class FakeRpcClient {
   calls: Array<{ method: string; params: unknown }> = [];
   documents = new Map<string, { text: string; tokenizerId: string; coreDoc: boolean; sourceMeta: Record<string, unknown> }>();


### PR DESCRIPTION
## Summary

- Makes the dream promotion watcher send source reconciliation even when parsing finds zero promotion candidates.
- Keeps unchanged-file hash suppression intact.
- Extends the watcher integration test to cover candidate removal and assert the second promotion RPC carries `entries: []`.

Fixes #316.

## Verification

- `pnpm exec tsc --noEmit` — PASS
- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/dream-promotion.test.js` — PASS

Note: this branch is stacked on #318 so the test suite can compile. Full `pnpm check` and `npm run test:integration` are still blocked by unrelated upstream unit/integration failures after #318's compile fix.

– Vale
