### PR TITLE
fix: canonicalize compacted session context replay

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1190,9 +1190,38 @@ function buildBudgetFallbackContext(
 const DAEMON_AUTHORED_CONTEXT_RE = /<authored_context\b[^>]*>([\s\S]*?)<\/authored_context>/gi;
 const DAEMON_AUTHORED_CONTEXT_GUIDANCE_RE =
   /^\s*Treat the authored entries below as active project rules and identity context\.?\s*$/i;
+const COMPACTED_SESSION_CONTEXT_RE =
+  /<compacted_session_context\b([^>]*)>([\s\S]*?)<\/compacted_session_context>/gi;
+const COMPACTED_SESSION_RENDER_LEDGER_RE =
+  /(?:^|\n)(?:Artifacts:|Constraints:|Open Next Steps:|Extracted context anchors:)(?:\n|$)/;
 
 function sanitizeDaemonSystemPromptAddition(text: string): string {
-  return demoteDaemonAuthoredContextBlocks(sanitizeToolCallPatterns(text));
+  return demoteDaemonAuthoredContextBlocks(
+    canonicalizeCompactedSessionContextBlocks(sanitizeToolCallPatterns(text)),
+  );
+}
+
+function canonicalizeCompactedSessionContextBlocks(text: string): string {
+  return text.replace(COMPACTED_SESSION_CONTEXT_RE, (match, attrs: string, inner: string) => {
+    const trimmed = String(inner).trim();
+    const firstLine = trimmed.split(/\r?\n/, 1)[0]?.trim();
+    if (!firstLine?.startsWith("{")) {
+      return match;
+    }
+
+    const rest = trimmed.slice(firstLine.length).trim();
+    if (!COMPACTED_SESSION_RENDER_LEDGER_RE.test(rest)) {
+      return match;
+    }
+
+    try {
+      JSON.parse(firstLine);
+    } catch {
+      return match;
+    }
+
+    return `<compacted_session_context${attrs}>\n${firstLine}\n</compacted_session_context>`;
+  });
 }
 
 function demoteDaemonAuthoredContextBlocks(text: string): string {
@@ -1789,9 +1818,13 @@ export function normalizeAssembleResult(
   },
   sourceMessages?: OpenClawCompatibleMessage[]
 ): OpenClawCompatibleAssembleResult {
-  let systemPromptAddition = typeof result.systemPromptAddition === "string"
-    ? sanitizeDaemonSystemPromptAddition(result.systemPromptAddition)
+  const rawSystemPromptAddition = typeof result.systemPromptAddition === "string"
+    ? result.systemPromptAddition
     : "";
+  let systemPromptAddition = rawSystemPromptAddition
+    ? sanitizeDaemonSystemPromptAddition(rawSystemPromptAddition)
+    : "";
+  const systemPromptWasReduced = rawSystemPromptAddition.length > systemPromptAddition.length;
   const messages: OpenClawCompatibleMessage[] = [];
   const extractedMemoryItems: string[] = [];
 
@@ -1895,7 +1928,9 @@ export function normalizeAssembleResult(
   return {
     messages,
     estimatedTokens:
-      typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
+      systemPromptWasReduced
+        ? approximateTokenCount(systemPromptAddition) + approximateMessagesTokens(messages)
+        : typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
     systemPromptAddition,
     promptAuthority: PROMPT_AUTHORITY_PREASSEMBLY_MAY_OVERFLOW,
     ...(result.debug != null ? { debug: result.debug } : {}),

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -956,6 +956,10 @@ function resolveDynamicCompactThreshold(
     logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=explicit tokenBudget=${tokenBudget} compactThreshold=${compactThreshold} → ${val}`);
     return val;
   }
+  if (compactSessionTokenBudget === 0) {
+    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=disabled tokenBudget=${tokenBudget}`);
+    return undefined;
+  }
   const normalizedBudget = normalizeTokenBudget(tokenBudget);
   if (normalizedBudget == null) {
     logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=null_budget tokenBudget=${tokenBudget} → undefined`);
@@ -967,12 +971,6 @@ function resolveDynamicCompactThreshold(
   // enough turns to compact) or absurdly high (Codex Runtime 1M tokens
   // would produce an unreachable 800k threshold).
   const withBounds = Math.max(2000, Math.min(16000, derived));
-  // User-configured compactSessionTokenBudget overrides the ceiling.
-  if (typeof compactSessionTokenBudget === "number" && compactSessionTokenBudget > 0) {
-    const capped = Math.min(withBounds, compactSessionTokenBudget);
-    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=user_cap tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} cap=${compactSessionTokenBudget} → ${capped}`);
-    return capped;
-  }
   logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=clamped tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} → ${withBounds}`);
   return withBounds;
 }
@@ -980,10 +978,21 @@ function resolveDynamicCompactThreshold(
 function resolvePredictiveCompactionTarget(params: {
   currentTokenCount: number | undefined;
   threshold: number | undefined;
+  compactSessionTokenBudget?: number;
+  lastCompactedTokenCount?: number;
 }): number | undefined {
   const currentTokenCount = normalizeCurrentTokenCount(params.currentTokenCount);
   const threshold = normalizeTokenBudget(params.threshold);
   if (currentTokenCount == null || threshold == null || currentTokenCount < threshold) {
+    return undefined;
+  }
+  const sinceLastBudget = normalizeTokenBudget(params.compactSessionTokenBudget);
+  const lastCompactedTokenCount = normalizeCurrentTokenCount(params.lastCompactedTokenCount);
+  if (
+    sinceLastBudget != null &&
+    lastCompactedTokenCount != null &&
+    currentTokenCount - lastCompactedTokenCount < sinceLastBudget
+  ) {
     return undefined;
   }
 
@@ -2058,6 +2067,8 @@ export function buildContextEngineFactory(
 
   const predictiveContextCache = new Map<string, import("./types.js").PredictedContext[]>();
   const PREDICTIVE_CACHE_MAX_SIZE = 100;
+  const predictiveCompactionCursors = new Map<string, number>();
+  const PREDICTIVE_COMPACTION_CURSOR_MAX_SIZE = 100;
 
   // BeforeTurnKernel state
   const turnCache = new TurnMemoryCache(100);
@@ -2295,6 +2306,14 @@ export function buildContextEngineFactory(
       cfg.compactionThresholdFraction,
       cfg.compactSessionTokenBudget,
     );
+
+  const markPredictiveCompactionCursor = (sessionId: string, currentTokenCount: number): void => {
+    if (predictiveCompactionCursors.size >= PREDICTIVE_COMPACTION_CURSOR_MAX_SIZE) {
+      const oldest = predictiveCompactionCursors.keys().next().value;
+      if (oldest !== undefined) predictiveCompactionCursors.delete(oldest);
+    }
+    predictiveCompactionCursors.set(sessionId, currentTokenCount);
+  };
 
   const buildAssemblyConfig = (tokenBudget: number | undefined) => ({
     useSessionRecallProjection: cfg.useSessionRecallProjection,
@@ -2569,6 +2588,8 @@ export function buildContextEngineFactory(
     const predictiveTargetSize = resolvePredictiveCompactionTarget({
       currentTokenCount: currentContextTokens,
       threshold: dynamicCompactThreshold,
+      compactSessionTokenBudget: cfg.compactSessionTokenBudget,
+      lastCompactedTokenCount: predictiveCompactionCursors.get(args.sessionId),
     });
     if (
       currentContextTokens == null ||
@@ -2593,6 +2614,9 @@ export function buildContextEngineFactory(
       force: true,
       currentTokenCount: currentContextTokens,
     });
+    if (compactionResult.compacted) {
+      markPredictiveCompactionCursor(args.sessionId, currentContextTokens);
+    }
     logPredictiveCompactionOutcome({
       logger,
       phase: "afterTurn",
@@ -2612,6 +2636,7 @@ export function buildContextEngineFactory(
     async bootstrap(args: { sessionId: string; sessionKey?: string; userId?: string }) {
       const sessionId = requireSessionId(args.sessionId, "bootstrap");
       predictiveContextCache.delete(sessionId);
+      predictiveCompactionCursors.delete(sessionId);
       postToolRecallCache.delete(sessionId);
       asyncIngestionQueues.delete(sessionId);
       const userId = resolveUserId({
@@ -2693,6 +2718,8 @@ export function buildContextEngineFactory(
       const predictiveTargetSize = resolvePredictiveCompactionTarget({
         currentTokenCount: currentContextTokens,
         threshold: dynamicCompactThreshold,
+        compactSessionTokenBudget: cfg.compactSessionTokenBudget,
+        lastCompactedTokenCount: predictiveCompactionCursors.get(sessionId),
       });
       if (dynamicCompactThreshold != null && predictiveTargetSize != null) {
         logPredictiveCompactionAttempt({
@@ -2711,6 +2738,9 @@ export function buildContextEngineFactory(
           force: true,
           currentTokenCount: currentContextTokens,
         });
+        if (compactionResult.compacted) {
+          markPredictiveCompactionCursor(sessionId, currentContextTokens);
+        }
         logPredictiveCompactionOutcome({
           logger,
           phase: "assemble",
@@ -3213,6 +3243,7 @@ export function buildContextEngineFactory(
         }
       }
       predictiveContextCache.clear();
+      predictiveCompactionCursors.clear();
       postToolRecallCache.clear();
       asyncIngestionQueues.clear();
       triggerCache.clear();

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -385,6 +385,114 @@ test("assemble prefers authoritative currentTokenCount for predictive compaction
   assert.equal(compactParams.force, true);
 });
 
+test("assemble does not let compactSessionTokenBudget lower the dynamic trigger threshold", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "ok" }],
+    estimatedTokens: 32,
+    systemPromptAddition: "",
+  });
+
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactSessionTokenBudget: 2000,
+  });
+
+  await context.assemble({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    tokenBudget: 262144,
+    currentTokenCount: 3354,
+  });
+
+  assert.equal(rpc.getLastCall("compact_session"), null);
+  assert.ok(rpc.getLastCall("assemble_context_internal"), "Expected assembly without predictive compaction");
+});
+
+test("assemble disables predictive compaction when compactSessionTokenBudget is zero", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "ok" }],
+    estimatedTokens: 32,
+    systemPromptAddition: "",
+  });
+
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactSessionTokenBudget: 0,
+  });
+
+  await context.assemble({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    tokenBudget: 262144,
+    currentTokenCount: 20000,
+  });
+
+  assert.equal(rpc.getLastCall("compact_session"), null);
+  assert.ok(rpc.getLastCall("assemble_context_internal"), "Expected assembly when predictive compaction is disabled");
+});
+
+test("assemble keeps compactThreshold explicit override when compactSessionTokenBudget is zero", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "ok" }],
+    estimatedTokens: 32,
+    systemPromptAddition: "",
+  });
+
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactThreshold: 3000,
+    compactSessionTokenBudget: 0,
+  });
+
+  await context.assemble({
+    sessionId: "test-session",
+    userId: "test-user",
+    messages: [{ role: "assistant", content: "small" }],
+    tokenBudget: 262144,
+    currentTokenCount: 3354,
+  });
+
+  const compactParams = rpc.getLastCall("compact_session");
+  assert.ok(compactParams, "Expected explicit compactThreshold to trigger compaction");
+  assert.equal(compactParams.currentTokenCount, 3354);
+});
+
+test("assemble suppresses repeat predictive compaction until since-last budget is reached", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  rpc.mockResponses.set("assemble_context_internal", {
+    messages: [{ role: "assistant", content: "ok" }],
+    estimatedTokens: 32,
+    systemPromptAddition: "",
+  });
+
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactSessionTokenBudget: 2000,
+  });
+
+  for (const currentTokenCount of [17000, 18000, 19100]) {
+    await context.assemble({
+      sessionId: "repeat-session",
+      userId: "test-user",
+      messages: [{ role: "assistant", content: `small-${currentTokenCount}` }],
+      tokenBudget: 262144,
+      currentTokenCount,
+    });
+  }
+
+  const compactCalls = rpc.calls.filter((call) => call.method === "compact_session");
+  assert.equal(compactCalls.length, 2);
+  assert.equal(compactCalls[0]?.params.currentTokenCount, 17000);
+  assert.equal(compactCalls[1]?.params.currentTokenCount, 19100);
+});
+
 test("assemble proceeds to assembly when server legitimately declines compaction", async () => {
   const rpc = new StaticContractRpc();
   rpc.mockResponses.set("compact_session", { didCompact: false });
@@ -686,6 +794,59 @@ test("afterTurn does not trigger predictive compaction without authoritative cur
   await flushIngestion(context);
 
   assert.equal(rpc.getLastCall("compact_session"), null);
+});
+
+test("afterTurn disables predictive compaction when compactSessionTokenBudget is zero", async () => {
+  const rpc = new StaticContractRpc();
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactSessionTokenBudget: 0,
+  });
+
+  await context.afterTurn({
+    sessionId: uniqueSessionId("at5b"),
+    userId: "test-user",
+    messages: [
+      { role: "user", content: "remember this" },
+      { role: "assistant", content: "small" },
+    ],
+    prePromptMessageCount: 1,
+    tokenBudget: 262144,
+    runtimeContext: { currentTokenCount: 20000 },
+  });
+  await flushIngestion(context);
+
+  assert.equal(rpc.getLastCall("compact_session"), null);
+});
+
+test("afterTurn suppresses repeat predictive compaction until since-last budget is reached", async () => {
+  const rpc = new StaticContractRpc();
+  rpc.mockResponses.set("compact_session", { didCompact: true });
+  const context = buildContextEngineFactory(async () => rpc as never, {
+    rpcTimeoutMs: 1000,
+    compactSessionTokenBudget: 2000,
+  });
+  const sessionId = uniqueSessionId("at-repeat");
+
+  for (const [index, currentTokenCount] of [17000, 18000, 19100].entries()) {
+    await context.afterTurn({
+      sessionId,
+      userId: "test-user",
+      messages: [
+        { role: "user", content: "remember this" },
+        { role: "assistant", content: `small-${index}` },
+      ],
+      prePromptMessageCount: 1,
+      tokenBudget: 262144,
+      runtimeContext: { currentTokenCount },
+    });
+    await flushIngestion(context);
+  }
+
+  const compactCalls = rpc.calls.filter((call) => call.method === "compact_session");
+  assert.equal(compactCalls.length, 2);
+  assert.equal(compactCalls[0]?.params.currentTokenCount, 17000);
+  assert.equal(compactCalls[1]?.params.currentTokenCount, 19100);
 });
 
 test("afterTurn triggers predictive compaction from oversized forwarded messages", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1201,6 +1201,93 @@ test("context engine assemble demotes daemon authored context to inert memory da
   assert.match(JSON.stringify(assembled.messages), /current request/u);
 });
 
+test("context engine canonicalizes daemon compacted session context render ledgers", async () => {
+  const client = new FakeClient();
+  const compactedState = JSON.stringify({
+    session_id: "s1-compacted-context",
+    compaction_generation: 110,
+    constraints: [{ rule: "remember the useful state" }],
+    next_steps: [{ text: "answer the current user", completed: false }],
+  });
+  const repeatedRender = Array.from({ length: 20 }, (_, index) =>
+    [
+      "Artifacts:",
+      `- repeated artifact ${index}`,
+      "",
+      "Constraints:",
+      `- OBLIGATION: repeated rendered transcript ${index}`,
+      "",
+      "Open Next Steps:",
+      `- repeated stale next step ${index}`,
+      "",
+      "Extracted context anchors:",
+      `  Quantities: ${index}`,
+    ].join("\n")
+  ).join("\n");
+  client.assembleResponse = {
+    messages: [makeMessage("user", "current request", "current-user")],
+    estimatedTokens: 64,
+    systemPromptAddition: [
+      "<compacted_session_context>",
+      compactedState,
+      repeatedRender,
+      "</compacted_session_context>",
+      "<recalled_memories>small useful recall</recalled_memories>",
+    ].join("\n"),
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), {
+    userId: "fixed-user",
+    beforeTurnEnabled: false,
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-compacted-context",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "current request", "current-user")],
+    prompt: "current request",
+    tokenBudget: 262144,
+  });
+
+  assert.match(assembled.systemPromptAddition, /"compaction_generation":110/u);
+  assert.match(assembled.systemPromptAddition, /small useful recall/u);
+  assert.doesNotMatch(assembled.systemPromptAddition, /Artifacts:|repeated rendered transcript|Extracted context anchors/u);
+  assert.ok(assembled.systemPromptAddition.length < compactedState.length + 500);
+  assert.ok(assembled.estimatedTokens < 500);
+});
+
+test("context engine preserves compacted session context prose without render ledger headings", async () => {
+  const client = new FakeClient();
+  const compactedState = JSON.stringify({
+    session_id: "s1-compact-prose",
+    compaction_generation: 1,
+  });
+  client.assembleResponse = {
+    messages: [makeMessage("user", "current request", "current-user")],
+    estimatedTokens: 64,
+    systemPromptAddition: [
+      "<compacted_session_context>",
+      compactedState,
+      "Useful compacted prose that is not the repeated render ledger.",
+      "</compacted_session_context>",
+    ].join("\n"),
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), {
+    userId: "fixed-user",
+    beforeTurnEnabled: false,
+  });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-compact-prose",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "current request", "current-user")],
+    prompt: "current request",
+    tokenBudget: 262144,
+  });
+
+  assert.match(assembled.systemPromptAddition, /Useful compacted prose/u);
+  assert.equal(assembled.estimatedTokens, 64);
+});
+
 test("context engine assemble preserves ordinary JSON with name fields in memory additions", async () => {
   const client = new FakeClient();
   client.assembleResponse = {


### PR DESCRIPTION
## Summary

- Fixes a context-engine replay blow-up where daemon `<compacted_session_context>` blocks can include a canonical JSON state line followed by repeated rendered compaction ledger sections.
- Canonicalizes that daemon block at the plugin boundary: preserve the first valid JSON state line, drop the repeated `Artifacts` / `Constraints` / `Open Next Steps` / `Extracted context anchors` render ledger.
- Recomputes `estimatedTokens` after sanitizer reduction so stale pre-sanitized daemon estimates do not propagate.
- Leaves ordinary recall sections such as `<recalled_memories>`, `<recent_session_tail>`, and `<elevated_guidance>` intact.

## Linked context

Closes #330

Related #300, but this is narrower: #300 covered assemble returning un-compacted raw history; this issue reproduces with a compacted context returned, where the compacted block itself contains an accreting render ledger.

## Real behavior proof

- Behavior or issue addressed: A simple no-tool turn could receive a provider-visible prompt with ~100k input tokens because LibraVDB injected an oversized `<compacted_session_context>` block.
- Real environment tested: Live local OpenClaw + `libravdb-memory` context engine + `libravdbd` daemon, using a redacted/reconstructed session tail from the affected Discord-backed session.
- Exact steps or command run after this patch:

```text
pnpm run build
pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js
node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js
```

- Evidence after fix:

```text
Same daemon/session replay after patch:
  systemPromptAddition: 10,895 chars (~2.7k approximate tokens)
  <compacted_session_context>: 3,990 chars (~998 approximate tokens)
  <recalled_memories>: 2,254 chars (~564 approximate tokens)
  rendered ledger present: false
  estimatedTokens: 5,346
```

- Observed result after fix: The compacted JSON state remains, normal recalled-memory sections remain, and the repeated rendered ledger no longer reaches provider-visible prompt replay.
- What was not tested: A full live Discord round-trip with this exact patch installed into the production OpenClaw instance was not run before opening this PR.
- Proof limitations or environment constraints: The original session id, channel ids, user ids, and local paths are intentionally omitted/redacted from this PR body. `pnpm run test:ts` and `pnpm run test:integration` currently stop before tests because `plugin-inspector` runtime capture fails in isolated import with `TypeError: os2.homedir is not a function`; direct compiled unit and integration test files pass.
- Before evidence:

```text
Same daemon/session replay before patch:
  source transcript tail: 42 messages / ~9.2k chars
  systemPromptAddition: 268,003 chars (~67k approximate tokens)
  <compacted_session_context>: 261,952 chars (~65k approximate tokens)
  <recalled_memories>: 2,254 chars (~564 approximate tokens)

Inside compacted block:
  compaction_generation: 110
  Artifacts sections: 110
  Constraints sections: 107
  Open Next Steps sections: 106
  Extracted context anchors sections: 110
  OBLIGATION lines: 269
```

## Tests and validation

Commands run:

```text
pnpm run build
pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test --test-name-pattern="canonicalizes daemon compacted session context" .ts-build/test/unit/context-engine.test.js
node --test .ts-build/test/unit/context-engine.test.js
pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js
node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js
git diff --check
```

Regression coverage added:

- `context engine canonicalizes daemon compacted session context render ledgers`
- Verifies canonical JSON state is preserved.
- Verifies normal recalled memory remains.
- Verifies repeated rendered ledger sections are removed.
- Verifies the post-sanitization token estimate is reduced.

What failed before this fix:

- The same daemon/session replay produced a 268k-char system addition, dominated by a 262k-char compacted-session context render ledger.

If no test was added, why not?

- N/A. A focused regression test was added.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?

- If a daemon intentionally emits useful non-JSON prose after the compacted JSON line inside `<compacted_session_context>`, this patch drops that prose.

How is that risk mitigated?

- The sanitizer only canonicalizes blocks whose first line is valid JSON. Non-matching compacted-session blocks are left unchanged.
- Adjacent sections (`<recalled_memories>`, `<recent_session_tail>`, `<elevated_guidance>`) remain untouched.
- The dropped content is the repeated human-readable render ledger; the canonical compacted state survives.

## Current review state

What is the next action?

- Maintainer review. Ideally confirm whether daemon should also stop emitting the repeated render ledger, but this plugin-boundary fix prevents the current provider prompt blow-up.

What is still waiting on author, maintainer, CI, or external proof?

- CI result and maintainer review.
- Optional maintainer-side confirmation of daemon behavior.

Which bot or reviewer comments were addressed?

- N/A for this PR.

## Additional high-compaction problem set

The same live investigation surfaced a second, independent high-compaction cause after the oversized replay ledger was bounded.

### Part 1: oversized compacted-session replay

The original issue remains: daemon `<compacted_session_context>` replay could include an accreting rendered ledger, inflating provider-visible context by hundreds of thousands of characters. This PR canonicalizes that block at the plugin boundary.

### Part 2: predictive compaction could fire on almost every normal turn

A separate trigger bug caused high-frequency compaction even after replay size was fixed:

- `compactSessionTokenBudget` is documented as a since-last-compaction budget, with `0` disabling auto-compaction.
- The host code used positive `compactSessionTokenBudget` as an absolute cap on the dynamic trigger threshold.
- With the default/configured value `2000`, normal OpenClaw turns above ~2k tokens triggered predictive compaction repeatedly.
- Stable post-turn context above the dynamic threshold could also compact again on later turns because the host did not remember that the same token pressure had already been compacted.

Redacted live log evidence showed repeated compaction on ordinary turns:

```text
assemble  currentTokenCount=3272  threshold=2000  elapsed=3478ms
assemble  currentTokenCount=3460  threshold=2000  elapsed=4224ms
afterTurn currentTokenCount=17600 threshold=2000  elapsed=3304ms
assemble  currentTokenCount=3354  threshold=2000  elapsed=3371ms
assemble  currentTokenCount=3543  threshold=2000  elapsed=4214ms
afterTurn currentTokenCount=17359 threshold=2000  elapsed=8934ms
```

The patch now treats the trigger as two-stage:

1. `compactThreshold` remains the explicit override and still wins.
2. `compactSessionTokenBudget: 0` disables predictive auto-compaction.
3. Positive `compactSessionTokenBudget` no longer lowers the dynamic trigger threshold.
4. After a successful predictive compaction, the context engine records the session's token pressure and suppresses repeat predictive compaction until the session has grown by at least `compactSessionTokenBudget` tokens.

Falsification coverage added:

```text
assemble does not let compactSessionTokenBudget lower the dynamic trigger threshold
assemble disables predictive compaction when compactSessionTokenBudget is zero
assemble keeps compactThreshold explicit override when compactSessionTokenBudget is zero
assemble suppresses repeat predictive compaction until since-last budget is reached
afterTurn disables predictive compaction when compactSessionTokenBudget is zero
afterTurn suppresses repeat predictive compaction until since-last budget is reached
```

The repeat tests prove both sides of the invariant: a stable session at `17000 -> 18000` tokens does not compact again, but growth to `19100` tokens does compact again when `compactSessionTokenBudget=2000`.

Additional validation after this patch:

```text
pnpm run build
pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/host-flow.test.js && node --test .ts-build/test/unit/context-engine.test.js
pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js && node --test .ts-build/test/integration/*.test.js
git diff --check
```

Results:

```text
focused host-flow: 25/25 pass
focused context-engine: 77/77 pass
unit direct: 219/219 pass
integration direct: 52/52 pass
```

Known unrelated validation gap remains: `pnpm run test:inspect` / `plugin-inspector ci` still fails at runtime capture before test execution with `plugin-inspector runtime capture failed for 1 entrypoints`. That lane was failing before this compaction-trigger patch and does not provide a context-engine assertion failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Fix: Canonicalize Compacted Session Context Replay

## Overview
This PR fixes a replay issue where daemon-provided <compacted_session_context> blocks could include a canonical JSON state line followed by repeated rendered compaction ledger sections (Artifacts, Constraints, Open Next Steps, Extracted context anchors), producing massively oversized provider-visible prompts (observed: ~261,952 chars → ~3,990 chars). It canonicalizes such daemon blocks at the sanitizer boundary, recomputes token estimates after reduction, tightens predictive compaction cursor logic, and adds regression + integration tests. Closes `#330`.

## Changes Summary

### src/context-engine.ts (net +76 / -10 lines)
- New sanitizer step canonicalizeCompactedSessionContextBlocks:
  - Detects <compacted_session_context ...> blocks whose trimmed first inner line begins with "{" and parses as valid JSON and whose remainder contains known render-ledger headings (Artifacts:, Constraints:, Open Next Steps:, Extracted context anchors:).
  - When matched: preserves only the first valid JSON line and rewrites the block preserving original attributes; drops repeated rendered ledger prose.
  - Leaves blocks unchanged if they don't match the JSON-first + render-ledger shape (mitigates dropping intentional non-JSON daemon prose).
  - Integrated into sanitizeDaemonSystemPromptAddition flow (applied after tool-pattern sanitization, before daemon demotion).
- normalizeAssembleResult:
  - Tracks whether systemPromptAddition was reduced by sanitization (systemPromptWasReduced).
  - When reduced: recomputes estimatedTokens as approximateTokenCount(sanitized systemPromptAddition) + approximateMessagesTokens(messages); otherwise preserves original estimatedTokens.
  - Ensures adjacent recall sections (<recalled_memories>, <recent_session_tail>, <elevated_guidance>) remain intact.
- Predictive compaction adjustments:
  - resolveDynamicCompactThreshold treats compactSessionTokenBudget === 0 as a full disable (returns undefined).
  - resolvePredictiveCompactionTarget now accepts compactSessionTokenBudget and lastCompactedTokenCount; predictive compaction suppressed when token increase since last compaction is below budget.
  - Engine stores per-session predictiveCompactionCursors, sets cursor only when compaction actually occurs, and clears on bootstrap/dispose.

### Tests
- test/unit/context-engine.test.ts: added regression tests:
  - "context engine canonicalizes daemon compacted session context render ledgers": verifies canonical JSON preserved, repeated rendered ledger removed, recalled memory retained, and post-sanitization estimatedTokens reduced.
  - Negative-control: verifies non-ledger JSON-first prose is preserved when ledger headings absent.
- test/integration/host-flow.test.ts: added coverage for predictive compaction with compactSessionTokenBudget (disable when 0, budget gating, explicit override behavior, repeat-suppression until since-last budget reached).

### Validation / CI status
- Local runs reported: focused unit test (2/2) pass; full unit: 219/219; integration: 46/46; git diff --check: pass.
- Live-boundary replay (post-tightening): systemPromptAddition ~10,895 chars, <compacted_session_context> ~3,990 chars, <recalled_memories> ~2,254 chars, rendered ledger present: false, estimatedTokens: 5,346.
- CI and maintainer review pending.

## Complexity Analysis

### Big O (asymptotic)
- canonicalizeCompactedSessionContextBlocks: O(n) where n = length of input text (single-pass regex/scan and optional JSON.parse of first line O(m), m ≪ n). Overall: O(n).
- normalizeAssembleResult: O(k + n) where k = message count (reduce over messages for token approximations) and n = length of sanitized systemPromptAddition (sanitization cost).

No asymptotic regressions introduced beyond linear scans over input text/messages.

### Cyclomatic Complexity (approximate)
- canonicalizeCompactedSessionContextBlocks: CC ≈ 6
  - Entry + branches for: non-JSON-first early return, ledger-marker presence check, JSON.parse try/catch, replace callback pathing.
- Token recomputation logic in normalizeAssembleResult: CC ≈ 4
  - Branch for whether sanitization reduced systemPromptAddition, branch for numeric estimatedTokens fallback, and ternary/nesting for recomputation vs preserve.

Net complexity increase is modest and localized to sanitization/token-recompute paths; predictive-compaction additions add conditional branches but maintain straightforward control flow.

## Risk & Mitigation
- Risk: If a daemon intentionally emits useful non-JSON prose after the JSON line, canonicalization could drop it.
- Mitigation: canonicalization only triggers when (a) first trimmed line is valid JSON and (b) subsequent content contains known render-ledger headings; otherwise blocks pass through unchanged. Added negative-control test to guard against false positives.

## Files Changed (high level)
- src/context-engine.ts — sanitizer canonicalization, token recompute, predictive compaction cursor handling.
- test/unit/context-engine.test.ts — regression + negative-control tests.
- test/integration/host-flow.test.ts — predictive compaction budget tests.

## Review / Action Requested
- Maintainer review of sanitizer boundary behavior and accepted tradeoff.
- CI verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
