### PR TITLE
fix: revert unintended compaction changes and keep render ledger for model readability

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1222,18 +1222,23 @@ function canonicalizeCompactedSessionContextBlocks(text: string): string {
 
     // Keep JSON state line + first (latest, most complete) render ledger.
     // Strip subsequent repeated render ledgers from older compaction cycles.
-    // Record boundary: second occurrence of "\nArtifacts:" at line start.
-    const ARTIFACTS_HEADING_RE = /\nArtifacts:/g;
+    // Record boundary: second occurrence of any render-ledger heading.
+    // Use the same heading set as COMPACTED_SESSION_RENDER_LEDGER_RE.
+    const HEADING_RE = /(?:^|\n)(?:Artifacts:|Constraints:|Open Next Steps:|Extracted context anchors:)/g;
     let headingMatch: RegExpExecArray | null;
     let headingCount = 0;
+    const seen = new Set<string>();
     let cutIdx = rest.length;
 
-    while ((headingMatch = ARTIFACTS_HEADING_RE.exec(rest)) !== null) {
-      headingCount++;
-      if (headingCount === 2) {
+    while ((headingMatch = HEADING_RE.exec(rest)) !== null) {
+      const heading = headingMatch[0].replace(/^\n/, "");
+      if (seen.has(heading)) {
+        // Repeat heading — second ledger starts here.
         cutIdx = headingMatch.index;
         break;
       }
+      seen.add(heading);
+      headingCount++;
     }
 
     const keptRest = rest.slice(0, cutIdx).trim();

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -956,10 +956,6 @@ function resolveDynamicCompactThreshold(
     logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=explicit tokenBudget=${tokenBudget} compactThreshold=${compactThreshold} → ${val}`);
     return val;
   }
-  if (compactSessionTokenBudget === 0) {
-    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=disabled tokenBudget=${tokenBudget}`);
-    return undefined;
-  }
   const normalizedBudget = normalizeTokenBudget(tokenBudget);
   if (normalizedBudget == null) {
     logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=null_budget tokenBudget=${tokenBudget} → undefined`);
@@ -971,6 +967,12 @@ function resolveDynamicCompactThreshold(
   // enough turns to compact) or absurdly high (Codex Runtime 1M tokens
   // would produce an unreachable 800k threshold).
   const withBounds = Math.max(2000, Math.min(16000, derived));
+  // User-configured compactSessionTokenBudget overrides the ceiling.
+  if (typeof compactSessionTokenBudget === "number" && compactSessionTokenBudget > 0) {
+    const capped = Math.min(withBounds, compactSessionTokenBudget);
+    logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=user_cap tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} cap=${compactSessionTokenBudget} → ${capped}`);
+    return capped;
+  }
   logger?.info?.(`[compact:trace] resolveDynamicCompactThreshold branch=clamped tokenBudget=${tokenBudget} normalizedBudget=${normalizedBudget} fraction=${fraction} derived=${derived} withBounds=${withBounds} → ${withBounds}`);
   return withBounds;
 }
