### PR TITLE
fix: merge dream and normal memory search

### DIFF
--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -116,13 +116,35 @@ function createMemorySearchManager(
       const minScore = normalizeNumber(params.minScore);
       const client = await getClient();
 
-      const result = dreamQuery.active && cfg.crossSessionRecall !== false && searchCorpus !== "sessions"
-        ? await client.searchText({
-            collection: resolveDreamCollection(userId),
-            text: queryText,
+      const dreamCollection = dreamQuery.active && cfg.crossSessionRecall !== false && searchCorpus !== "sessions"
+        ? resolveDreamCollection(userId)
+        : undefined;
+      const normalSearch = searchResolvedCollections(
+        client,
+        cfg,
+        userId,
+        sessionId,
+        queryText,
+        k,
+        searchCorpus,
+        params.kind,
+        params.signals,
+      );
+      const result = dreamCollection
+        ? mergeSearchResults(
+            await Promise.all([
+              normalSearch,
+              client.searchText({
+                collection: dreamCollection,
+                text: queryText,
+                k,
+                kind: params.kind || undefined,
+                signals: params.signals && params.signals.length > 0 ? params.signals : undefined,
+              }),
+            ]),
             k,
-          })
-        : await searchResolvedCollections(client, cfg, userId, sessionId, queryText, k, searchCorpus, params.kind, params.signals);
+          )
+        : await normalSearch;
       const filteredResults =
         minScore === undefined
           ? result.results
@@ -224,6 +246,23 @@ async function searchResolvedCollections(
         kind: kindFilter,
         signals: signalFilter,
       });
+}
+
+function mergeSearchResults(
+  responses: Array<{ results: ProtoSearchResult[] }>,
+  limit: number,
+): { results: ProtoSearchResult[] } {
+  const seenIds = new Set<string>();
+  const results = responses
+    .flatMap((response) => response.results)
+    .sort((left, right) => right.score - left.score)
+    .filter((item) => {
+      if (seenIds.has(item.id)) return false;
+      seenIds.add(item.id);
+      return true;
+    })
+    .slice(0, limit);
+  return { results };
 }
 
 function resolveSearchCollections(

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -109,6 +109,7 @@ test("memory runtime bridge merges, deduplicates, and caps dream and normal resu
       results: [
         { id: "dream", score: 0.9, text: "dream memory", metadata: { collection: "dream:u1" } },
         { id: "shared", score: 0.8, text: "higher-ranked duplicate", metadata: { collection: "dream:u1" } },
+        { id: "overflow", score: 0.6, text: "outside result limit", metadata: { collection: "dream:u1" } },
       ],
     };
   };

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -74,7 +74,7 @@ test("memory runtime bridge searches the resolved durable namespace under the la
   assert.equal(result[0]?.source, "memory");
 });
 
-test("memory runtime bridge routes dream queries to the dream collection when cross-session recall is enabled", async () => {
+test("memory runtime bridge adds dream results to normal memory when cross-session recall is enabled", async () => {
   for (const cfg of [{}, { crossSessionRecall: true }] satisfies PluginConfig[]) {
     const rpc = new FakeRpc();
     const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
@@ -83,12 +83,56 @@ test("memory runtime bridge routes dream queries to the dream collection when cr
     const result = await manager.search({ query: "tell me about your dreams from last week", userId: "u1" });
 
     assert.ok(Array.isArray(result));
-    assert.equal(rpc.calls[1]?.method, "searchText");
-    assert.deepEqual(rpc.calls[1]?.params.collection, "dream:u1");
-    assert.equal(rpc.calls.some((call) => call.method === "searchTextCollections"), false);
-    assert.equal(result.length, 1);
+    assert.equal(rpc.calls[1]?.method, "searchTextCollections");
+    assert.equal(rpc.calls[2]?.method, "searchText");
+    assert.deepEqual(rpc.calls[2]?.params.collection, "dream:u1");
+    assert.equal(result.length, 2);
     assert.equal(result[0]?.snippet, "dream recall item");
+    assert.equal(result[1]?.snippet, "remembered item");
   }
+});
+
+test("memory runtime bridge merges, deduplicates, and caps dream and normal results", async () => {
+  const rpc = new FakeRpc();
+  rpc.searchTextCollections = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchTextCollections", params });
+    return {
+      results: [
+        { id: "normal", score: 0.95, text: "normal memory", metadata: { collection: "user:u1" } },
+        { id: "shared", score: 0.7, text: "lower-ranked duplicate", metadata: { collection: "user:u1" } },
+      ],
+    };
+  };
+  rpc.searchText = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchText", params });
+    return {
+      results: [
+        { id: "dream", score: 0.9, text: "dream memory", metadata: { collection: "dream:u1" } },
+        { id: "shared", score: 0.8, text: "higher-ranked duplicate", metadata: { collection: "dream:u1" } },
+      ],
+    };
+  };
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({
+    query: "tell me about your dreams",
+    userId: "u1",
+    limit: 3,
+    kind: "episodic",
+    signals: ["visual"],
+  });
+
+  assert.ok(Array.isArray(result));
+  assert.deepEqual(result.map((item) => item.snippet), [
+    "normal memory",
+    "dream memory",
+    "higher-ranked duplicate",
+  ]);
+  assert.deepEqual(rpc.calls[1]?.params.kind, "episodic");
+  assert.deepEqual(rpc.calls[1]?.params.signals, ["visual"]);
+  assert.deepEqual(rpc.calls[2]?.params.kind, "episodic");
+  assert.deepEqual(rpc.calls[2]?.params.signals, ["visual"]);
 });
 
 test("memory runtime bridge rejects invalid dream collections before daemon search", async () => {


### PR DESCRIPTION
## Summary

- Search the regular session/user/global collections for dream queries instead of replacing them with the dream collection.
- Search the dedicated dream collection alongside ordinary memory, then merge by score, deduplicate by record ID, and cap the combined result to the requested limit.
- Forward `kind` and `signals` filters to the dream search path.

## Root cause

Dream routing used an exclusive ternary: once a dream signal was active, it called only `searchText` for `dream:<user>` and skipped `searchResolvedCollections`. That suppressed all relevant ordinary memory and also dropped structured filters.

## Impact

Dream-related queries can now retrieve both promoted dream entries and related normal memories. An empty dream collection no longer makes an otherwise valid memory query return no hits.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/memory-runtime.test.js` — 18/18 passed
- `pnpm check` — reached the full unit suite; 218/220 passed, with two pre-existing failures in `slot-conflict.test.ts` caused by stale expected tool lists on `main`
- `git diff --check`

Fixes #347.

– Vale
