### PR TITLE
fix: harden turn manifest storage and overlap

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -7,6 +7,7 @@ export interface TurnEntry {
   index: number;
   role: string;
   contentHash: string;
+  idHash?: string;
   turnHash: string;
   ingestedAt: number;
 }
@@ -25,18 +26,27 @@ export interface KernelCompatibleMessage {
 }
 
 export class TurnManifestStore {
-  private manifestDir: string;
+  private readonly manifestDirOverride?: string;
 
-  constructor() {
-    this.manifestDir = path.join(os.homedir(), ".openclaw", "libravdb-manifests");
-    if (!fs.existsSync(this.manifestDir)) {
-      fs.mkdirSync(this.manifestDir, { recursive: true });
-    }
+  constructor(manifestDir?: string) {
+    this.manifestDirOverride = manifestDir;
   }
 
   private getManifestPath(sessionId: string): string {
-    const safe = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
-    return path.join(this.manifestDir, `${safe}.manifest.json`);
+    const digest = this.hashString(sessionId);
+    return path.join(this.getManifestDir(), `${digest}.manifest.json`);
+  }
+
+  private getManifestDir(): string {
+    if (this.manifestDirOverride) {
+      return this.manifestDirOverride;
+    }
+    const stateRoot = process.env.OPENCLAW_STATE_DIR?.trim();
+    return path.join(stateRoot || path.join(os.homedir(), ".openclaw"), "libravdb-manifests");
+  }
+
+  private ensureManifestDir(): void {
+    fs.mkdirSync(this.getManifestDir(), { recursive: true });
   }
 
   public hashString(data: string): string {
@@ -63,6 +73,11 @@ export class TurnManifestStore {
       const raw = fs.readFileSync(filePath, "utf8");
       const manifest = JSON.parse(raw) as TurnManifest;
 
+      if (manifest.sessionId !== sessionId) {
+        logger?.warn?.(`[LibraVDB] Manifest session mismatch for ${sessionId}. Forcing re-sync.`);
+        return this.createEmpty(sessionId);
+      }
+
       if (!this.verifyChain(manifest)) {
         logger?.warn?.(`[LibraVDB] Manifest chain broken for session ${sessionId}. Forcing re-sync.`);
         return this.createEmpty(sessionId);
@@ -76,6 +91,7 @@ export class TurnManifestStore {
   }
 
   public save(manifest: TurnManifest): void {
+    this.ensureManifestDir();
     const filePath = this.getManifestPath(manifest.sessionId);
     const tempPath = `${filePath}.${process.pid}.tmp`;
 
@@ -110,22 +126,42 @@ export class TurnManifestStore {
       return 0;
     }
 
-    // Build a map of contentHash → index in our manifest
-    const known = new Map<string, number>();
-    for (const turn of manifest.turns) {
-      known.set(turn.contentHash, turn.index);
-    }
-
-    // Scan incoming messages from newest to oldest to find the last match
-    for (let i = incomingMessages.length - 1; i >= 0; i--) {
-      const contentHash = this.hashString(incomingMessages[i].content);
-      if (known.has(contentHash)) {
-        return i + 1; // everything at and after this index is new
+    const maxOverlap = Math.min(manifest.turns.length, incomingMessages.length);
+    for (let overlapLength = maxOverlap; overlapLength > 0; overlapLength--) {
+      if (this.matchesManifestTail(manifest.turns, incomingMessages, overlapLength)) {
+        return overlapLength;
       }
     }
 
     // No overlap found — OpenClaw trimmed too much or session diverged
     return 0;
+  }
+
+  private matchesManifestTail(
+    turns: TurnEntry[],
+    incomingMessages: KernelCompatibleMessage[],
+    overlapLength: number,
+  ): boolean {
+    const manifestStart = turns.length - overlapLength;
+    let hasMessageIdentity = false;
+
+    for (let i = 0; i < overlapLength; i++) {
+      const turn = turns[manifestStart + i];
+      const msg = incomingMessages[i];
+      if (!turn || !msg || turn.role !== msg.role || turn.contentHash !== this.hashString(msg.content)) {
+        return false;
+      }
+      const incomingIdHash = msg.id ? this.hashString(msg.id) : undefined;
+      if (turn.idHash || incomingIdHash) {
+        if (turn.idHash === incomingIdHash) {
+          hasMessageIdentity = true;
+        } else if (overlapLength === 1) {
+          return false;
+        }
+      }
+    }
+
+    return hasMessageIdentity || overlapLength > 1;
   }
 
   public appendACKedMessages(
@@ -140,6 +176,7 @@ export class TurnManifestStore {
       const msg = newMessages[i];
       const absoluteIndex = startingIndex + i;
       const contentHash = this.hashString(msg.content);
+      const idHash = msg.id ? this.hashString(msg.id) : undefined;
 
       currentHash = this.hashString(`${absoluteIndex}${msg.role}${contentHash}${currentHash}`);
 
@@ -147,6 +184,7 @@ export class TurnManifestStore {
         index: absoluteIndex,
         role: msg.role,
         contentHash,
+        ...(idHash ? { idHash } : {}),
         turnHash: currentHash,
         ingestedAt: Date.now(),
       });

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -6,12 +6,6 @@ import path from "node:path";
 
 import { createMarkdownIngestionHandle, type FsDirentLike } from "../../src/markdown-ingest.js";
 
-type FsDirentLike = {
-  name: string;
-  isDirectory(): boolean;
-  isFile(): boolean;
-};
-
 class FakeRpcClient {
   calls: Array<{ method: string; params: unknown }> = [];
   documents = new Map<string, { text: string; tokenizerId: string; coreDoc: boolean; sourceMeta: Record<string, unknown> }>();

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fsp from "node:fs/promises";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { TurnManifestStore } from "../../src/manifest.js";
+
+test("manifest store does not create its directory until save", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-manifest-lazy-"));
+  const manifestDir = path.join(tempRoot, "manifests");
+  const store = new TurnManifestStore(manifestDir);
+
+  assert.equal(fs.existsSync(manifestDir), false);
+  store.load("session-a");
+  assert.equal(fs.existsSync(manifestDir), false);
+
+  store.save(store.createEmpty("session-a"));
+  assert.equal(fs.existsSync(manifestDir), true);
+});
+
+test("manifest store keeps lossy-sanitizer session ids in distinct files", async () => {
+  const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-manifest-collide-"));
+  const store = new TurnManifestStore(manifestDir);
+  const slashManifest = store.appendACKedMessages(
+    store.createEmpty("session/a"),
+    [{ role: "user", content: "slash session" }],
+    0,
+  );
+  const underscoreManifest = store.appendACKedMessages(
+    store.createEmpty("session_a"),
+    [{ role: "user", content: "underscore session" }],
+    0,
+  );
+
+  store.save(slashManifest);
+  store.save(underscoreManifest);
+
+  assert.equal(store.load("session/a").sessionId, "session/a");
+  assert.equal(store.load("session/a").turns[0]?.contentHash, store.hashString("slash session"));
+  assert.equal(store.load("session_a").sessionId, "session_a");
+  assert.equal(store.load("session_a").turns[0]?.contentHash, store.hashString("underscore session"));
+});
+
+test("manifest store rejects a file whose embedded session id does not match", async () => {
+  const manifestDir = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-manifest-mismatch-"));
+  const store = new TurnManifestStore(manifestDir);
+  const warnings: string[] = [];
+
+  store.save(store.appendACKedMessages(
+    store.createEmpty("session/a"),
+    [{ role: "user", content: "wrong file" }],
+    0,
+  ));
+  await fsp.copyFile(
+    path.join(manifestDir, `${store.hashString("session/a")}.manifest.json`),
+    path.join(manifestDir, `${store.hashString("session_a")}.manifest.json`),
+  );
+
+  const loaded = store.load("session_a", { warn: (message) => warnings.push(message) });
+
+  assert.equal(loaded.sessionId, "session_a");
+  assert.equal(loaded.turns.length, 0);
+  assert.match(warnings[0] ?? "", /session mismatch/u);
+});
+
+test("manifest overlap requires ordered tail-prefix match", () => {
+  const store = new TurnManifestStore("/tmp/unused-manifest-test");
+  const manifest = store.appendACKedMessages(
+    store.createEmpty("session-a"),
+    [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+    ],
+    0,
+  );
+
+  assert.equal(store.findOverlapIndex(manifest, [
+    { role: "user", content: "first" },
+    { role: "assistant", content: "second" },
+  ]), 2);
+  assert.equal(store.findOverlapIndex(manifest, [
+    { role: "assistant", content: "second" },
+  ]), 0);
+});
+
+test("manifest overlap tolerates rotated ids for ordered multi-message matches", () => {
+  const store = new TurnManifestStore("/tmp/unused-manifest-test");
+  const manifest = store.appendACKedMessages(
+    store.createEmpty("session-a"),
+    [
+      { role: "user", content: "first", id: "synthetic-1" },
+      { role: "assistant", content: "second", id: "synthetic-2" },
+    ],
+    0,
+  );
+
+  assert.equal(store.findOverlapIndex(manifest, [
+    { role: "user", content: "first", id: "rotated-1" },
+    { role: "assistant", content: "second", id: "rotated-2" },
+  ]), 2);
+});
+
+test("manifest overlap distinguishes single repeated content by message id", () => {
+  const store = new TurnManifestStore("/tmp/unused-manifest-test");
+  const manifest = store.appendACKedMessages(
+    store.createEmpty("session-a"),
+    [{ role: "user", content: "ok", id: "turn-1" }],
+    0,
+  );
+
+  assert.equal(store.findOverlapIndex(manifest, [{ role: "user", content: "ok", id: "turn-1" }]), 1);
+  assert.equal(store.findOverlapIndex(manifest, [{ role: "user", content: "ok", id: "turn-2" }]), 0);
+  assert.equal(store.findOverlapIndex(manifest, [{ role: "user", content: "ok" }]), 0);
+});


### PR DESCRIPTION
## Summary
- Stores turn manifests under hashed session-id filenames and validates the embedded `sessionId` before trusting a file.
- Defers manifest directory creation until save time and honors `OPENCLAW_STATE_DIR` before falling back to the default state root.
- Replaces unordered content-hash overlap with ordered tail-prefix matching, while using message-id hashes to disambiguate single repeated-content turns.
- Adds unit coverage for lazy directory creation, sanitizer-collision session IDs, session mismatch rejection, ordered overlap, rotated synthetic IDs, and single-turn repeated content.

Fixes #309.
Fixes #310.
Fixes #311.

## Verification
- `pnpm exec tsc --noEmit` — PASS
- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/manifest.test.js && node --test --test-name-pattern="afterTurn is idempotent" .ts-build/test/unit/context-engine.test.js` — PASS
- `pnpm check` — FAILS after TypeScript/plugin inspector, in existing unrelated context-engine/memory-provider/slot-conflict unit tests.
- `npm run test:integration` — FAILS in existing unrelated checklist/host-flow expectation tests; manifest-targeted and markdown/dream integration coverage passes.

Stack note: this branch includes #318 so test compilation is unblocked before this focused manifest change.

– Vale