### PR TITLE
[AI-assisted] Reject HTTP-style grpc endpoints

### DIFF
--- a/docs/TLS_configuration.md
+++ b/docs/TLS_configuration.md
@@ -18,7 +18,7 @@ Because these rules are automatic, most users do not set any TLS-related fields.
 
 | Field | Type | Default | When to use |
 |---|---|---|---|
-| `grpcEndpoint` | string | — | The vector service address. Set to a unix socket path, a loopback address, or a remote host. |
+| `grpcEndpoint` | string | — | The vector service address. Use `unix:<path>` or `tcp:<host>:<port>`. HTTP URL schemes are rejected so TLS policy cannot be bypassed accidentally. |
 | `grpcEndpointTlsCa` | string | — | Path to a CA certificate PEM file. Required only when the vector service certificate is self-signed or signed by a private CA not in the system certificate store. |
 | `grpcEndpointTlsMode` | `"auto"` \| `"tls"` \| `"insecure"` | `"auto"` | Override the automatic selection. `"auto"` applies the default rules above. `"tls"` forces TLS regardless of address. `"insecure"` forces plaintext regardless of address. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ CPU when a provider is unavailable.
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `sidecarPath` | string | `auto` | `"auto"` probes standard socket paths; set `unix:/path` or `tcp:host:port` to override |
-| `grpcEndpoint` | string | — | gRPC kernel endpoint. See `grpcEndpointTlsMode` for credential control. |
+| `grpcEndpoint` | string | — | gRPC kernel endpoint. Use `unix:<path>` or `tcp:<host>:<port>`; HTTP URL schemes are rejected. See `grpcEndpointTlsMode` for credential control. |
 | `grpcEndpointTlsCa` | string | — | Path to CA certificate PEM file. Only needed for self-signed or private CA certs. Omit when using Let's Encrypt or cert-manager. |
 | `grpcEndpointTlsMode` | string | `"auto"` | gRPC credential mode. `"auto"`: loopback/unix → plaintext, remote → TLS. `"tls"`: always TLS. `"insecure"`: always plaintext. |
 | `grpcEndpointTlsClientCert` | string | — | Path to client certificate PEM for mTLS. Must be paired with `grpcEndpointTlsClientKey`. |