@@ -978,21 +980,10 @@ function resolveDynamicCompactThreshold(
 function resolvePredictiveCompactionTarget(params: {
   currentTokenCount: number | undefined;
   threshold: number | undefined;
-  compactSessionTokenBudget?: number;
-  lastCompactedTokenCount?: number;
 }): number | undefined {
   const currentTokenCount = normalizeCurrentTokenCount(params.currentTokenCount);
   const threshold = normalizeTokenBudget(params.threshold);
   if (currentTokenCount == null || threshold == null || currentTokenCount < threshold) {
-    return undefined;
-  }
-  const sinceLastBudget = normalizeTokenBudget(params.compactSessionTokenBudget);
-  const lastCompactedTokenCount = normalizeCurrentTokenCount(params.lastCompactedTokenCount);
-  if (
-    sinceLastBudget != null &&
-    lastCompactedTokenCount != null &&
-    currentTokenCount - lastCompactedTokenCount < sinceLastBudget
-  ) {
     return undefined;
   }
 
@@ -1229,7 +1220,27 @@ function canonicalizeCompactedSessionContextBlocks(text: string): string {
       return match;
     }
 
-    return `<compacted_session_context${attrs}>\n${firstLine}\n</compacted_session_context>`;
+    // Keep JSON state line + first (latest, most complete) render ledger.
+    // Strip subsequent repeated render ledgers from older compaction cycles.
+    // Record boundary: second occurrence of "\nArtifacts:" at line start.
+    const ARTIFACTS_HEADING_RE = /\nArtifacts:/g;
+    let headingMatch: RegExpExecArray | null;
+    let headingCount = 0;
+    let cutIdx = rest.length;
+
+    while ((headingMatch = ARTIFACTS_HEADING_RE.exec(rest)) !== null) {
+      headingCount++;
+      if (headingCount === 2) {
+        cutIdx = headingMatch.index;
+        break;
+      }
+    }
+
+    const keptRest = rest.slice(0, cutIdx).trim();
+    if (!keptRest) {
+      return `<compacted_session_context${attrs}>\n${firstLine}\n</compacted_session_context>`;
+    }
+    return `<compacted_session_context${attrs}>\n${firstLine}\n${keptRest}\n</compacted_session_context>`;
   });
 }
 
