### PR TITLE
fix: deduplicate consecutive provider replay messages in normalizeAssembleResult

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1898,7 +1898,11 @@ export function normalizeAssembleResult(
         lastUserIndex >= 0 ? lastUserIndex : undefined,
       );
       if (liveToolProtocolSource) {
-        pushProviderReplayMessage(preserveLiveToolProtocolMessage(liveToolProtocolSource.message));
+        // Live tool protocol messages are cursor-guarded by
+        // consumeLiveToolAtCursor — consecutive toolResults with the
+        // same content but different toolCallId linkage must not be
+        // collapsed. Push directly, bypassing provider-replay dedup.
+        messages.push(preserveLiveToolProtocolMessage(liveToolProtocolSource.message));
         liveSourceCursor = liveToolProtocolSource.index + 1;
       } else if (findLiveToolSourceInCurrentTurn(message, content, sourceMessages, undefined, lastUserIndex >= 0 ? lastUserIndex : undefined) >= 0) {
         if (liveSourceCursor !== undefined && sourceMessages) {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1861,9 +1861,6 @@ export function normalizeAssembleResult(
   ): void => {
     const key = `${message.role}\0${message.content}`;
     if (key === lastProviderReplayKey) {
-      // Two distinct source messages with identical sanitized content are
-      // legitimate repetition, not a daemon-bug duplicate. Only dedup when
-      // both match the same source index (or source index is unavailable).
       if (
         lastSourceIndex !== undefined &&
         sourceIndex !== undefined &&
@@ -1897,6 +1894,7 @@ export function normalizeAssembleResult(
   if (Array.isArray(result.messages)) {
     const lastUserIndex = sourceMessages ? findLastUserMessageIndex(sourceMessages) : -1;
     let liveSourceCursor = sourceMessages ? lastUserIndex + 1 : undefined;
+    let providerReplaySourceCursor: number | undefined = sourceMessages ? 0 : undefined;
     for (const message of result.messages) {
       const content = normalizeKernelContent(message.content);
       const historicalToolSource = getHistoricalToolSource(message.role, message.content, content);
@@ -1947,7 +1945,7 @@ export function normalizeAssembleResult(
           continue;
         }
         const providerReplaySourceIndex = sourceMessages
-          ? findMatchingSourceMessageIndex(message, content, sourceMessages)
+          ? findMatchingSourceMessageIndex(message, content, sourceMessages, providerReplaySourceCursor)
           : undefined;
         pushProviderReplayMessage(
           {
@@ -1957,6 +1955,13 @@ export function normalizeAssembleResult(
           },
           providerReplaySourceIndex,
         );
+        if (
+          providerReplaySourceCursor !== undefined &&
+          providerReplaySourceIndex !== undefined &&
+          providerReplaySourceIndex >= 0
+        ) {
+          providerReplaySourceCursor = providerReplaySourceIndex + 1;
+        }
       } else {
         // Daemon memory items may not be in sourceMessages — only advance
         // cursor if the message is actually findable in the source transcript.

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1855,7 +1855,7 @@ export function normalizeAssembleResult(
   let lastProviderReplayKey: string | undefined;
 
   const pushProviderReplayMessage = (message: OpenClawCompatibleMessage): void => {
-    const key = `${message.role}\0${normalizeKernelContent(message.content)}`;
+    const key = `${message.role}\0${message.content}`;
     if (key === lastProviderReplayKey) {
       return;
     }

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1853,14 +1853,32 @@ export function normalizeAssembleResult(
   const messages: OpenClawCompatibleMessage[] = [];
   const extractedMemoryItems: string[] = [];
   let lastProviderReplayKey: string | undefined;
+  let lastSourceIndex: number | undefined;
 
-  const pushProviderReplayMessage = (message: OpenClawCompatibleMessage): void => {
+  const pushProviderReplayMessage = (
+    message: OpenClawCompatibleMessage,
+    sourceIndex?: number,
+  ): void => {
     const key = `${message.role}\0${message.content}`;
     if (key === lastProviderReplayKey) {
-      return;
+      // Two distinct source messages with identical sanitized content are
+      // legitimate repetition, not a daemon-bug duplicate. Only dedup when
+      // both match the same source index (or source index is unavailable).
+      if (
+        lastSourceIndex !== undefined &&
+        sourceIndex !== undefined &&
+        lastSourceIndex >= 0 &&
+        sourceIndex >= 0 &&
+        lastSourceIndex !== sourceIndex
+      ) {
+        // Fall through — push the message.
+      } else {
+        return;
+      }
     }
     messages.push(message);
     lastProviderReplayKey = key;
+    lastSourceIndex = sourceIndex;
   };
 
   const pushMemoryItem = (args: {
@@ -1928,11 +1946,17 @@ export function normalizeAssembleResult(
           }
           continue;
         }
-        pushProviderReplayMessage({
-          role: message.role,
-          content: sanitizedContent,
-          ...(typeof message.id === "string" ? { id: message.id } : {}),
-        });
+        const providerReplaySourceIndex = sourceMessages
+          ? findMatchingSourceMessageIndex(message, content, sourceMessages)
+          : undefined;
+        pushProviderReplayMessage(
+          {
+            role: message.role,
+            content: sanitizedContent,
+            ...(typeof message.id === "string" ? { id: message.id } : {}),
+          },
+          providerReplaySourceIndex,
+        );
       } else {
         // Daemon memory items may not be in sourceMessages — only advance
         // cursor if the message is actually findable in the source transcript.

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1852,6 +1852,16 @@ export function normalizeAssembleResult(
   const systemPromptWasReduced = rawSystemPromptAddition.length > systemPromptAddition.length;
   const messages: OpenClawCompatibleMessage[] = [];
   const extractedMemoryItems: string[] = [];
+  let lastProviderReplayKey: string | undefined;
+
+  const pushProviderReplayMessage = (message: OpenClawCompatibleMessage): void => {
+    const key = `${message.role}\0${normalizeKernelContent(message.content)}`;
+    if (key === lastProviderReplayKey) {
+      return;
+    }
+    messages.push(message);
+    lastProviderReplayKey = key;
+  };
 
   const pushMemoryItem = (args: {
     content: string;
@@ -1888,7 +1898,7 @@ export function normalizeAssembleResult(
         lastUserIndex >= 0 ? lastUserIndex : undefined,
       );
       if (liveToolProtocolSource) {
-        messages.push(preserveLiveToolProtocolMessage(liveToolProtocolSource.message));
+        pushProviderReplayMessage(preserveLiveToolProtocolMessage(liveToolProtocolSource.message));
         liveSourceCursor = liveToolProtocolSource.index + 1;
       } else if (findLiveToolSourceInCurrentTurn(message, content, sourceMessages, undefined, lastUserIndex >= 0 ? lastUserIndex : undefined) >= 0) {
         if (liveSourceCursor !== undefined && sourceMessages) {
@@ -1914,7 +1924,7 @@ export function normalizeAssembleResult(
           }
           continue;
         }
-        messages.push({
+        pushProviderReplayMessage({
           role: message.role,
           content: sanitizedContent,
           ...(typeof message.id === "string" ? { id: message.id } : {}),

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1100,6 +1100,38 @@ test("context engine assemble deduplicates provider replay after sanitization", 
   ]);
 });
 
+test("context engine assemble preserves legitimate consecutive identical messages from different source indices", async () => {
+  const client = new FakeClient();
+  client.assembleResponse = {
+    messages: [
+      makeMessage("user", "yes", "user-1"),
+      makeMessage("user", "yes", "user-2"),
+      makeMessage("user", "current question", "user-3"),
+    ],
+    estimatedTokens: 64,
+    systemPromptAddition: "",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-legitimate-consecutive-identical",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("user", "yes", "user-1"),
+      makeMessage("user", "yes", "user-2"),
+      makeMessage("user", "current question", "user-3"),
+    ],
+    prompt: "current question",
+    tokenBudget: 4000,
+  });
+
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "yes", id: "user-1" },
+    { role: "user", content: "yes", id: "user-2" },
+    { role: "user", content: "current question", id: "user-3" },
+  ]);
+});
+
 test("context engine assemble moves historical tool calls and results out of assistant replay", async () => {
   const client = new FakeClient();
   const currentMessages = [

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1132,6 +1132,38 @@ test("context engine assemble preserves legitimate consecutive identical message
   ]);
 });
 
+test("context engine assemble preserves legitimate consecutive identical no-id messages from different source indices", async () => {
+  const client = new FakeClient();
+  client.assembleResponse = {
+    messages: [
+      makeMessage("user", "yes"),
+      makeMessage("user", "yes"),
+      makeMessage("user", "current question"),
+    ],
+    estimatedTokens: 64,
+    systemPromptAddition: "",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-legitimate-consecutive-identical-no-id",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("user", "yes"),
+      makeMessage("user", "yes"),
+      makeMessage("user", "current question"),
+    ],
+    prompt: "current question",
+    tokenBudget: 4000,
+  });
+
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "yes" },
+    { role: "user", content: "yes" },
+    { role: "user", content: "current question" },
+  ]);
+});
+
 test("context engine assemble moves historical tool calls and results out of assistant replay", async () => {
   const client = new FakeClient();
   const currentMessages = [

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1040,6 +1040,66 @@ test("context engine assemble does not duplicate consumed live tool protocol", a
   assert.doesNotMatch(assembled.systemPromptAddition, /SAME_RESULT_TEXT|\[tool:web_search\]/u);
 });
 
+test("context engine assemble drops consecutive duplicate provider replay messages", async () => {
+  const client = new FakeClient();
+  client.assembleResponse = {
+    messages: [
+      makeMessage("user", "current question", "user-1"),
+      makeMessage("assistant", "same answer", "assistant-1"),
+      makeMessage("assistant", "same answer", "assistant-duplicate"),
+    ],
+    estimatedTokens: 64,
+    systemPromptAddition: "",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-consecutive-provider-duplicate",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("user", "current question", "user-1"),
+      makeMessage("assistant", "same answer", "assistant-1"),
+    ],
+    prompt: "current question",
+    tokenBudget: 4000,
+  });
+
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "current question", id: "user-1" },
+    { role: "assistant", content: "same answer", id: "assistant-1" },
+  ]);
+});
+
+test("context engine assemble deduplicates provider replay after sanitization", async () => {
+  const client = new FakeClient();
+  client.assembleResponse = {
+    messages: [
+      makeMessage("user", "current question", "user-1"),
+      makeMessage("assistant", "same answer [[reply_to_current]]", "assistant-1"),
+      makeMessage("assistant", "same answer", "assistant-duplicate"),
+    ],
+    estimatedTokens: 64,
+    systemPromptAddition: "",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+  const assembled = await engine.assemble({
+    sessionId: "s1-sanitized-provider-duplicate",
+    sessionKey: "sk1",
+    messages: [
+      makeMessage("user", "current question", "user-1"),
+      makeMessage("assistant", "same answer [[reply_to_current]]", "assistant-1"),
+    ],
+    prompt: "current question",
+    tokenBudget: 4000,
+  });
+
+  assert.deepEqual(assembled.messages, [
+    { role: "user", content: "current question", id: "user-1" },
+    { role: "assistant", content: "same answer", id: "assistant-1" },
+  ]);
+});
+
 test("context engine assemble moves historical tool calls and results out of assistant replay", async () => {
   const client = new FakeClient();
   const currentMessages = [


### PR DESCRIPTION
## Summary

When the daemon returns duplicate consecutive messages in `assembleContextInternal` (due to the async `afterTurn` race between the continuity tail and `visibleMsgs`), the plugin forwarded both to the model, causing LLMs to enter a copy-paste repetition loop where the assistant repeats its own prior response verbatim.

## Fix

Add `pushProviderReplayMessage` gate in `normalizeAssembleResult` that skips messages whose `role\0sanitized-content` matches the immediately preceding pushed message. Covers both:
- The live-tool replay path
- The real-transcript path

Memory items and system prompt additions are not affected by this dedup state.

This is a **defensive guard** — the root cause fix is in the daemon (libravdbd v1.8.17, `excludeVisibleTranscriptTailOverlap`), but the plugin should never forward duplicate messages regardless of daemon behavior.

## Test plan

- [x] Consecutive duplicate assistant replay suppression
- [x] Duplicates that become identical only after sanitization (`[[reply_to_current]]` stripped)
- [x] Existing live-tool ordering behavior preserved
- [x] `pnpm exec tsc -p tsconfig.tests.json` passes
- [x] Full unit test suite passes (79/79)

## Stack

Requires daemon-side fix: [libravdbd v1.8.17](https://github.com/zephyr-systems/libravdbd/releases/tag/v1.8.17) (`excludeVisibleTranscriptTailOverlap`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Complexity Analysis

### Time Complexity
- **Impact**: O(m × n) where m = number of provider replay messages and n = average content length.
  - Deduplication key comparisons are O(k) where k ≈ role + sanitized content length.
  - Unlike the original draft, the helper no longer calls normalizeKernelContent on already-sanitized content, so per-message normalization work is avoided — this reduces constant-factor work but does not change the asymptotic bound.
  - Array push operations remain O(1) amortized.
  - Overall complexity remains linear in the number of messages with per-message string processing.

### Cyclomatic Complexity
- **Regression**: +3 net increase in cyclomatic complexity in normalizeAssembleResult / pushProviderReplayMessage area.
  - Added conditional logic beyond a single equality check:
    - Skip duplicates when key equals last key, but preserve when distinct non-negative source indices differ.
    - Branching for presence/absence of providerReplaySourceIndex and fallback to content-only dedup.
    - Exclusions for memory items and system prompt additions, and a live-tool bypass path.
  - These additions increase CC modestly (several small branches) but are localized and keep nesting shallow.

## Summary of Changes

- Introduces session-local consecutive deduplication for provider-replay messages in normalizeAssembleResult via a new pushProviderReplayMessage helper.
  - Dedup key composed from role + already-sanitized message.content (avoid re-normalizing).
  - Deduplication scoped only to the provider-replay transcript path; live-tool / tool-protocol messages bypass the gate to preserve toolCallId ordering.
  - Includes providerReplaySourceIndex in the dedup key so identical content from different source positions is preserved; when source index is unavailable, falls back to content-only dedup.
  - Adds a moving providerReplaySourceCursor to assign distinct source indices for consecutive no-ID messages, preventing incorrect deduplication of adjacent anonymous messages.
  - Memory items and system prompt additions are excluded from deduplication.
- Tests:
  - Adds regression tests verifying suppression of consecutive duplicate assistant replay messages, duplicates that appear only after sanitization, and that live-tool ordering behavior is preserved.
  - Typecheck and unit test suite pass (79/79 tests).
- Notes:
  - The root race-condition was addressed in daemon libravdbd v1.8.17 (excludeVisibleTranscriptTailOverlap); this plugin-side guard remains defensive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->