### PR TITLE
fix: don't shut down shared runtime on per-session delete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function shouldShutdownRuntimeForLifecycleCleanup(
   // and compaction provider, so it must only be torn down on a plugin-scoped cleanup.
   // Shutting it down on a single session delete leaves it permanently "shut down"
   // and breaks memory ingestion for every other live session until a gateway restart.
-  return RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason) && !sessionKey;
+  return RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason) && sessionKey === undefined;
 }
 
 export function register(api: OpenClawPluginApi) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,17 @@ export const MEMORY_ID = "libravdb-memory";
 const LIGHTWEIGHT_MODES = new Set(["cli-metadata", "setup-only"]);
 const RUNTIME_CLEANUP_SHUTDOWN_REASONS = new Set(["delete"]);
 
-export function shouldShutdownRuntimeForLifecycleCleanup(reason: string): boolean {
-  return RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason);
+export function shouldShutdownRuntimeForLifecycleCleanup(
+  reason: string,
+  sessionKey?: string,
+): boolean {
+  // `reason: "delete"` fires for per-session deletes (sessionKey set) as well as
+  // plugin-scoped teardown (no sessionKey). The vector-service runtime is a
+  // process-wide singleton shared by every session's context engine, memory tools,
+  // and compaction provider, so it must only be torn down on a plugin-scoped cleanup.
+  // Shutting it down on a single session delete leaves it permanently "shut down"
+  // and breaks memory ingestion for every other live session until a gateway restart.
+  return RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason) && !sessionKey;
 }
 
 export function register(api: OpenClawPluginApi) {
@@ -228,7 +237,7 @@ export function register(api: OpenClawPluginApi) {
     id: "libravdb-shutdown",
     description: "Shut down the vector service runtime on terminal plugin cleanup",
     async cleanup(ctx) {
-      if (shouldShutdownRuntimeForLifecycleCleanup(ctx.reason)) {
+      if (shouldShutdownRuntimeForLifecycleCleanup(ctx.reason, ctx.sessionKey)) {
         logger.info?.(`LibraVDB ${ctx.reason} — shutting down runtime`);
         await runtime.shutdown();
       } else if (ctx.reason === "disable") {

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -138,7 +138,11 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
     registerRuntimeLifecycle?(registration: {
       id: string;
       description?: string;
-      cleanup(ctx: { reason: "disable" | "reset" | "delete" | "restart" }): void | Promise<void>;
+      cleanup(ctx: {
+        reason: "disable" | "reset" | "delete" | "restart";
+        sessionKey?: string;
+        runId?: string;
+      }): void | Promise<void>;
     }): void;
     on(event: string, handler: (...args: unknown[]) => void | Promise<void>, opts?: { priority?: number }): void;
   }

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -218,5 +218,18 @@ test("runtime lifecycle cleanup preserves context-engine runtime on disable", ()
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("disable"), false);
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("reset"), false);
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("restart"), false);
+  // Plugin-scoped delete (no sessionKey) tears the singleton runtime down.
   assert.equal(shouldShutdownRuntimeForLifecycleCleanup("delete"), true);
+});
+
+test("runtime lifecycle cleanup preserves runtime on per-session delete", () => {
+  // A session delete fires reason "delete" WITH a sessionKey. The runtime is a
+  // process-wide singleton, so it must NOT be shut down — doing so breaks memory
+  // ingestion for every other live session until a gateway restart.
+  assert.equal(
+    shouldShutdownRuntimeForLifecycleCleanup("delete", "agent:main:session:abc"),
+    false,
+  );
+  // Plugin-scoped delete (sessionKey absent) still tears the singleton down.
+  assert.equal(shouldShutdownRuntimeForLifecycleCleanup("delete", undefined), true);
 });


### PR DESCRIPTION
## What this fixes

Deleting **any single session** shuts down the plugin's process-wide vector-service runtime,
silently breaking memory ingestion for **every other live session** until the gateway is restarted.

The runtime created by `createPluginRuntime()` is a singleton shared by the context engine, memory
tools, compaction provider, and prompt builder. The `registerRuntimeLifecycle` cleanup tore it down
whenever `ctx.reason === "delete"`:

```ts
if (shouldShutdownRuntimeForLifecycleCleanup(ctx.reason)) {
  await runtime.shutdown();
}
```

