### PR TITLE
fix: converge chunk sizing so dense/CJK documents aren't silently dropped (#359)

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -18,6 +18,17 @@ const DEFAULT_OPTIONS: IngestQueueOptions = {
   maxRetries: 4,
 };
 
+// Heuristic used to translate a token budget into a character budget. This is a
+// generous average for English prose; dense/structured/CJK text runs well below
+// it, which is why chunk sizing must back off empirically (see enqueueIngest)
+// rather than trust this ratio alone.
+const CHARS_PER_TOKEN = 4;
+
+// Floor for the adaptive chunk-size back-off. If a chunk is still rejected at
+// this token budget we stop shrinking and drop it (last resort), guaranteeing
+// the retry loop terminates.
+const MIN_CHUNK_TOKENS = 16;
+
 interface IngestMarkdownDocumentParams {
   sourceDoc: string;
   text: string;
@@ -123,22 +134,35 @@ export class IngestQueue {
       const resp = await this.ingestWithRetry(chunkParams);
       lastFeedback = resp.feedback;
 
-      if (
-        lastFeedback &&
-        lastFeedback.nodesAccepted === 0 &&
-        lastFeedback.tokenBurstLimit &&
-        lastFeedback.tokenBurstLimit > 0 &&
-        lastFeedback.tokenBurstLimit < currentLimit
-      ) {
-        currentLimit = lastFeedback.tokenBurstLimit;
-        continue;
-      }
-
       if (lastFeedback && lastFeedback.nodesAccepted === 0) {
+        // The daemon rejected the chunk (over its token-burst limit). Shrink the
+        // budget and retry the SAME offset. Prefer the daemon's stated limit
+        // when it is actually lower; otherwise our chars/token estimate was too
+        // generous for this content (dense / CJK text runs well under
+        // CHARS_PER_TOKEN), so base the next budget on half the just-rejected
+        // chunk's real size. This converges for any token density without
+        // needing the true ratio — and crucially does NOT stall when the daemon
+        // keeps reporting the same limit (the original `< currentLimit` guard
+        // could never shrink past it, silently dropping dense documents).
+        const daemonLimit = lastFeedback.tokenBurstLimit;
+        let nextLimit = daemonLimit && daemonLimit > 0 && daemonLimit < currentLimit
+          ? daemonLimit
+          : currentLimit;
+        if (nextLimit * CHARS_PER_TOKEN >= chunkText.length) {
+          nextLimit = Math.floor(chunkText.length / CHARS_PER_TOKEN / 2);
+        }
+        if (nextLimit >= MIN_CHUNK_TOKENS && nextLimit < currentLimit) {
+          currentLimit = nextLimit;
+          continue;
+        }
+
+        // Already at the minimum chunk size and still rejected — drop this chunk
+        // (last resort; advancing the offset prevents an infinite loop).
         this.logger.warn?.(
           `[ingest-queue] Chunk permanently rejected for ${sourceDoc} ` +
           `at offset=${offset} length=${chunkText.length} ` +
-          `tokenBurstLimit=${lastFeedback.tokenBurstLimit ?? "unset"}`,
+          `tokenBurstLimit=${lastFeedback.tokenBurstLimit ?? "unset"} ` +
+          `currentLimit=${currentLimit}`,
         );
       }
 
@@ -194,7 +218,7 @@ function splitIntoChunks(text: string, maxTokens: number): Array<{ text: string;
   if (!(maxTokens > 0)) {
     return [{ text, ordinal: 0 }];
   }
-  const maxChars = maxTokens * 4;
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
   if (text.length <= maxChars) {
     return [{ text, ordinal: 0 }];
   }

--- a/test/unit/ingest-queue.test.ts
+++ b/test/unit/ingest-queue.test.ts
@@ -147,3 +147,61 @@ test("ok=false ingest responses fail instead of being treated as accepted", asyn
   assert.equal(calls[1]?.mode, IngestMode.REPLACE);
   assert.equal(calls[0]?.text, calls[1]?.text, "rejected chunks must not advance the offset");
 });
+
+test("dense content backs off below the token-burst limit instead of dropping the document", async () => {
+  // Simulate a daemon whose real tokenizer runs ~1.7 chars/token: a chunk is
+  // soft-rejected (ok=true, nodesAccepted=0, tokenBurstLimit=512) when its real
+  // token count exceeds 512 — i.e. when it is longer than ~870 chars. The
+  // chunker estimates 4 chars/token, so at the 512 limit it produces 2048-char
+  // chunks that never fit. The pre-fix loop only shrank when the reported limit
+  // was *below* currentLimit, so it stalled at 512 and dropped the document.
+  // The back-off must keep shrinking until chunks actually fit.
+  const REAL_CHARS_PER_TOKEN = 1.7;
+  const DAEMON_TOKEN_LIMIT = 512;
+  const maxAcceptedChars = Math.floor(DAEMON_TOKEN_LIMIT * REAL_CHARS_PER_TOKEN); // 870
+
+  const accepted: string[] = [];
+  const warnings: string[] = [];
+  let calls = 0;
+  const queue = new IngestQueue(
+    async (params) => {
+      calls += 1;
+      assert.ok(calls < 1000, "back-off must converge, not loop forever");
+      const realTokens = Math.ceil(params.text.length / REAL_CHARS_PER_TOKEN);
+      if (realTokens > DAEMON_TOKEN_LIMIT) {
+        return {
+          ok: true,
+          feedback: feedback({
+            nodesAccepted: 0,
+            nodesRejected: 1,
+            tokensIngested: 0,
+            tokenBurstLimit: DAEMON_TOKEN_LIMIT,
+          }),
+        };
+      }
+      accepted.push(params.text);
+      return { ok: true, feedback: feedback({ tokenBurstLimit: DAEMON_TOKEN_LIMIT }) };
+    },
+    async () => {},
+    { error() {}, warn(msg: string) { warnings.push(String(msg)); } },
+    { chunkTokens: 8192, maxRetries: 0, retryBaseDelayMs: 0 },
+  );
+
+  const doc = "lorem ipsum dolor ".repeat(600); // ~10.8k chars
+
+  await queue.enqueueIngest("/vault/dense.md", doc, baseParams());
+
+  assert.ok(accepted.length > 0, "document must be ingested, not dropped");
+  for (const chunk of accepted) {
+    assert.ok(
+      chunk.length <= maxAcceptedChars,
+      `accepted chunk (${chunk.length} chars) should fit under the real ${DAEMON_TOKEN_LIMIT}-token limit (~${maxAcceptedChars} chars)`,
+    );
+  }
+  assert.equal(accepted.join(""), doc, "all content ingested contiguously with no gaps");
+  assert.equal(
+    warnings.filter((w) => w.includes("permanently rejected")).length,
+    0,
+    "no content permanently dropped",
+  );
+});


### PR DESCRIPTION
Fixes #359.

## Problem

`splitIntoChunks` (`src/ingest-queue.ts`) sizes chunks at **4 chars/token**. Dense/structured/CJK content runs ~1.7 chars/token, so a chunk the chunker believes is 512 tokens (2048 chars) is really ~1,200 tokens and the daemon rejects it (`nodesAccepted=0, tokenBurstLimit=512`).

The retry loop only shrank when the reported limit was **strictly below** `currentLimit`:

```js
if (lastFeedback.tokenBurstLimit > 0 && lastFeedback.tokenBurstLimit < currentLimit) {
  currentLimit = lastFeedback.tokenBurstLimit; continue;
}
```

Once `currentLimit` reached 512 and the 2048-char chunk was still rejected, `512 < 512` is false → no shrink → it advanced past the rejected chunk and **dropped the content**. Uniformly-dense files lost *every* chunk — zero vectors ingested, only a `WARN` each.

## Fix

On rejection, shrink and retry the **same offset**:
- prefer the daemon's stated `tokenBurstLimit` when it's actually lower;
- otherwise base the next budget on **half the just-rejected chunk's real size**, so chunk sizing converges for any token density without needing the true chars/token ratio;
- floor at `MIN_CHUNK_TOKENS` so the loop always terminates (still drops as a genuine last resort, preserving prior behavior).

No magic ratio change — the back-off discovers the real density empirically. `CHARS_PER_TOKEN` is now a named constant shared by the loop and `splitIntoChunks`.

## Testing

- `tsc --noEmit` clean; `tsc -p tsconfig.build.json` + bundle clean.
- New regression test in `test/unit/ingest-queue.test.ts`: a simulated ~1.7 chars/token daemon (rejects chunks > ~870 chars) now ingests the **whole** document in fitting chunks (`accepted.join("") === doc`, every accepted chunk ≤ the real limit, zero `permanently rejected`). Against the old loop this document was entirely dropped. Existing ingest-queue tests still pass (4/4).
- Reproduces/fixes a live failure: on an Intel Mac production deployment, dense daily-memory markdown files were logging `Chunk permanently rejected ... tokenBurstLimit=512` for every chunk and storing nothing. Happy to validate the built plugin against those exact files.

## Note

The underlying 4-vs-~1.7 chars/token estimate also affects budget sizing elsewhere; this PR fixes the **data-loss** symptom (dropped documents). A real-tokenizer-based chunk sizer would be a larger follow-up.