### PR TITLE
fix: preserve dream signals in compound queries

### DIFF
--- a/src/dream-routing.ts
+++ b/src/dream-routing.ts
@@ -23,11 +23,11 @@ const DREAM_PATTERN_RULES: Array<{ label: string; patterns: RegExp[] }> = [
 
 /** Phrases that contain "dream" but are idiomatic (not memory-recall intent). */
 const DREAM_FALSE_POSITIVE_PATTERNS: RegExp[] = [
-  /\bpipe\s+dreams?\b/i,
-  /\bdream\s+team\b/i,
-  /\bamerican\s+dream\b/i,
-  /\bdream\s+(?:house|home|car|wedding|vacation|job|school)\b/i,
-  /\bin\s+(?:my|our|your)\s+dreams\b/i,
+  /\bpipe\s+dreams?\b/gi,
+  /\bdream\s+team\b/gi,
+  /\bamerican\s+dream\b/gi,
+  /\bdream\s+(?:house|home|car|wedding|vacation|job|school)\b/gi,
+  /\bin\s+(?:my|our|your)\s+dreams\b/gi,
 ];
 
 const DREAM_MATCHED_PATTERNS = ["dream"] as const;
@@ -38,15 +38,13 @@ export interface DreamQuerySignal {
 }
 
 export function detectDreamQuerySignal(queryText: string): DreamQuerySignal {
+  const candidateText = DREAM_FALSE_POSITIVE_PATTERNS.reduce(
+    (text, pattern) => text.replace(pattern, " "),
+    queryText,
+  );
+
   for (const rule of DREAM_PATTERN_RULES) {
-    if (rule.patterns.some((pattern) => pattern.test(queryText))) {
-      // Reject known idiomatic false positives that slip through.
-      if (DREAM_FALSE_POSITIVE_PATTERNS.some((p) => p.test(queryText))) {
-        return {
-          active: false,
-          matchedPatterns: [],
-        };
-      }
+    if (rule.patterns.some((pattern) => pattern.test(candidateText))) {
       return {
         active: true,
         matchedPatterns: [...DREAM_MATCHED_PATTERNS],

--- a/test/unit/dream-routing.test.ts
+++ b/test/unit/dream-routing.test.ts
@@ -23,6 +23,12 @@ test("dream routing detects explicit dream phrasing", () => {
   assert.equal(detectDreamQuerySignal("dream recall practice").active, true);
 });
 
+test("dream routing preserves explicit dream phrasing alongside idioms", () => {
+  assert.equal(detectDreamQuerySignal("I had a dream about my dream house").active, true);
+  assert.equal(detectDreamQuerySignal("I had a dream about the American dream").active, true);
+  assert.equal(detectDreamQuerySignal("I had a dream last night about my dream job").active, true);
+});
+
 test("dream routing rejects idiomatic false positives", () => {
   assert.equal(detectDreamQuerySignal("pipe dream architecture").active, false);
   assert.equal(detectDreamQuerySignal("pipe dreams everywhere").active, false);
@@ -37,6 +43,12 @@ test("dream routing rejects idiomatic false positives", () => {
   assert.equal(detectDreamQuerySignal("dream home interior design").active, false);
   assert.equal(detectDreamQuerySignal("in my dreams").active, false);
   assert.equal(detectDreamQuerySignal("in your dreams").active, false);
+});
+
+test("dream routing rejects idioms that overlap dream recall patterns", () => {
+  assert.equal(detectDreamQuerySignal("tell me about the American dream").active, false);
+  assert.equal(detectDreamQuerySignal("pipe dreams about instant success").active, false);
+  assert.equal(detectDreamQuerySignal("tell me about your dream job").active, false);
 });
 
 test("dream routing ignores ordinary memory queries", () => {


### PR DESCRIPTION
## Summary

- Remove known idiomatic dream phrases from a query before evaluating genuine dream-recall patterns.
- Preserve dream routing when a real recollection phrase and an idiom appear in the same compound query.
- Keep false-positive-only queries such as “tell me about your dream job” on the ordinary memory path.

## Root cause

The detector rejected the entire query whenever any false-positive phrase appeared, even if another part of the same query independently matched explicit dream-recall intent.

## Impact

Queries such as “I had a dream about my dream house” now search dream memory, while idiomatic uses of “dream” alone remain filtered out.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/dream-routing.test.js` — 6/6 passed
- `git diff --check`

Fixes #348.

– Vale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Sanitizes idiomatic “dream” phrases before evaluating genuine dream-recall patterns.
- Preserves dream routing for compound queries while preventing idiom-only false positives.
- Adds coverage for mixed idiomatic/genuine queries and overlapping false-positive patterns.

## Verification

- TypeScript checks passed.
- Six dream-routing tests passed.
- `git diff --check` passed.

## Complexity

- **Big O:** No asymptotic regression; processing remains linear in query length for a fixed set of regex patterns.
- **Cyclomatic complexity:** No regression; per-rule false-positive branching was replaced with preprocessing and simplifies the detection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->