--- a/src/libravdb-client.ts
+++ b/src/libravdb-client.ts
@@ -77,8 +77,10 @@ export interface LibravDBClientOptions {
 }
 
 export function resolveClientEndpoint(configuredEndpoint?: string): string {
-  if (configuredEndpoint && configuredEndpoint !== "auto") return configuredEndpoint;
-  if (process.env.LIBRAVDB_GRPC_ENDPOINT) return process.env.LIBRAVDB_GRPC_ENDPOINT;
+  const configured = configuredEndpoint?.trim();
+  if (configured && configured !== "auto") return configured;
+  const envEndpoint = process.env.LIBRAVDB_GRPC_ENDPOINT?.trim();
+  if (envEndpoint) return envEndpoint;
 
   if (process.platform === "win32") return "tcp:127.0.0.1:37421";
 
@@ -96,6 +98,23 @@ export function resolveClientEndpoint(configuredEndpoint?: string): string {
     if (fs.existsSync(fullPath)) return `unix:${fullPath}`;
   }
   return `unix:${path.join(os.homedir(), ".libravdbd", "run", sockName)}`;
+}
+
+export function validateClientEndpoint(endpoint: string): void {
+  if (endpoint === "auto" || endpoint.startsWith("unix:") || endpoint.startsWith("tcp:")) {
+    return;
+  }
+
+  if (/^https?:\/\//i.test(endpoint)) {
+    throw new Error(
+      `LibraVDB: grpc endpoint must use "tcp:" or "unix:" scheme, not an HTTP URL: ${endpoint}. ` +
+      `Use tcp:<host>:<port>; TLS is selected with grpcEndpointTlsMode.`,
+    );
+  }
+
+  throw new Error(
+    `LibraVDB: unsupported grpc endpoint "${endpoint}". Use "auto", "unix:<path>", or "tcp:<host>:<port>".`,
+  );
 }
 
 export function isLegacyJsonRpcHealthResponse(payload: string): boolean {
@@ -249,6 +268,7 @@ export class LibravDBClient {
     this.secret = options.secret ?? loadSecretFromEnv();
 
     const rawEndpoint = resolveClientEndpoint(options.endpoint);
+    validateClientEndpoint(rawEndpoint);
     this.endpoint = rawEndpoint;
     this.legacyProbeTimeoutMs = Math.min(options.timeoutMs ?? 30000, 1000);
     const isUnix = rawEndpoint.startsWith("unix:");

--- a/test/unit/libravdb-client.test.ts
+++ b/test/unit/libravdb-client.test.ts
@@ -58,6 +58,31 @@ test("resolveClientEndpoint returns explicit endpoint unchanged", () => {
   assert.equal(resolveClientEndpoint("unix:/custom/path/sock"), "unix:/custom/path/sock");
 });
 
+test("client rejects HTTP-style grpc endpoints before transport setup", () => {
+  assert.throws(
+    () => new LibravDBClient({ endpoint: "http://memory.internal:50051" }),
+    /grpc endpoint must use "tcp:" or "unix:" scheme/,
+  );
+  assert.throws(
+    () => new LibravDBClient({ endpoint: "https://memory.internal:50051", tlsMode: "tls" }),
+    /grpc endpoint must use "tcp:" or "unix:" scheme/,
+  );
+});
+
+test("client rejects HTTP-style grpc endpoint from environment", () => {
+  const prev = process.env.LIBRAVDB_GRPC_ENDPOINT;
+  try {
+    process.env.LIBRAVDB_GRPC_ENDPOINT = "http://memory.internal:50051";
+    assert.throws(
+      () => new LibravDBClient({}),
+      /grpc endpoint must use "tcp:" or "unix:" scheme/,
+    );
+  } finally {
+    if (prev !== undefined) process.env.LIBRAVDB_GRPC_ENDPOINT = prev;
+    else delete process.env.LIBRAVDB_GRPC_ENDPOINT;
+  }
+});
+
 test("resolveClientEndpoint returns env var when endpoint is undefined or auto", () => {
   const prev = process.env.LIBRAVDB_GRPC_ENDPOINT;
   try {


### PR DESCRIPTION
## Summary

Reject HTTP-style `grpcEndpoint` values before the LibraVDB client creates a transport.

The client already selected TLS credentials for remote endpoints, but an explicit endpoint such as `http://memory.internal:50051` kept the `http://` scheme as the Connect base URL. That made the documented TLS policy bypassable through URL-shaped endpoint input.

This change keeps the supported endpoint shapes explicit:

- `auto`
- `unix:<path>`
- `tcp:<host>:<port>`

`http://` and `https://` values now throw a clear configuration error that tells users to use `tcp:<host>:<port>` and select TLS with `grpcEndpointTlsMode`.

## Security Impact

This closes a configuration path where a remote LibraVDB endpoint could be treated as TLS-required by credential selection while still using an insecure HTTP transport URL. The fix fails closed before network transport setup.

## Test Plan

- `git diff --check`
- `pnpm exec tsc -p tsconfig.tests.json`
- `node --test .ts-build/test/unit/libravdb-client.test.js`  
  Result: 22/22 passing, including HTTP/HTTPS endpoint rejection coverage.
- Direct before/after probe:
  - clean main baseline accepted `http://memory.internal:50051`
  - patched branch rejected the same endpoint with the new `tcp:`/`unix:` error
- `pnpm run check`
  - unit portion passed: 219/219
  - integration portion remained red at 44/47 due to the same three `host-flow` assembly/compaction tests on both patched branch and clean main baseline, so this is not introduced by this patch

## Compatibility

Existing documented `unix:` and `tcp:` endpoint configurations keep working. HTTP URL-shaped endpoint values now fail fast and should be changed to `tcp:<host>:<port>`.
