### PR TITLE
[AI-assisted] Fix memory_grep default session recall

### DIFF
--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -49,6 +49,13 @@ type MemoryGrepDetails = {
   truncated: boolean;
 };
 
+type GrepSearchResult = {
+  id: string;
+  score: number;
+  text: string;
+  metadataJson?: Uint8Array;
+};
+
 // ── Constants ──
 
 const MAX_EXPAND_TOKENS = 8000;
@@ -181,6 +188,30 @@ function safeMatch(text: string, pattern: string, mode: "regex" | "text"): boole
   } catch {
     return text.toLowerCase().includes(pattern.toLowerCase());
   }
+}
+
+function parseGrepMetadata(result: GrepSearchResult): Record<string, unknown> {
+  if (result.metadataJson && result.metadataJson.length > 0) {
+    try {
+      return JSON.parse(new TextDecoder().decode(result.metadataJson)) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function readGrepRole(result: GrepSearchResult): string {
+  const meta = parseGrepMetadata(result);
+  return typeof meta.role === "string" ? meta.role : "unknown";
+}
+
+function buildMessageGrepCollections(sessionId: string): string[] {
+  const collections = [`session_raw:${sessionId}`];
+  if (sessionId.length > 0) {
+    collections.push(`session:${sessionId}`);
+  }
+  return collections;
 }
 
 // ── Tool factories ──
@@ -432,26 +463,38 @@ export function createMemoryGrepTool(
 
         if (scope === "messages" || scope === "both") {
           const searchK = Math.min(limit * 3, 200);
-          const turnResults = await client.searchText({
-            collection: `session_raw:${sessionId}`,
-            text: pattern,
-            k: searchK,
-          });
-          for (const r of (turnResults.results ?? [])) {
-            if (turns.length >= limit || totalChars >= MAX_GREP_CHARS) break;
-            if (!safeMatch(r.text, pattern, mode)) continue;
-            totalMatches++;
-            const snippet = truncateSnippet(r.text);
-            let role = "unknown";
-            if (r.metadataJson && r.metadataJson.length > 0) {
-              try {
-                const decoder = new TextDecoder();
-                const meta = JSON.parse(decoder.decode(r.metadataJson)) as Record<string, unknown>;
-                role = typeof meta.role === "string" ? meta.role : "unknown";
-              } catch { /* best-effort */ }
+          const bestTurnById = new Map<string, {
+            turnId: string;
+            snippet: string;
+            role: string;
+            score: number;
+          }>();
+          for (const collection of buildMessageGrepCollections(sessionId)) {
+            const turnResults = await client.searchText({
+              collection,
+              text: pattern,
+              k: searchK,
+            });
+            for (const r of (turnResults.results ?? [])) {
+              if (!safeMatch(r.text, pattern, mode)) continue;
+              const candidate = {
+                turnId: r.id,
+                snippet: truncateSnippet(r.text),
+                role: readGrepRole(r),
+                score: r.score,
+              };
+              const existing = bestTurnById.get(r.id);
+              if (!existing || candidate.score > existing.score) {
+                bestTurnById.set(r.id, candidate);
+              }
             }
-            turns.push({ turnId: r.id, snippet, role, score: r.score });
-            totalChars += snippet.length;
+          }
+          const dedupedTurns = [...bestTurnById.values()].sort((a, b) => b.score - a.score);
+          for (const turn of dedupedTurns) {
+            if (turns.length >= limit || totalChars >= MAX_GREP_CHARS) break;
+            totalMatches++;
+            turns.push(turn);
+            totalChars += turn.snippet.length;
           }
         }
 

--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -193,7 +193,10 @@ function safeMatch(text: string, pattern: string, mode: "regex" | "text"): boole
 function parseGrepMetadata(result: GrepSearchResult): Record<string, unknown> {
   if (result.metadataJson && result.metadataJson.length > 0) {
     try {
-      return JSON.parse(new TextDecoder().decode(result.metadataJson)) as Record<string, unknown>;
+      const parsed = JSON.parse(new TextDecoder().decode(result.metadataJson)) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
     } catch {
       return {};
     }

--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -207,11 +207,8 @@ function readGrepRole(result: GrepSearchResult): string {
 }
 
 function buildMessageGrepCollections(sessionId: string): string[] {
-  const collections = [`session_raw:${sessionId}`];
-  if (sessionId.length > 0) {
-    collections.push(`session:${sessionId}`);
-  }
-  return collections;
+  if (sessionId.length === 0) return [];
+  return [`session_raw:${sessionId}`, `session:${sessionId}`];
 }
 
 // ── Tool factories ──

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -112,6 +112,29 @@ test("memory_grep defaults to the active session id", async () => {
   assert.equal(client.calls.length, 1);
 });
 
+test("memory_grep does not query message collections without a session id", async () => {
+  const client = new CollectionRecallClient({
+    "session_raw:": [{
+      id: "turn-1",
+      score: 0.99,
+      text: "needle in malformed collection",
+      metadataJson: encodeMetadata({ role: "user" }),
+    }],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => undefined,
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string }> };
+
+  assert.equal(details.totalMatches, 0);
+  assert.deepEqual(details.turns, []);
+  assert.equal(client.calls.length, 0);
+});
+
 test("memory_grep searches the default active session collection for messages", async () => {
   const client = new CollectionRecallClient({
     "session_raw:active-session": [],

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -167,6 +167,34 @@ test("memory_grep searches the default active session collection for messages", 
   }]);
 });
 
+test("memory_grep treats non-object message metadata as missing", async () => {
+  const client = new CollectionRecallClient({
+    "session_raw:active-session": [{
+      id: "turn-1",
+      score: 0.77,
+      text: "needle survives non-object metadata",
+      metadataJson: new TextEncoder().encode("null"),
+    }],
+    "session:active-session": [],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; snippet: string; role: string; score: number }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle survives non-object metadata",
+    role: "unknown",
+    score: 0.77,
+  }]);
+});
+
 test("memory_grep keeps independent summary and message budgets", async () => {
   const client = new CollectionRecallClient({
     "session_summary:active-session": [{

--- a/test/unit/memory-recall.test.ts
+++ b/test/unit/memory-recall.test.ts
@@ -12,6 +12,13 @@ const silentLogger = {
   info(_message: string) {},
 };
 
+type FakeSearchResult = {
+  id: string;
+  score: number;
+  text: string;
+  metadataJson?: Uint8Array;
+};
+
 class FakeRecallClient {
   public calls: Array<{ method: string; params: Record<string, unknown> }> = [];
 
@@ -29,7 +36,7 @@ class FakeRecallClient {
     };
   }
 
-  async searchText(params: Record<string, unknown>) {
+  async searchText(params: Record<string, unknown>): Promise<{ results: FakeSearchResult[] }> {
     this.calls.push({ method: "searchText", params });
     return {
       results: [{
@@ -41,6 +48,24 @@ class FakeRecallClient {
           eviction_cue: "summary cue",
         })),
       }],
+    };
+  }
+}
+
+function encodeMetadata(value: Record<string, unknown>): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+class CollectionRecallClient extends FakeRecallClient {
+  constructor(private readonly resultsByCollection: Record<string, FakeSearchResult[]>) {
+    super();
+  }
+
+  override async searchText(params: Record<string, unknown>): Promise<{ results: FakeSearchResult[] }> {
+    this.calls.push({ method: "searchText", params });
+    const collection = typeof params.collection === "string" ? params.collection : "";
+    return {
+      results: this.resultsByCollection[collection] ?? [],
     };
   }
 }
@@ -84,6 +109,154 @@ test("memory_grep defaults to the active session id", async () => {
   assert.equal((result.details as { totalMatches: number }).totalMatches, 1);
   assert.equal(client.calls[0]?.method, "searchText");
   assert.equal(client.calls[0]?.params.collection, "session_summary:active-session");
+  assert.equal(client.calls.length, 1);
+});
+
+test("memory_grep searches the default active session collection for messages", async () => {
+  const client = new CollectionRecallClient({
+    "session_raw:active-session": [],
+    "session:active-session": [{
+      id: "turn-1",
+      score: 0.88,
+      text: "needle inside default session collection",
+      metadataJson: encodeMetadata({ role: "user" }),
+    }],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; snippet: string; role: string; score: number }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(client.calls.map((call) => call.params.collection), [
+    "session_raw:active-session",
+    "session:active-session",
+  ]);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle inside default session collection",
+    role: "user",
+    score: 0.88,
+  }]);
+});
+
+test("memory_grep keeps independent summary and message budgets", async () => {
+  const client = new CollectionRecallClient({
+    "session_summary:active-session": [{
+      id: "sum_1",
+      score: 0.7,
+      text: "needle inside summary text",
+      metadataJson: encodeMetadata({ eviction_cue: "summary cue" }),
+    }],
+    "session_raw:active-session": [],
+    "session:active-session": [{
+      id: "turn-1",
+      score: 0.99,
+      text: "needle inside default session collection",
+      metadataJson: encodeMetadata({ role: "assistant" }),
+    }],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "both", limit: 1 });
+  const details = result.details as {
+    totalMatches: number;
+    summaries: Array<{ summaryId: string; snippet: string; score: number; evictionCue?: string }>;
+    turns: Array<{ turnId: string; snippet: string; role: string; score: number }>;
+  };
+
+  assert.deepEqual(client.calls.map((call) => call.params.collection), [
+    "session_summary:active-session",
+    "session_raw:active-session",
+    "session:active-session",
+  ]);
+  assert.equal(details.totalMatches, 2);
+  assert.deepEqual(details.summaries, [{
+    summaryId: "sum_1",
+    snippet: "needle inside summary text",
+    score: 0.7,
+    evictionCue: "summary cue",
+  }]);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle inside default session collection",
+    role: "assistant",
+    score: 0.99,
+  }]);
+});
+
+test("memory_grep deduplicates messages only after exact matching", async () => {
+  const client = new CollectionRecallClient({
+    "session_raw:active-session": [{
+      id: "turn-1",
+      score: 0.99,
+      text: "semantic neighbor without the target phrase",
+      metadataJson: encodeMetadata({ role: "user" }),
+    }],
+    "session:active-session": [{
+      id: "turn-1",
+      score: 0.5,
+      text: "needle appears in the default session collection",
+      metadataJson: encodeMetadata({ role: "assistant" }),
+    }],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; snippet: string; role: string; score: number }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle appears in the default session collection",
+    role: "assistant",
+    score: 0.5,
+  }]);
+});
+
+test("memory_grep keeps the highest-scored duplicate message hit", async () => {
+  const client = new CollectionRecallClient({
+    "session_raw:active-session": [{
+      id: "turn-1",
+      score: 0.71,
+      text: "needle inside duplicate raw collection",
+      metadataJson: encodeMetadata({ role: "user" }),
+    }],
+    "session:active-session": [{
+      id: "turn-1",
+      score: 0.88,
+      text: "needle inside default session collection",
+      metadataJson: encodeMetadata({ role: "user" }),
+    }],
+  });
+  const tool = createMemoryGrepTool(
+    async () => client as unknown as LibravDBClient,
+    () => "active-session",
+    silentLogger,
+  );
+
+  const result = await tool.execute("call-1", { pattern: "needle", scope: "messages" });
+  const details = result.details as { totalMatches: number; turns: Array<{ turnId: string; snippet: string; role: string; score: number }> };
+
+  assert.equal(details.totalMatches, 1);
+  assert.deepEqual(details.turns, [{
+    turnId: "turn-1",
+    snippet: "needle inside default session collection",
+    role: "user",
+    score: 0.88,
+  }]);
 });
 
 test("memory_expand defaults to the active session id", async () => {


### PR DESCRIPTION
## Summary

- Problem: `memory_grep` searched `session_raw:<id>` for message scope but missed exact active-session hits stored in LibraVDB's default `session:<id>` recall collection.
- Solution: search the default `session:<id>` collection as part of the message grep bucket while keeping summary and message searches independent.
- What changed: `memory_grep` now queries `session_raw:<id>` and `session:<id>` separately for message results when a session ID is available, skips malformed empty-session message collection names, treats non-object grep metadata as missing metadata, filters exact/regex matches before deduplication, and keeps the highest-scored duplicate turn ID.
- What did NOT change (scope boundary): no daemon, manifest, activation, lifecycle, dependency, lockfile, storage schema, auth, migration, `memory_search`, or `memory_expand` behavior changed.

## Motivation

`memory_grep` is the exact-match fallback for active-session recall. Current `main` already uses the default `session:<id>` collection for normal session recall, but `memory_grep(scope="messages")` still searched only `session_raw:<id>`. That made exact grep unreliable for active-session text indexed in the default session collection.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #303 earlier draft for the same bug; this version rebases the fix onto current `main` and addresses the review feedback about mixed top-k, scope, provenance, and deduplication.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: `memory_grep(scope="messages")` now finds exact active-session hits stored under the default `session:<id>` collection.
- Real environment tested: Linux throwaway checkout of current `main` at `96b7694` plus this patch through head `e00b029`, using Node `v24.16.0` and `pnpm@9.15.9`.
- Exact steps or command run after this patch:

```bash
corepack pnpm@9 install --frozen-lockfile --store-dir throwaway-pnpm-store
git diff --check
corepack pnpm@9 exec tsc -p tsconfig.tests.json
node --test .ts-build/test/unit/memory-recall.test.js
node --test .ts-build/test/unit/memory-tools.test.js .ts-build/test/unit/memory-runtime.test.js .ts-build/test/unit/before-turn.test.js
corepack pnpm@9 exec tsc --noEmit
corepack pnpm@9 run build
```

- Evidence after fix:

```text
memory-recall.test.js: tests 12, pass 12, fail 0
memory-tools.test.js + memory-runtime.test.js + before-turn.test.js: tests 34, pass 34, fail 0
tsc -p tsconfig.tests.json: pass
tsc --noEmit: pass
pnpm run build: pass
git diff --check: pass
```

- Observed result after fix: the targeted tests verify default-session-only message hits are returned, summary-only scope does not query `session:<id>`, empty session IDs do not query malformed message collections like `session_raw:`, syntactically valid non-object message metadata falls back to `role: "unknown"` without dropping the hit, `scope="both"` preserves independent summary/message budgets, non-matching duplicate IDs no longer suppress matching hits, and duplicate matching turn IDs keep the highest score.
- What was not tested: production daemon data with a live packaged OpenClaw host session, external hosted providers, GitHub Actions completion, and maintainer-hosted production runtime.
- Before evidence:

```text
Current main at 96b7694:
memory_grep(scope="summaries") -> searchText(collection="session_summary:<id>")
memory_grep(scope="messages")  -> searchText(collection="session_raw:<id>")

Missing before this patch:
memory_grep(scope="messages") did not search collection="session:<id>"
```

## Root Cause

- Root cause: `memory_grep` hard-coded the experimental message collection `session_raw:<id>` but did not include the default session recall collection `session:<id>`.
- Missing detection / guardrail: tests only asserted the summary active-session fallback, not the default message recall collection used by ordinary session recall, the empty-session message collection guard, or best-effort handling for non-object message metadata.
- Contributing context (if known): an earlier implementation tried to solve this with one mixed multi-collection search stream, but review correctly identified top-k starvation, scope leakage, provenance assumptions, and dedup ordering risks.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/memory-recall.test.ts`
- Scenario the test should lock in: `memory_grep(scope="messages")` searches both `session_raw:<id>` and default `session:<id>` for non-empty sessions, returns a hit that exists only in the default session collection, does not query malformed message collections when no session ID is available, and keeps matching turns when `metadataJson` parses to a non-object such as JSON `null`.
- Why this is the smallest reliable guardrail: the bug is in plugin-side collection selection and result filtering before daemon search results are returned, so fake-client unit tests can assert exact collection calls and result behavior.
- Existing test that already covers this (if any): none before this patch.
- If no new test is added, why not: New focused tests were added.

## User-visible / Behavior Changes

`memory_grep` can now find exact active-session text stored in the default session recall collection. Existing summary search and raw-message search behavior remain available.

## Diagram

```text
Before:
memory_grep(scope="messages")
  -> session_raw:<id> only
  -> misses hits stored only in session:<id>

After:
memory_grep(scope="messages")
  -> session_raw:<id>
  -> session:<id>
  -> exact/regex filter
  -> dedupe matching turns by highest score

Empty session ID:
memory_grep(scope="messages")
  -> no message collection lookup
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No new endpoint; message grep may issue one additional `SearchText` request for the active session's default `session:<id>` collection.
- Command/tool execution surface changed? No.
- Data access scope changed? No new durable namespace; this aligns `memory_grep` with the same active-session collection already used by LibraVDB session recall.
- If any `Yes`, explain risk + mitigation: The additional lookup is limited to a non-empty current active session ID and covered by unit tests that assert summary scope does not query `session:<id>` and empty message scope does not query `session_raw:`.

## Repro + Verification

### Environment

- OS: Linux throwaway checkout
- Runtime/container: Node `v24.16.0`, `pnpm@9.15.9`
- Model/provider: Not applicable
- Integration/channel (if any): LibraVDB recall tool path with fake daemon clients for deterministic collection routing
- Relevant config (redacted): no credentials, tokens, private runtime config, or external provider account used

### Steps

1. Check out current `main` at `96b7694`.
2. Apply this patch.
3. Install dependencies with `pnpm@9` and a throwaway store.
4. Compile test artifacts with `tsc -p tsconfig.tests.json`.
5. Run targeted `memory-recall` tests.
6. Run adjacent memory/runtime/before-turn unit tests.
7. Run TypeScript no-emit, production build, and whitespace diff checks.

### Expected

- `memory_grep(scope="summaries")` searches only `session_summary:<id>`.
- `memory_grep(scope="messages")` searches `session_raw:<id>` and `session:<id>`.
- `memory_grep(scope="messages")` with no session ID does not query malformed message collections.
- Non-object message metadata falls back to `role: "unknown"` without dropping matching turns.
- `memory_grep(scope="both")` keeps independent summary and message result budgets.
- Duplicate turn IDs are deduplicated after exact/regex filtering, keeping the highest score.
- Targeted and adjacent tests, TypeScript, build, and whitespace checks pass.

### Actual

- Summary scope stayed isolated to `session_summary:<id>`.
- Message scope returned the default-session-only hit.
- Empty message scope made no malformed `session_raw:` lookup.
- A matching turn with `metadataJson` set to JSON `null` returned with `role: "unknown"`.
- `scope="both"` returned one summary and one message with `limit=1`.
- A non-matching duplicate no longer suppressed a later matching duplicate.
- The highest-scored duplicate matching turn was retained.
- Targeted and adjacent tests, TypeScript, build, and whitespace checks passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
git diff --check: pass
corepack pnpm@9 exec tsc -p tsconfig.tests.json: pass

memory-recall.test.js:
tests 12
pass 12
fail 0

memory-tools.test.js + memory-runtime.test.js + before-turn.test.js:
tests 34
pass 34
fail 0

corepack pnpm@9 exec tsc --noEmit: pass
corepack pnpm@9 run build: pass
```

## Human Verification

- Verified scenarios: default-session-only message hit, empty-session message collection guard, non-object message metadata fallback, summary-only scope isolation, independent `scope="both"` budgets, dedup after exact matching, highest-score duplicate selection, role fallback from metadata, targeted recall tools, adjacent memory/runtime/before-turn units, TypeScript, production build, and whitespace diff check.
- Edge cases checked: non-matching duplicate before matching duplicate, same turn ID across raw/default session collections, default active session ID fallback, missing active session ID for message scope, JSON `null` metadata, and no dependency/lockfile changes.
- What you did **not** verify: live packaged OpenClaw host session, external hosted providers, GitHub Actions completion, full unit suite, host-flow integration, plugin inspector, and maintainer-hosted production daemon behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

CodeRabbit's PR #342 review thread about empty `sessionId` message collection names is addressed by commit `ad33283` and was resolved by `coderabbitai[bot]` after re-review. No human GitHub review reply or manual thread resolve was posted. The code also addresses the prior #303 top-level review feedback about mixed top-k, summaries scope, dedup-before-filtering, duplicate selection, and collection provenance.

The Vale/compoodment request-changes review about non-object `metadataJson` is addressed by commit `e00b029`. No human GitHub review reply or manual thread resolve was posted; reviewer re-review is still needed.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: No upgrade steps required.

## Risks and Mitigations

- Risk: searching one additional active-session collection could return duplicate turn IDs.
  - Mitigation: message results are exact/regex filtered first, then deduplicated by turn ID with highest score retained.
- Risk: summary results could be starved by high-scoring turn results.
  - Mitigation: summary and message searches remain separate; `session:<id>` is never queried for `scope="summaries"`.
- Risk: daemon results may not include collection provenance in metadata.
  - Mitigation: message classification no longer depends on `metadataJson.collection`; the code knows which bucket it is searching.
- Risk: missing session context could create malformed message collection lookups.
  - Mitigation: message grep returns no message collections for an empty session ID, covered by regression test.
- Risk: syntactically valid non-object metadata such as JSON `null` could throw while reading `role` and drop matching message results.
  - Mitigation: grep metadata parsing now only returns non-null, non-array objects; other parsed values fall back to `{}` and `role: "unknown"`, covered by regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a correctness bug in `memory_grep(scope="messages")` where active-session message hits stored in the default `session:<id>` collection were missed because only the experimental `session_raw:<id>` collection was queried.

## Changes

### `src/tools/memory-recall.ts`

**Algorithmic Changes:**
- **Collection querying**: Replaced single-collection search (`session_raw:${sessionId}`) with dual-collection queries via new helper `buildMessageGrepCollections(sessionId)`, which returns `["session_raw:${sessionId}", "session:${sessionId}"]` for non-empty session IDs or `[]` for empty ones (guards malformed collection names).
- **Deduplication**: Introduced a `Map<turnId, {turnId, snippet, role, score}>` to deduplicate results per `turnId`, retaining the highest-scored duplicate when the same turn appears in both collections.
- **Filtering order**: Exact/regex matching via `safeMatch()` is applied **before** deduplication, ensuring only exact matches contribute to the deduped set.
- **Helper functions**: 
  - `parseGrepMetadata()` - Safely decodes and validates metadata JSON; returns empty object for malformed/non-object metadata.
  - `readGrepRole()` - Extracts `role` field from parsed metadata with "unknown" fallback.
  - `buildMessageGrepCollections()` - O(1), returns 0 or 2 collection names.

**Complexity Analysis:**
- **Big O**: Worst-case remains **O(k·L + k log k)** where k = searchK ≈ min(limit·3, 200) and L = average text snippet length. The sorting of deduped results (`dedupedTurns.sort()`) dominates. However, **number of SearchText requests increases from 1 to 2** (constant factor of 2× for active session).
  - Per collection: O(k) iterations over results
  - Per result: O(L) for `safeMatch()`, O(L) for `truncateSnippet()`, O(M) for metadata parse (M = metadata size), O(1) for Map operations
  - Final sort: O(k log k) across all unique turnIds from both collections
  - **Total: O(2 × (k·L + k·M)) + O(k log k) ≈ O(k·L + k log k)** - asymptotically identical to single-collection baseline
  
- **Cyclomatic Complexity**: No regression. Loop structure (for each of 2 collections → filter results → dedup → sort) adds ~1 conditional branch but maintains baseline complexity of ~6–7 (comparable to original ~5–6).

- **Space Complexity**: O(k) for `bestTurnById` Map and O(k) for sorted results—no regression vs. single-collection approach.

**Mitigations for 2× search overhead:**
- Early filtering: `safeMatch()` is applied per result before Map insertion, reducing actual objects stored from 400 (2×200) to only those matching the pattern.
- Score-keeping: Only the highest-scored duplicate is retained, reducing final result cardinality.
- Bounded limit: searchK capped at 200, making absolute cost predictable (max 400 results processed, typically < 50 after filtering).

### `test/unit/memory-recall.test.ts`

**Coverage Additions:**
- **Guard test**: Validates that empty session IDs do not trigger message collection queries (prevents malformed `session_raw:` and `session:` lookups).
- **Dual-collection test**: Confirms queries over both `session_raw:active-session` and `session:active-session`, validating metadata decoding (role extraction with "unknown" fallback).
- **Non-object metadata test**: Verifies that non-object metadata (e.g., `null`) is treated as missing and role defaults to "unknown".
- **Independent budgets test**: Asserts that `scope="both"` maintains separate per-collection result limits for summaries and messages (e.g., limit:1 can yield 1 summary + 1 message).
- **Deduplication-after-filtering test**: Confirms exact matching occurs before deduplication (high-score semantic neighbors without pattern match are excluded).
- **Highest-score-retention test**: Validates that when the same `turnId` appears in multiple collections, the higher-scored variant is retained.

**Test Infrastructure:**
- Introduced typed `FakeSearchResult` interface with optional `metadataJson: Uint8Array`.
- Added `CollectionRecallClient` subclass of `FakeRecallClient` to return per-collection results based on the `collection` parameter.
- `encodeMetadata()` helper for test fixture construction.

## Known Risks & Limitations

- **Production daemon data**: Not tested against real-world LibraVDB daemon collections; behavior with malformed or missing `session:` collections is untested in production.
- **External hosted providers**: No validation against external/cloud-hosted LibraVDB instances.
- **Additional SearchText latency**: One extra search per active-session grep query; impact on slow network/storage backends not measured.

## Unaffected

- Daemon, manifest, activation, lifecycle, dependencies, lockfiles, storage schema, auth, and migration logic.
- `memory_search`, `memory_expand`, `memory_describe` tools and their prompt guidance.
- Summary search logic (remains independent; `session_summary:<id>` queried only for `scope="summaries"` or `scope="both"`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->