### PR TITLE
fix: demote routine log messages to info and wire logLevel config

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1053,7 +1053,7 @@ function logPredictiveCompactionOutcome(params: {
     params.logger.info?.(message);
     return;
   }
-  params.logger.warn?.(message);
+  params.logger.info?.(message);
 }
 
 /**
@@ -1122,7 +1122,7 @@ function boundAfterTurnMessagesForIngest(
 
   const bounded = trimMessagesToBudget(messages, AFTER_TURN_INGEST_MAX_TOKENS)
     .map((message) => normalizeKernelMessage(message));
-  logger.warn?.(
+  logger.info?.(
     `LibraVDB afterTurn trimmed oversized ingest payload sessionId=${sessionId} ` +
     `estimatedTokens=${estimatedTokens} maxTokens=${AFTER_TURN_INGEST_MAX_TOKENS} ` +
     `forwardedMessages=${bounded.length}`,
@@ -1766,7 +1766,7 @@ function ensureReplaySafeUserTurn(
   const fallbackUser = findLastReplaySafeUserMessage(sourceMessages);
   if (!fallbackUser) return assembled;
 
-  logger?.warn?.(
+  logger?.info?.(
     "LibraVDB assemble produced no replay-safe user turn; reinjecting the latest user message for provider compatibility.",
   );
   const baseEstimatedTokens = Math.max(
@@ -2790,7 +2790,7 @@ export function buildContextEngineFactory(
           reason: compactionResult.reason,
         });
         if (!compactionResult.ok) {
-          logger.warn?.(
+          logger.info?.(
             `LibraVDB predictive compaction blocked assemble path at ${currentContextTokens} tokens ` +
             `(threshold=${dynamicCompactThreshold}): ${compactionResult.reason ?? "compaction failed"}`,
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { buildMemoryRuntimeBridge } from "./memory-runtime.js";
 import { createLibraVdbMemoryTools } from "./memory-tools.js";
 import { createPluginRuntime } from "./plugin-runtime.js";
 import type { PluginConfig } from "./types.js";
+import { levelFilteredLogger } from "./types.js";
 
 export const MEMORY_ID = "libravdb-memory";
 
@@ -24,7 +25,8 @@ export function shouldShutdownRuntimeForLifecycleCleanup(reason: string): boolea
 
 export function register(api: OpenClawPluginApi) {
   const registrationMode = api.registrationMode;
-  const logger = api.logger ?? console;
+  const baseLogger = api.logger ?? console;
+  const logger = levelFilteredLogger(baseLogger, (api.pluginConfig as PluginConfig)?.logLevel);
 
   if (registrationMode === "cli-metadata") {
     registerMemoryCliMetadata(api);
@@ -170,7 +172,7 @@ export function register(api: OpenClawPluginApi) {
 
   api.registerContextEngine(
     MEMORY_ID,
-    () => buildContextEngineFactory(runtime, cfg, api.logger ?? console),
+    () => buildContextEngineFactory(runtime, cfg, logger),
   );
 
   // Register the daemon's extractive summarization as a pluggable
@@ -191,8 +193,8 @@ export function register(api: OpenClawPluginApi) {
     },
   });
 
-  const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getClient, api.logger ?? console);
-  const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getClient, api.logger ?? console);
+  const markdownIngestion = createMarkdownIngestionHandle(cfg, runtime.getClient, logger);
+  const dreamPromotion = createDreamPromotionHandle(cfg, runtime.getClient, logger);
 
   api.registerService?.({
     id: "libravdb-markdown-ingestion",
@@ -200,7 +202,7 @@ export function register(api: OpenClawPluginApi) {
       try {
         await markdownIngestion.start();
       } catch (error) {
-        api.logger?.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+        logger.warn?.(`LibraVDB markdown ingestion failed to start: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
     async stop() {
@@ -214,7 +216,7 @@ export function register(api: OpenClawPluginApi) {
       try {
         await dreamPromotion.start();
       } catch (error) {
-        api.logger?.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
+        logger.warn?.(`LibraVDB dream promotion failed to start: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
     async stop() {
@@ -251,8 +253,8 @@ export function register(api: OpenClawPluginApi) {
     if (sessionId) clearSessionTrigger(sessionId);
   });
 
-  api.on("before_reset", createBeforeResetHook(runtime, api.logger ?? console));
-  api.on("session_end", createSessionEndHook(runtime, api.logger ?? console));
+  api.on("before_reset", createBeforeResetHook(runtime, logger));
+  api.on("session_end", createSessionEndHook(runtime, logger));
   api.on("gateway_stop", async () => {
     await runtime.shutdown();
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,3 +190,20 @@ export interface PredictedContext {
   text: string;
   reason: string;
 }
+
+const LOG_LEVEL_RANK: Record<string, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+/** Wraps a LoggerLike with logLevel filtering. Levels below configured min are dropped. */
+export function levelFilteredLogger(base: LoggerLike, logLevel: PluginConfig["logLevel"]): LoggerLike {
+  const minRank = LOG_LEVEL_RANK[logLevel ?? "warn"];
+  return {
+    error: (msg) => base.error(msg),
+    warn: (msg) => { if (LOG_LEVEL_RANK.warn <= minRank) base.warn?.(msg); },
+    info: (msg) => { if (LOG_LEVEL_RANK.info <= minRank) base.info?.(msg); },
+  };
+}


