### PR TITLE
docs: fix grpc endpoint examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ other public CAs automatically.
 Set `grpcEndpointTlsCa` to the path of the CA certificate PEM file:
 ```json
 {
-  "grpcEndpoint": "tcp:yourvector service.internal:50051",
+  "grpcEndpoint": "tcp:libravdb.internal:50051",
   "grpcEndpointTlsCa": "/etc/certs/ca.pem"
 }
 ```
@@ -64,7 +64,7 @@ When the vector service requires client certificate authentication, set both
 be present or both be omitted):
 ```json
 {
-  "grpcEndpoint": "tcp:yourvector service.internal:50051",
+  "grpcEndpoint": "tcp:libravdb.internal:50051",
   "grpcEndpointTlsCa": "/etc/certs/ca.pem",
   "grpcEndpointTlsClientCert": "/etc/certs/client-cert.pem",
   "grpcEndpointTlsClientKey": "/etc/certs/client-key.pem"


### PR DESCRIPTION
## Summary

- Replaces two invalid TLS configuration examples that used `tcp:yourvector service.internal:50051`.
- Uses `tcp:libravdb.internal:50051`, which matches the documented `tcp:<host>:<port>` endpoint shape.

## Motivation

The old placeholder included a space in the host name. That contradicts the endpoint format documented elsewhere and becomes especially confusing now that HTTP-style and unsupported endpoint schemes fail fast.

## Verification

- `grep -RIn "yourvector service" docs README.md openclaw.plugin.json src test || true` — no remaining matches
- `git diff --check` — pass

Docs-only change; no runtime tests run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Fix: gRPC Endpoint Examples

This pull request corrects invalid placeholder values in gRPC TLS configuration examples in `docs/configuration.md`. 

### Changes
Two JSON configuration examples in the "Remote vector service with CA-issued cert" and "Remote vector service with mTLS" sections have been updated:
- Changed `grpcEndpoint` placeholder from `tcp:yourvector service.internal:50051` to `tcp:libravdb.internal:50051`

### Rationale
The previous placeholder contained a space in the hostname (`yourvector service`), which contradicts the documented `tcp:<host>:<port>` endpoint format and could cause confusion given that HTTP-style and unsupported endpoint schemes now fail fast with validation.

### Impact
- **Documentation-only change** — no code modifications, no runtime behavior changes
- **Lines changed**: +2/-2
- **Complexity**: No Big O notation or cyclomatic complexity implications (documentation only)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->