### PR TITLE
docs: document npm audit workaround

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,5 +1,48 @@
 # Dependency Rationale
 
+## npm audit and Connect transport dependencies
+
+The npm package depends on `@connectrpc/connect-node` for the gRPC transport used
+to reach the separately installed `libravdbd` service. The current Connect 1.x
+line resolves `@connectrpc/connect-node@1.7.0`, which depends on `undici@5.29.0`.
+
+Some npm consumers may therefore see `npm audit --omit=dev` report this path:
+
+```text
+@xdarkicex/openclaw-memory-libravdb
+└─┬ @connectrpc/connect-node@1.7.0
+  └── undici@5.29.0
+```
+
+This is not fixed by the `pnpm.overrides` entry in this repository. That override
+only affects this repo's own pnpm install; it does not force npm's dependency
+resolution in a consuming OpenClaw project.
+
+If an operator needs a temporary npm-side audit workaround while the plugin still
+targets Connect 1.x, use root-project `overrides` in the consuming project:
+
+```json
+{
+  "overrides": {
+    "undici": "6.24.0"
+  }
+}
+```
+
+Then reinstall and re-run the audit:
+
+```bash
+npm install
+npm audit --omit=dev
+```
+
+Treat this as a consumer workaround, not the upstream package fix. Moving the
+plugin itself to Connect 2.x is a source migration, not a one-line dependency
+bump: Connect 2 removes the current `createPromiseClient` API, protobuf 2 removes
+the current `PartialMessage` export used by this codebase, and transport options
+changed. The durable upstream fix needs the plugin and generated contracts to
+migrate across that API boundary together.
+
 ## LibraVDB over LanceDB
 
 LibraVDB was chosen as the vector store because the plugin needs more than a single-table embedding lookup.


### PR DESCRIPTION
## Summary

- Documents why npm consumers can still see `@connectrpc/connect-node -> undici@5.29.0` audit findings even though this repo has a pnpm override.
- Adds a narrow root-project npm `overrides.undici = 6.24.0` workaround for operators who need to clear the current audit path while the plugin targets Connect 1.x.
- Calls out that the durable upstream fix is a coordinated Connect/protobuf 2.x migration, not a one-line dependency bump.

Fixes xDarkicex/openclaw-memory-libravdb#340.

## Verification

- Created a fresh npm throwaway project with `@xdarkicex/openclaw-memory-libravdb@1.9.8` and `overrides.undici = 6.24.0`.
- Confirmed `npm ls @xdarkicex/openclaw-memory-libravdb @connectrpc/connect-node undici --all --package-lock-only` resolves `@connectrpc/connect-node@1.7.0 -> undici@6.24.0 overridden`.
- Confirmed `npm audit --omit=dev --json` reports `0` vulnerabilities for that throwaway install.
- Docs-only change; no runtime tests run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation-only PR: npm audit workaround guide

This PR adds a new section to `docs/dependencies.md` explaining the npm audit vulnerability path caused by the plugin's dependency on `@connectrpc/connect-node@1.7.0`, which transitively pulls in `undici@5.29.0`.

**Key points documented:**

- **Root cause:** The repository's `pnpm.overrides` entry for undici does not affect npm consumers, only this repository's own pnpm install
- **Workaround:** Provides instructions for consuming projects to apply a temporary npm-side `overrides` entry (`undici: 6.24.0`) with reinstall and re-audit commands
- **Upstream context:** Clarifies that a durable fix requires migrating the plugin from Connect 1.x to Connect 2.x, which is a broader source migration (not a simple dependency bump) due to API removals in both Connect 2 and protobuf 2

The documentation also preserves existing sections explaining the rationale for LibraVDB (chosen over LanceDB for its collection-level namespacing, delete operations, and local-first architecture) and Slabby (allocation-optimized slab storage for the vector-heavy workload).

**Note:** Complexity analysis not applicable—this is a documentation-only change with no code modifications.

**Verification:** Operator-performed steps confirmed the workaround effectiveness on a test project with overrides applied.

Fixes xDarkicex/openclaw-memory-libravdb#340.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->