### PR TITLE
fix: add deadline to AssembleContextInternal gRPC call

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2887,16 +2887,22 @@ export function buildContextEngineFactory(
             }
           }
 
-          const resp = await client.assembleContextInternal({
-            sessionId,
-            sessionKey: args.sessionKey,
-            userId,
-            prompt: strippedPrompt,
-            messages,
-            tokenBudget: args.tokenBudget,
-            config: buildAssemblyConfig(args.tokenBudget),
-            emitDebug: true,
-          });
+          const assembleTimeout = cfg.assembleTimeoutMs ?? 30000;
+          const resp = await Promise.race([
+            client.assembleContextInternal({
+              sessionId,
+              sessionKey: args.sessionKey,
+              userId,
+              prompt: strippedPrompt,
+              messages,
+              tokenBudget: args.tokenBudget,
+              config: buildAssemblyConfig(args.tokenBudget),
+              emitDebug: true,
+            }),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error(`AssembleContextInternal timed out after ${assembleTimeout}ms`)), assembleTimeout)
+            ),
+          ]);
           const assembled = normalizeAssembleResult(resp, args.messages);
           const continuityContext = await injectContinuityContext({
             client,

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface PluginConfig {
   beforeTurnEnabled?: boolean;
   /** Timeout in milliseconds for the BeforeTurnKernel gRPC call. Default: 5000 */
   beforeTurnTimeoutMs?: number;
+  /** Timeout in milliseconds for the AssembleContextInternal gRPC call. Default: 30000 */
+  assembleTimeoutMs?: number;
   /** Maximum number of retrieved memories to inject per turn. Default: 5 */
   beforeTurnMaxMemories?: number;
   /** Minimum similarity score (0.0–1.0) for semantic search hits. Default: 0.4 */

--- a/test/unit/assemble-timeout.test.ts
+++ b/test/unit/assemble-timeout.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Verify the Promise.race timeout pattern used by assembleContextInternal.
+// When an underlying gRPC call hangs (daemon unresponsive), the timeout
+// must reject within the configured window so the agent pipeline recovers.
+
+test("assemble timeout rejects when promise hangs", async () => {
+  const timeoutMs = 50;
+
+  const neverResolves = new Promise<never>(() => {
+    // intentionally never settles — simulates hung gRPC call
+  });
+
+  const timedOut = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`AssembleContextInternal timed out after ${timeoutMs}ms`)), timeoutMs)
+  );
+
+  const start = Date.now();
+  await assert.rejects(
+    () => Promise.race([neverResolves, timedOut]),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("timed out"));
+      assert.ok(err.message.includes(String(timeoutMs)));
+      return true;
+    }
+  );
+  const elapsed = Date.now() - start;
+  // Allow 50ms grace for timer imprecision
+  assert.ok(elapsed < timeoutMs + 50, `timeout took ${elapsed}ms, expected ~${timeoutMs}ms`);
+});
+
+test("assemble timeout returns result when promise resolves before timeout", async () => {
+  const timeoutMs = 5000;
+
+  const resolvesQuickly = Promise.resolve({ messages: [], systemPromptAddition: "" });
+
+  const timedOut = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`AssembleContextInternal timed out after ${timeoutMs}ms`)), timeoutMs)
+  );
+
+  const result = await Promise.race([resolvesQuickly, timedOut]);
+  assert.deepEqual(result, { messages: [], systemPromptAddition: "" });
+});
+
+test("assemble timeout uses configured value", () => {
+  // Default: 30000ms
+  const cfg = {} as { assembleTimeoutMs?: number };
+  const timeout = cfg.assembleTimeoutMs ?? 30000;
+  assert.equal(timeout, 30000);
+
+  // Explicit: 15000ms
+  cfg.assembleTimeoutMs = 15000;
+  const custom = cfg.assembleTimeoutMs ?? 30000;
+  assert.equal(custom, 15000);
+});


### PR DESCRIPTION
## Summary
- The `AssembleContextInternal` gRPC call had no deadline, unlike all other daemon RPCs (`BeforeTurnKernel` has 5s, `rpcTimeoutMs` defaults to 120s via client config but wasn't being enforced per-call)
- If the daemon gRPC transport hangs (healthy daemon, lost response on unix socket), this call blocks the entire agent pipeline indefinitely → permanent spinner in web UI
- Add a `Promise.race` with configurable `assembleTimeoutMs` (default 30s) matching the same pattern as `BeforeTurnKernel`

## Changes
- `src/context-engine.ts`: wrap `assembleContextInternal` call in `Promise.race` with timeout
- `src/types.ts`: add `assembleTimeoutMs` to `PluginConfig` type
- `test/unit/assemble-timeout.test.ts`: unit test verifying timeout rejects hung promise and resolves when promise completes

## Test plan
- [x] `node --test .ts-build/test/unit/assemble-timeout.test.js` — 3/3 pass
- [ ] Verify agent recovers with error log after daemon restart (needs live daemon test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a configurable per-call deadline to the `AssembleContextInternal` gRPC call to prevent indefinite blocking when the daemon's gRPC transport hangs, even if the daemon itself is healthy. The implementation uses a `Promise.race`-based timeout pattern (default 30 seconds), mirroring the pattern already established by `BeforeTurnKernel` in the same codebase.

## Changes

**src/context-engine.ts** (16 lines added, 10 removed)
- Wraps `client.assembleContextInternal()` call in `Promise.race()` with a configurable timeout
- Reads `cfg.assembleTimeoutMs` (defaults to 30000 ms) and races the daemon call against a timeout promise
- On timeout, rejects with error message: `AssembleContextInternal timed out after ${assembleTimeout}ms`
- The rejection is caught by existing `try/catch` in the `assemble()` method, which falls back to the budget-clamped replay-safe path

**src/types.ts** (2 lines added)
- Added optional `assembleTimeoutMs?: number` property to `PluginConfig` interface
- Documented as timeout for the `AssembleContextInternal` gRPC call with 30000 ms default

**test/unit/assemble-timeout.test.ts** (57 lines added, new file)
- Three unit tests verify: (1) timeout rejects hung promises within configured window with correct error message, (2) fast-resolving promises return unchanged when completed before timeout, (3) default (30000 ms) and custom timeout values work as configured
- All tests pass (3/3)

## Complexity Analysis

**Big O Notation:**
- **Time Complexity**: O(1) — The timeout mechanism uses a fixed constant delay. `Promise.race()` itself is O(1), racing exactly two promises with no loops or data structure traversals.
- **Space Complexity**: O(1) — Only one timeout configuration variable and a single timeout promise added, both constant size.

**Cyclomatic Complexity:** No regression
- The change does not introduce new conditional branches or decision paths
- Mirrors the existing `BeforeTurnKernel` timeout pattern (which uses identical `Promise.race` structure)
- No `if/else`, loops, or conditional operators added to the function's control flow
- Cyclomatic complexity change: **0**

## Test Results

Unit tests pass: 3/3 passing
- Timeout rejection timing verified to fire within configured window
- Error messages validated to include both "timed out" and timeout value
- Default and custom timeout configuration values confirmed working

Integration testing pending: verification that agent recovers with error log after daemon restart (requires live daemon).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->