### PR DESCRIPTION
## Summary

- Demote four routine/defensive `warn` messages to `info` that were flooding logs on active sessions
- Wire up the `logLevel` config option that was declared but never connected

## Changes

### Log demotions (warn → info)
- `logPredictiveCompactionOutcome` — not-compacted branch (overbudget)
- `boundAfterTurnMessagesForIngest` — trimmed oversized ingest payload
- `ensureReplaySafeUserTurn` — no replay-safe user turn, reinjecting latest
- Predictive compaction blocked assemble path

### logLevel wiring
- Added `levelFilteredLogger()` wrapper in `types.ts` that filters by configured level
- All logger consumers in `index.ts` now use the filtered logger instead of raw `api.logger`

## Test plan

- [ ] Set `logLevel: "info"` in plugin config — verify warn messages are suppressed
- [ ] Set `logLevel: "error"` in plugin config — verify info messages are suppressed
- [ ] Verify four demoted messages still appear at info level when logLevel is "info"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## fix: demote routine log messages to info and wire logLevel config

### Overview
This PR demotes four routine defensive `warn` log messages to `info` level to reduce log flooding during active sessions, and wires up the previously unconnected `logLevel` configuration option across all logging subsystems.

### Changes

**src/context-engine.ts**
- Demoted four predictive/after-turn logging statements from `warn` to `info`:
  - Predictive compaction outcome when compaction does not occur (budget overrun)
  - After-turn ingest payload trimming due to size constraints
  - Re-injecting latest user turn when no replay-safe version is produced by assemble
  - Predictive compaction blocking the assemble fallback path
- No functional logic, control flow, or API changes

**src/types.ts**
- Added `levelFilteredLogger()` utility function that wraps `LoggerLike` with level-based filtering
- Introduces `LOG_LEVEL_RANK` mapping defining log level thresholds (error=0, warn=1, info=2, debug=3)
- Returns a proxy logger that:
  - Always forwards `error` messages
  - Conditionally forwards `warn` and `info` based on configured minimum threshold
  - Omits `debug` handling
- Defaults to `"warn"` level when `logLevel` is not configured

**src/index.ts**
- Updated `register()` to derive logger via `levelFilteredLogger(api.logger ?? console, config.logLevel)`
- Threads the filtered logger instance to all downstream consumers:
  - Context engine factory
  - Markdown ingestion handler
  - Dream promotion handler
  - `before_reset` and `session_end` lifecycle hooks
- Ensures consistent log-level filtering behavior across all subsystems

### Complexity Analysis

**Big O Notation:** No regressions
- Log message demotions have no algorithmic impact
- Logger proxy filtering operates in **O(1)** per invocation (single level rank comparison)
- No iterative or recursive operations introduced
- Log level rank lookup via map access is constant time

**Cyclomatic Complexity:** Minimal, localized increase
- `context-engine.ts`: No change (log-only modifications)
- `index.ts`: No change (parameter threading)
- `types.ts`: New `levelFilteredLogger()` function introduces **+3 to +5 cyclomatic paths**
  - Conditional branch for error (always pass-through)
  - Conditional branch for warn/info (level threshold comparison)
  - Default level evaluation
  - Logger proxy method interception with conditional forwarding
  - Complexity increase is isolated to the new utility function and does not affect existing code paths

### Testing Considerations
- `logLevel: "info"` configuration should suppress `warn` messages
- `logLevel: "error"` configuration should suppress both `warn` and `info` messages
- Four demoted messages should appear at `info` level when threshold is appropriately configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->