But in OpenClaw, cleanup reason `"delete"` is **session-scoped**, not plugin-scoped. It is produced
only by session deletion (`src/gateway/session-reset-service.ts`, `session-delete` → `"delete"`),
always with `ctx.sessionKey` set and no `pluginId`; `runPluginHostCleanup` then runs **every**
plugin's runtime-lifecycle cleanup. Actual plugin removal/disable uses `"disable"`/`"restart"`
(`src/plugins/host-hook-cleanup.ts`), never `"delete"`. So this cleanup fired on routine session
deletes — e.g. an ephemeral cron/subagent session completing — and left the singleton permanently
`stopped`, after which every `afterTurn` threw `LibraVDB plugin runtime has been shut down`.

The vendored SDK ambient type (`src/openclaw-plugin-sdk.d.ts`) typed the cleanup ctx as
`{ reason }` only — it omitted `sessionKey`/`runId` that the core contract
(`src/plugins/host-hooks.ts`) actually passes — which hid the distinction the cleanup needed.

## The change

1. Widen the vendored cleanup ctx type to `{ reason; sessionKey?; runId? }` to match the core
   contract.
2. Make the predicate scope-aware: `shouldShutdownRuntimeForLifecycleCleanup(reason, sessionKey?)`
   → `RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason) && !sessionKey`.
3. Pass `ctx.sessionKey` at the call site, so the runtime is torn down only on a plugin-scoped
   cleanup (no `sessionKey`). Process shutdown remains handled by the existing `gateway_stop` hook.

## Evidence

Reproduced and verified live on OpenClaw `2026.6.9`, plugin `1.9.8`: an ephemeral cron session was
deleted, after which the runtime stayed shut down and `afterTurn` failed for the long-lived session
every turn until a gateway restart; the daemon (`libravdbd`) was healthy throughout.

Tests (`node --test`, `test/unit/slot-conflict.test.ts`):

- Added: `runtime lifecycle cleanup preserves runtime on per-session delete` — asserts
  `"delete"` **with** a `sessionKey` does **not** shut the runtime down, while a plugin-scoped
  delete (no `sessionKey`) still does.
- Before/after: with the predicate reverted to `has(reason)`, the new test fails
  (`AssertionError: expected false`); with the fix, the full unit file passes **10/10** and
  `tsc --noEmit` is clean.

🤖 AI-assisted (Claude Code). Fixes #355.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a critical bug where deleting any session terminates the plugin's process-wide vector-service singleton runtime, breaking memory ingestion for all other live sessions until gateway restart.

**Root Cause:**
The `registerRuntimeLifecycle` cleanup handler shut down the singleton runtime whenever cleanup reason was `"delete"`, conflating per-session deletes (which set `sessionKey`) with plugin-scoped teardown (which omit `sessionKey`). The vendored SDK types omitted the `sessionKey` and `runId` fields, obscuring the distinction.

**Changes:**

1. **src/index.ts**: Updated `shouldShutdownRuntimeForLifecycleCleanup()` signature to accept optional `sessionKey` parameter; logic now returns true only when `RUNTIME_CLEANUP_SHUTDOWN_REASONS.has(reason) && !sessionKey`, ensuring shutdown occurs only on plugin-scoped cleanup. Updated the call site at line 240 to pass `ctx.sessionKey`, enabling proper scope detection.

2. **src/openclaw-plugin-sdk.d.ts**: Extended the `cleanup` callback context type in `registerRuntimeLifecycle` to include optional `sessionKey` and `runId` fields, aligning the vendored type with the core SDK contract.

3. **test/unit/slot-conflict.test.ts**: Added regression test asserting that per-session deletes (with `sessionKey`) preserve the runtime while plugin-scoped deletes (without `sessionKey`) shut it down.

**Complexity Analysis:**
- **Big O**: No regression — remains O(1) for Set-based predicate evaluation
- **Cyclomatic Complexity**: No regression — function maintains CC=2 (compound condition, no new branches)
- The additional guard clause (`!sessionKey`) is a single boolean check with no impact on asymptotic complexity

**Impact:**
Sessions can now be deleted safely without terminating the shared runtime singleton. Per-session cleanup (with `sessionKey` present) preserves the runtime for other active sessions; only plugin-scoped cleanup (no `sessionKey`) tears down the singleton as intended.

Lines changed: +30/-4 across three files. Estimated code review effort: Low (surgical fix with clear scope boundaries).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->