### PR TITLE
fix: correct sanitization pipeline order and tighten token recomputation test

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1206,7 +1206,7 @@ const COMPACTED_SESSION_RENDER_LEDGER_RE =
 
 function sanitizeDaemonSystemPromptAddition(text: string): string {
   return demoteDaemonAuthoredContextBlocks(
-    canonicalizeCompactedSessionContextBlocks(sanitizeToolCallPatterns(text)),
+    sanitizeToolCallPatterns(canonicalizeCompactedSessionContextBlocks(text)),
   );
 }
 

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1226,7 +1226,7 @@ test("context engine canonicalizes daemon compacted session context render ledge
   ).join("\n");
   client.assembleResponse = {
     messages: [makeMessage("user", "current request", "current-user")],
-    estimatedTokens: 64,
+    estimatedTokens: 50_000,
     systemPromptAddition: [
       "<compacted_session_context>",
       compactedState,
@@ -1253,6 +1253,7 @@ test("context engine canonicalizes daemon compacted session context render ledge
   assert.doesNotMatch(assembled.systemPromptAddition, /Artifacts:|repeated rendered transcript|Extracted context anchors/u);
   assert.ok(assembled.systemPromptAddition.length < compactedState.length + 500);
   assert.ok(assembled.estimatedTokens < 500);
+  assert.ok(assembled.estimatedTokens < (client.assembleResponse.estimatedTokens ?? Infinity));
 });
 
 test("context engine preserves compacted session context prose without render ledger headings", async () => {


### PR DESCRIPTION
## Summary

Two focused fixes on top of #331:

1. **Swap sanitization pipeline order** — `canonicalizeCompactedSessionContextBlocks` now runs before `sanitizeToolCallPatterns`, so canonicalization sees raw daemon text. If `sanitizeToolCallPatterns` ever modified a JSON first line inside `<compacted_session_context>`, the old order would cause `JSON.parse` to fail and the block (including the render ledger) would pass through unchanged.

2. **Tighten token recomputation test** — seeds a deliberately stale `estimatedTokens: 50_000` instead of `64`, and asserts the post-sanitization estimate is strictly less than the seed. The old test passed even if recomputation was silently skipped.

## Test plan

- [x] Narrow compile passes
- [x] Both compacted context tests pass (canonicalization + prose preservation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR corrects the order of transformations in the `sanitizeDaemonSystemPromptAddition` sanitization pipeline and tightens token recomputation test assertions.

### Changes

**src/context-engine.ts** (1 line changed)
- Reordered the sanitization pipeline so `canonicalizeCompactedSessionContextBlocks` executes before `sanitizeToolCallPatterns`
- This ensures canonicalization operates on raw daemon text before any tool-call pattern sanitization
- Addresses a bug where if `sanitizeToolCallPatterns` modified a JSON first line inside `<compacted_session_context>`, the subsequent `JSON.parse` could fail, causing the block (including render ledger) to pass through unchanged

**test/unit/context-engine.test.ts** (2 lines changed)
- Increased the mocked daemon `assembleResponse.estimatedTokens` from 64 to 50_000 in the compacted context canonicalization test
- Updated the assertion to verify that `assembled.estimatedTokens < (client.assembleResponse.estimatedTokens ?? Infinity)`
- This tightens the test by seeding a deliberately stale token estimate and confirming recomputation occurs (the previous test with a small seed value could pass even if recomputation was skipped)

### Complexity Analysis

- **Big O Impact**: No regressions. Both affected functions perform regex replacements with O(n) complexity. Reordering them does not change asymptotic complexity.
- **Cyclomatic Complexity Impact**: No regressions. The reorder is a sequential composition within `sanitizeDaemonSystemPromptAddition` (CC=1, no branches). The affected functions maintain their individual complexity: `canonicalizeCompactedSessionContextBlocks` (CC=4) and `sanitizeToolCallPatterns` (CC=3). Only their execution order changes, with no modifications to their logic.

### Test Coverage

- Both compacted context tests pass (canonicalization and prose preservation)
- Narrow compile passes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->