@@ -2067,9 +2078,6 @@ export function buildContextEngineFactory(
 
   const predictiveContextCache = new Map<string, import("./types.js").PredictedContext[]>();
   const PREDICTIVE_CACHE_MAX_SIZE = 100;
-  const predictiveCompactionCursors = new Map<string, number>();
-  const PREDICTIVE_COMPACTION_CURSOR_MAX_SIZE = 100;
-
   // BeforeTurnKernel state
   const turnCache = new TurnMemoryCache(100);
   const circuitBreakers = new Map<string, FailureState>();
@@ -2306,14 +2314,6 @@ export function buildContextEngineFactory(
       cfg.compactionThresholdFraction,
       cfg.compactSessionTokenBudget,
     );
-
-  const markPredictiveCompactionCursor = (sessionId: string, currentTokenCount: number): void => {
-    if (predictiveCompactionCursors.size >= PREDICTIVE_COMPACTION_CURSOR_MAX_SIZE) {
-      const oldest = predictiveCompactionCursors.keys().next().value;
-      if (oldest !== undefined) predictiveCompactionCursors.delete(oldest);
-    }
-    predictiveCompactionCursors.set(sessionId, currentTokenCount);
-  };
 
   const buildAssemblyConfig = (tokenBudget: number | undefined) => ({
     useSessionRecallProjection: cfg.useSessionRecallProjection,
@@ -2588,8 +2588,6 @@ export function buildContextEngineFactory(
     const predictiveTargetSize = resolvePredictiveCompactionTarget({
       currentTokenCount: currentContextTokens,
       threshold: dynamicCompactThreshold,
-      compactSessionTokenBudget: cfg.compactSessionTokenBudget,
-      lastCompactedTokenCount: predictiveCompactionCursors.get(args.sessionId),
     });
     if (
       currentContextTokens == null ||
@@ -2614,9 +2612,6 @@ export function buildContextEngineFactory(
       force: true,
       currentTokenCount: currentContextTokens,
     });
-    if (compactionResult.compacted) {
-      markPredictiveCompactionCursor(args.sessionId, currentContextTokens);
-    }
     logPredictiveCompactionOutcome({
       logger,
       phase: "afterTurn",
@@ -2636,7 +2631,6 @@ export function buildContextEngineFactory(
     async bootstrap(args: { sessionId: string; sessionKey?: string; userId?: string }) {
       const sessionId = requireSessionId(args.sessionId, "bootstrap");
       predictiveContextCache.delete(sessionId);
-      predictiveCompactionCursors.delete(sessionId);
       postToolRecallCache.delete(sessionId);
       asyncIngestionQueues.delete(sessionId);
       const userId = resolveUserId({
@@ -2718,8 +2712,6 @@ export function buildContextEngineFactory(
       const predictiveTargetSize = resolvePredictiveCompactionTarget({
         currentTokenCount: currentContextTokens,
         threshold: dynamicCompactThreshold,
-        compactSessionTokenBudget: cfg.compactSessionTokenBudget,
-        lastCompactedTokenCount: predictiveCompactionCursors.get(sessionId),
       });
       if (dynamicCompactThreshold != null && predictiveTargetSize != null) {
         logPredictiveCompactionAttempt({
@@ -2738,9 +2730,6 @@ export function buildContextEngineFactory(
           force: true,
           currentTokenCount: currentContextTokens,
         });
-        if (compactionResult.compacted) {
-          markPredictiveCompactionCursor(sessionId, currentContextTokens);
-        }
         logPredictiveCompactionOutcome({
           logger,
           phase: "assemble",
@@ -3243,7 +3232,6 @@ export function buildContextEngineFactory(
         }
       }
       predictiveContextCache.clear();
-      predictiveCompactionCursors.clear();
       postToolRecallCache.clear();
       asyncIngestionQueues.clear();
       triggerCache.clear();

--- a/test/integration/host-flow.test.ts
+++ b/test/integration/host-flow.test.ts
@@ -385,56 +385,6 @@ test("assemble prefers authoritative currentTokenCount for predictive compaction
   assert.equal(compactParams.force, true);
 });
 
-test("assemble does not let compactSessionTokenBudget lower the dynamic trigger threshold", async () => {
-  const rpc = new StaticContractRpc();
-  rpc.mockResponses.set("assemble_context_internal", {
-    messages: [{ role: "assistant", content: "ok" }],
-    estimatedTokens: 32,
-    systemPromptAddition: "",
-  });
-
-  const context = buildContextEngineFactory(async () => rpc as never, {
-    rpcTimeoutMs: 1000,
-    compactSessionTokenBudget: 2000,
-  });
-
-  await context.assemble({
-    sessionId: "test-session",
-    userId: "test-user",
-    messages: [{ role: "assistant", content: "small" }],
-    tokenBudget: 262144,
-    currentTokenCount: 3354,
-  });
-
-  assert.equal(rpc.getLastCall("compact_session"), null);
-  assert.ok(rpc.getLastCall("assemble_context_internal"), "Expected assembly without predictive compaction");
-});
-
-test("assemble disables predictive compaction when compactSessionTokenBudget is zero", async () => {
-  const rpc = new StaticContractRpc();
-  rpc.mockResponses.set("assemble_context_internal", {
-    messages: [{ role: "assistant", content: "ok" }],
-    estimatedTokens: 32,
-    systemPromptAddition: "",
-  });
-
-  const context = buildContextEngineFactory(async () => rpc as never, {
-    rpcTimeoutMs: 1000,
-    compactSessionTokenBudget: 0,
-  });
-
-  await context.assemble({
-    sessionId: "test-session",
-    userId: "test-user",
-    messages: [{ role: "assistant", content: "small" }],
-    tokenBudget: 262144,
-    currentTokenCount: 20000,
-  });
-
-  assert.equal(rpc.getLastCall("compact_session"), null);
-  assert.ok(rpc.getLastCall("assemble_context_internal"), "Expected assembly when predictive compaction is disabled");
-});
-
 test("assemble keeps compactThreshold explicit override when compactSessionTokenBudget is zero", async () => {
   const rpc = new StaticContractRpc();
   rpc.mockResponses.set("compact_session", { didCompact: true });
@@ -461,36 +411,6 @@ test("assemble keeps compactThreshold explicit override when compactSessionToken
   const compactParams = rpc.getLastCall("compact_session");
   assert.ok(compactParams, "Expected explicit compactThreshold to trigger compaction");
   assert.equal(compactParams.currentTokenCount, 3354);
-});
-
-test("assemble suppresses repeat predictive compaction until since-last budget is reached", async () => {
-  const rpc = new StaticContractRpc();
-  rpc.mockResponses.set("compact_session", { didCompact: true });
-  rpc.mockResponses.set("assemble_context_internal", {
-    messages: [{ role: "assistant", content: "ok" }],
-    estimatedTokens: 32,
-    systemPromptAddition: "",
-  });
-
-  const context = buildContextEngineFactory(async () => rpc as never, {
-    rpcTimeoutMs: 1000,
-    compactSessionTokenBudget: 2000,
-  });
-
-  for (const currentTokenCount of [17000, 18000, 19100]) {
-    await context.assemble({
-      sessionId: "repeat-session",
-      userId: "test-user",
-      messages: [{ role: "assistant", content: `small-${currentTokenCount}` }],
-      tokenBudget: 262144,
-      currentTokenCount,
-    });
-  }
-
-  const compactCalls = rpc.calls.filter((call) => call.method === "compact_session");
-  assert.equal(compactCalls.length, 2);
-  assert.equal(compactCalls[0]?.params.currentTokenCount, 17000);
-  assert.equal(compactCalls[1]?.params.currentTokenCount, 19100);
 });
 
 test("assemble proceeds to assembly when server legitimately declines compaction", async () => {
@@ -794,59 +714,6 @@ test("afterTurn does not trigger predictive compaction without authoritative cur
   await flushIngestion(context);
 
   assert.equal(rpc.getLastCall("compact_session"), null);
-});
-
-test("afterTurn disables predictive compaction when compactSessionTokenBudget is zero", async () => {
-  const rpc = new StaticContractRpc();
-  const context = buildContextEngineFactory(async () => rpc as never, {
-    rpcTimeoutMs: 1000,
-    compactSessionTokenBudget: 0,
-  });
-
-  await context.afterTurn({
-    sessionId: uniqueSessionId("at5b"),
-    userId: "test-user",
-    messages: [
-      { role: "user", content: "remember this" },
-      { role: "assistant", content: "small" },
-    ],
-    prePromptMessageCount: 1,
-    tokenBudget: 262144,
-    runtimeContext: { currentTokenCount: 20000 },
-  });
-  await flushIngestion(context);
-
-  assert.equal(rpc.getLastCall("compact_session"), null);
-});
-
-test("afterTurn suppresses repeat predictive compaction until since-last budget is reached", async () => {
-  const rpc = new StaticContractRpc();
-  rpc.mockResponses.set("compact_session", { didCompact: true });
-  const context = buildContextEngineFactory(async () => rpc as never, {
-    rpcTimeoutMs: 1000,
-    compactSessionTokenBudget: 2000,
-  });
-  const sessionId = uniqueSessionId("at-repeat");
-
-  for (const [index, currentTokenCount] of [17000, 18000, 19100].entries()) {
-    await context.afterTurn({
-      sessionId,
-      userId: "test-user",
-      messages: [
-        { role: "user", content: "remember this" },
-        { role: "assistant", content: `small-${index}` },
-      ],
-      prePromptMessageCount: 1,
-      tokenBudget: 262144,
-      runtimeContext: { currentTokenCount },
-    });
-    await flushIngestion(context);
-  }
-
-  const compactCalls = rpc.calls.filter((call) => call.method === "compact_session");
-  assert.equal(compactCalls.length, 2);
-  assert.equal(compactCalls[0]?.params.currentTokenCount, 17000);
-  assert.equal(compactCalls[1]?.params.currentTokenCount, 19100);
 });
 
 test("afterTurn triggers predictive compaction from oversized forwarded messages", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1248,11 +1248,18 @@ test("context engine canonicalizes daemon compacted session context render ledge
     tokenBudget: 262144,
   });
 
+  // JSON state and recalled memories are preserved.
   assert.match(assembled.systemPromptAddition, /"compaction_generation":110/u);
   assert.match(assembled.systemPromptAddition, /small useful recall/u);
-  assert.doesNotMatch(assembled.systemPromptAddition, /Artifacts:|repeated rendered transcript|Extracted context anchors/u);
-  assert.ok(assembled.systemPromptAddition.length < compactedState.length + 500);
-  assert.ok(assembled.estimatedTokens < 500);
+  // First render ledger is kept (model-readable prose for session state).
+  assert.match(assembled.systemPromptAddition, /repeated artifact 0/u);
+  assert.match(assembled.systemPromptAddition, /repeated rendered transcript 0/u);
+  // Later repeated render ledgers from older compaction cycles are stripped.
+  assert.doesNotMatch(assembled.systemPromptAddition, /repeated artifact 19/u);
+  assert.doesNotMatch(assembled.systemPromptAddition, /repeated rendered transcript 19/u);
+  // Size is still reduced (20 ledgers → 1 ledger).
+  assert.ok(assembled.systemPromptAddition.length < compactedState.length + 2000);
+  assert.ok(assembled.estimatedTokens < 1000);
   assert.ok(assembled.estimatedTokens < (client.assembleResponse.estimatedTokens ?? Infinity));
 });
 

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1255,6 +1255,9 @@ test("context engine canonicalizes daemon compacted session context render ledge
   assert.match(assembled.systemPromptAddition, /repeated artifact 0/u);
   assert.match(assembled.systemPromptAddition, /repeated rendered transcript 0/u);
   // Later repeated render ledgers from older compaction cycles are stripped.
+  // Only the first (index 0) is kept — even index 1 should be gone.
+  assert.doesNotMatch(assembled.systemPromptAddition, /repeated artifact 1/u);
+  assert.doesNotMatch(assembled.systemPromptAddition, /repeated rendered transcript 1/u);
   assert.doesNotMatch(assembled.systemPromptAddition, /repeated artifact 19/u);
   assert.doesNotMatch(assembled.systemPromptAddition, /repeated rendered transcript 19/u);
   // Size is still reduced (20 ledgers → 1 ledger).


### PR DESCRIPTION
## Summary

Hotfix for v1.9.1 regressions caused by unintended WIP code that was squash-merged in PR #331.

### Compaction crash (reported by multiple users)

The squash included unreviewed predictive compaction changes that broke `compactSessionTokenBudget` semantics:

- `=== 0` became a **hard disable** of all automatic compaction (was: no-op, cap not applied)
- Threshold cap `Math.min(withBounds, budget)` was **removed** (was: user-configured ceiling)
- New `predictiveCompactionCursors` state + repeat-suppression guard **prevented re-compaction** within budget window

This reverts all three to v1.9.0 behavior.

### Result replay (reported by Elfiena)

`canonicalizeCompactedSessionContextBlocks` was stripping ALL prose after the JSON state line, leaving models with only raw JSON that they could not parse effectively. Models lost context about artifacts, constraints, decisions, and next steps → repeated actions they already took.

Fix: keep the first (latest, most complete) render ledger prose alongside the JSON, strip only repeated render ledgers from older compaction cycles. Boundary detection uses the second `\nArtifacts:` occurrence.

## Changes

| File | Change |
|------|--------|
| `context-engine.ts` | Revert compaction WIP, keep first render ledger |
| `host-flow.test.ts` | Remove 4 tests that blessed WIP behavior |
| `context-engine.test.ts` | Update assertions for kept render ledger |

## Test plan

- [x] Narrow compile passes
- [x] Full context-engine unit test suite passes (0 failures)
- [x] Canonicalization test: first ledger kept, later ledgers stripped