### PR TITLE
fix: ignore non-object memory metadata

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -282,7 +282,10 @@ function normalizeSearchCorpus(value: unknown): "all" | "memory" | "sessions" {
 function parseMetadataJson(item: { metadataJson?: Uint8Array }): Record<string, unknown> {
   if (item.metadataJson && item.metadataJson.length > 0) {
     try {
-      return JSON.parse(new TextDecoder().decode(item.metadataJson));
+      const parsed = JSON.parse(new TextDecoder().decode(item.metadataJson)) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
     } catch (e) {
       // ignore
     }

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -206,6 +206,35 @@ test("memory runtime bridge falls back to metadata text when search result text 
   assert.equal(loaded.text, metadataText);
 });
 
+test("memory runtime bridge treats non-object metadata JSON as missing", async () => {
+  const rpc = new FakeRpc();
+  (rpc as { searchTextCollections: (params: Record<string, unknown>) => Promise<{ results: unknown[] }> }).searchTextCollections = async (params) => {
+    rpc.calls.push({ method: "searchTextCollections", params });
+    return {
+      results: [
+        {
+          id: "turn-1",
+          score: 0.88,
+          text: "remembered item survives non-object metadata",
+          metadataJson: new TextEncoder().encode("null"),
+        },
+      ],
+    };
+  };
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "remembered item", sessionId: "s1" }) as Array<{
+    path: string;
+    snippet: string;
+    source: string;
+  }>;
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.snippet, "remembered item survives non-object metadata");
+  assert.equal(result[0]?.source, "memory");
+});
+
 test("memory runtime bridge does not authorize hidden paths from legacy search results", async () => {
   const rpc = new FakeRpc();
   const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});


### PR DESCRIPTION
## Summary

- Treat non-object `metadataJson` values in the memory runtime bridge as missing metadata.
- Add a regression test for JSON `null` metadata so matching memory search results still return instead of throwing.

Quality: `Q5 proven`

Evidence:
- Current upstream throws `Cannot read properties of null (reading 'collection')` when `metadataJson` decodes to JSON `null`.
- The failure is deterministic in `test/unit/memory-runtime.test.ts` before the fix.
- The fix is limited to `parseMetadataJson()` and preserves malformed metadata as best-effort `{}`.

Scope:
- Trigger: daemon/search result returns syntactically valid but non-object `metadataJson`.
- Impact: the memory runtime bridge can fail a public memory search path instead of returning the matching hit.
- Security: not a security claim; this is robustness/availability for recall.

## Verification

```text
corepack pnpm@9 exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/memory-runtime.test.js
corepack pnpm@9 run test:ts
```

Regression proof before fix:

```text
TypeError: Cannot read properties of null (reading 'collection')
```

After fix:

```text
memory runtime bridge treats non-object metadata JSON as missing
18/18 focused memory-runtime tests passed
218/218 unit tests passed
```

– Vale
