### PR TITLE
fix: don't log async queue-time ingests as "permanently rejected"

### DIFF
--- a/src/ingest-queue.ts
+++ b/src/ingest-queue.ts
@@ -123,21 +123,24 @@ export class IngestQueue {
       const resp = await this.ingestWithRetry(chunkParams);
       lastFeedback = resp.feedback;
 
-      if (
-        lastFeedback &&
-        lastFeedback.nodesAccepted === 0 &&
-        lastFeedback.tokenBurstLimit &&
-        lastFeedback.tokenBurstLimit > 0 &&
-        lastFeedback.tokenBurstLimit < currentLimit
-      ) {
-        currentLimit = lastFeedback.tokenBurstLimit;
-        continue;
-      }
-
-      if (lastFeedback && lastFeedback.nodesAccepted === 0) {
+      // The daemon ingests asynchronously: this RPC returns at queue-time,
+      // before the embed/commit runs, so nodesAccepted is normally 0 here even
+      // though the chunk was successfully queued (it commits moments later).
+      // Only nodesRejected > 0 signals an actual rejection. Previously this loop
+      // treated nodesAccepted === 0 as a permanent rejection, which fired on
+      // every async-queued chunk under load — flooding the logs with false
+      // "permanently rejected" warnings even though the content committed fine.
+      if (lastFeedback && lastFeedback.nodesRejected > 0) {
+        // A real rejection. If the daemon reported a lower per-chunk token
+        // limit, shrink and retry the same offset before giving up.
+        if (lastFeedback.tokenBurstLimit > 0 && lastFeedback.tokenBurstLimit < currentLimit) {
+          currentLimit = lastFeedback.tokenBurstLimit;
+          continue;
+        }
         this.logger.warn?.(
-          `[ingest-queue] Chunk permanently rejected for ${sourceDoc} ` +
+          `[ingest-queue] Chunk rejected for ${sourceDoc} ` +
           `at offset=${offset} length=${chunkText.length} ` +
+          `nodesRejected=${lastFeedback.nodesRejected} ` +
           `tokenBurstLimit=${lastFeedback.tokenBurstLimit ?? "unset"}`,
         );
       }

--- a/test/unit/ingest-queue.test.ts
+++ b/test/unit/ingest-queue.test.ts
@@ -147,3 +147,63 @@ test("ok=false ingest responses fail instead of being treated as accepted", asyn
   assert.equal(calls[1]?.mode, IngestMode.REPLACE);
   assert.equal(calls[0]?.text, calls[1]?.text, "rejected chunks must not advance the offset");
 });
+
+test("async queue-time nodesAccepted=0 / nodesRejected=0 is success, not a rejection", async () => {
+  // The daemon queues asynchronously and returns before commit, so a perfectly
+  // good ingest reports nodesAccepted=0, nodesRejected=0 at RPC time. This must
+  // NOT be logged as "permanently rejected" (the bug that flooded logs under
+  // load) and must not trigger pointless chunk-shrinking.
+  const calls: string[] = [];
+  const warnings: string[] = [];
+  const queue = new IngestQueue(
+    async (params) => {
+      calls.push(params.text);
+      return {
+        ok: true,
+        feedback: feedback({ nodesAccepted: 0, nodesRejected: 0, tokensIngested: 0, tokenBurstLimit: 512 }),
+      };
+    },
+    async () => {},
+    { error() {}, warn(m: string) { warnings.push(String(m)); } },
+    { chunkTokens: 8192, maxRetries: 0, retryBaseDelayMs: 0 },
+  );
+
+  const doc = "lorem ipsum dolor sit amet ".repeat(2000); // ~54k chars → multiple chunks
+
+  await queue.enqueueIngest("/vault/dense.md", doc, baseParams());
+
+  assert.equal(
+    warnings.filter((w) => w.toLowerCase().includes("reject")).length,
+    0,
+    "async-queued chunks must not produce rejection warnings",
+  );
+  assert.equal(calls.join(""), doc, "the whole document is submitted contiguously");
+});
+
+test("a real rejection (nodesRejected>0) with a lower burst limit shrinks and retries the same offset", async () => {
+  const calls: string[] = [];
+  let n = 0;
+  const queue = new IngestQueue(
+    async (params) => {
+      calls.push(params.text);
+      n += 1;
+      // First attempt: a genuine rejection reporting a lower per-chunk limit.
+      if (n === 1) {
+        return { ok: true, feedback: feedback({ nodesAccepted: 0, nodesRejected: 2, tokenBurstLimit: 256 }) };
+      }
+      // After shrinking, the smaller chunks queue fine (async, nothing rejected).
+      return { ok: true, feedback: feedback({ nodesAccepted: 0, nodesRejected: 0, tokenBurstLimit: 512 }) };
+    },
+    async () => {},
+    { error() {}, warn() {} },
+    { chunkTokens: 1024, maxRetries: 0, retryBaseDelayMs: 0 },
+  );
+
+  const doc = "x".repeat(8000);
+
+  await queue.enqueueIngest("/d.md", doc, baseParams());
+
+  assert.ok(calls.length >= 2, "should retry after a real rejection");
+  assert.ok(calls[1].length < calls[0].length, "the retry shrinks the chunk");
+  assert.equal(calls[0].slice(0, calls[1].length), calls[1], "the retry is the same offset, just smaller");
+});


### PR DESCRIPTION
## Summary

The chunk ingest loop (`src/ingest-queue.ts`) logs `Chunk permanently rejected` and shrinks the chunk budget whenever the daemon's `ingest_markdown_document` returns `nodesAccepted === 0`. But the daemon ingests **asynchronously** — the RPC returns at *queue-time*, before the embed/commit runs — so a perfectly good ingest reports `nodesAccepted: 0` (and `nodesRejected: 0`) on return; the content commits moments later as the WAL drains.

Under load (a backed-up WAL) `nodesAccepted: 0` is the *normal* return, so this fired on nearly every chunk, flooding logs with false `Chunk permanently rejected` warnings even though nothing was rejected and all content committed.

Evidence (running daemon, GGUF backend): the ingest feedback for a wide range of inputs — a full 8.9 KB document, a 2 KB slice, an 80-char slice, even plain English — is uniformly:

```
nodesAccepted: 0   nodesRejected: 0   tokensIngested: 0   walDepth: climbing
```

`nodesRejected` is `0` throughout; the WAL depth climbs (queued) and the documents are retrievable seconds later.

## Fix

Gate the rejection path on `nodesRejected > 0` — the only signal of an actual rejection — instead of `nodesAccepted === 0`:

- `nodesRejected === 0` (the normal async-queued case) → success: no warning, no shrink, advance.
- `nodesRejected > 0` → a real rejection: shrink-and-retry the same offset if the daemon reported a lower `tokenBurstLimit`, otherwise log an accurate `Chunk rejected` including the `nodesRejected` count.

This removes the false-alarm flood without weakening genuine rejection handling. (The `ok === false` transport-error path is unchanged.)

## Testing

- `tsc --noEmit` clean; unit suite green (5/5), including two new tests:
  - async queue-time `nodesAccepted=0 / nodesRejected=0` produces **no** rejection warning and submits the whole document;
  - a real `nodesRejected > 0` with a lower burst limit shrinks and retries the **same** offset.
- Validated against a live deployment: re-ingesting a 646-file markdown corpus produced **0** rejection lines (the previous build logged 128+ before being interrupted), `errors=0`, and the previously-"rejected" dense documents are retrievable. Driving the three worst offenders straight through the patched queue (fresh hashes, bypassing dedup) produced 0 warnings.

## Note

This supersedes #360, which I closed — that PR chased a chunk-size theory, but the symptom was never a size rejection (the daemon never set `nodesRejected > 0`); it was this async-queue mislabeling. Apologies for the detour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed chunk ingest handling so async queue-time ingests with `nodesAccepted === 0` and `nodesRejected === 0` are treated as successful instead of being logged as permanently rejected.

- Rejection detection now keys off `nodesRejected > 0`
- Real rejections still shrink/retry when a lower `tokenBurstLimit` is reported
- Otherwise, rejections log `Chunk rejected` with the rejection count
- Added tests for:
  - async zero-accept/zero-reject success path
  - real rejection retry/shrink behavior

Complexity:
- Big O: no regression
- Cyclomatic complexity: no regression

<!-- end of auto-generated comment: release notes by coderabbit.ai -->