### PR TITLE
fix: reset cooldown on circuit class change

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1809,6 +1809,7 @@ export function buildContextEngineFactory(
     if (state.class !== cls) {
       state.class = cls;
       state.consecutive = 0;
+      state.cooldownUntil = 0;
     }
     state.consecutive++;
     state.lastFailure = Date.now();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -577,6 +577,57 @@ test("context engine assemble strips OpenClaw untrusted metadata envelope from p
   assert.equal(call.params.prompt, "@User-1234 Reply with exactly PONG.");
 });
 
+test("context engine clears a stale circuit cooldown when the failure class changes", async () => {
+  class DeferredBeforeTurnClient extends FakeClient {
+    public pendingBeforeTurn: Array<{ reject(error: unknown): void }> = [];
+    public beforeTurnSucceeds = false;
+
+    beforeTurnKernel(params: Record<string, unknown>): Promise<{ predictions: [] }> {
+      this.calls.push({ method: "beforeTurnKernel", params });
+      if (this.beforeTurnSucceeds) return Promise.resolve({ predictions: [] });
+      return new Promise((_resolve, reject) => {
+        this.pendingBeforeTurn.push({ reject });
+      });
+    }
+  }
+
+  const client = new DeferredBeforeTurnClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), {
+    userId: "fixed-user",
+    beforeTurnTimeoutMs: 1000,
+    assembleTimeoutMs: 1000,
+  });
+  const assemble = (turn: number) => engine.assemble({
+    sessionId: "circuit-class-change",
+    sessionKey: "sk1",
+    messages: [makeMessage("user", `query ${turn}`)],
+    prompt: `query ${turn}`,
+    tokenBudget: 4000,
+  });
+  const nextEventLoopTurn = () => new Promise<void>((resolve) => setImmediate(resolve));
+  const grpcError = (code: number, message: string) => Object.assign(new Error(message), { code });
+
+  const attempts = [1, 2, 3, 4].map(assemble);
+  await nextEventLoopTurn();
+  assert.equal(client.pendingBeforeTurn.length, 4, "all failures should already be in flight");
+
+  for (let index = 0; index < 3; index++) {
+    client.pendingBeforeTurn[index].reject(grpcError(4, "deadline exceeded"));
+    await nextEventLoopTurn();
+  }
+  client.pendingBeforeTurn[3].reject(grpcError(14, "unavailable"));
+  await Promise.all(attempts);
+
+  client.beforeTurnSucceeds = true;
+  await assemble(5);
+
+  assert.equal(
+    client.calls.filter((call) => call.method === "beforeTurnKernel").length,
+    5,
+    "the new failure class should not inherit the timeout cooldown",
+  );
+});
+
 test("context engine assemble uses latest selected-context user utterance as retrieval query", async () => {
   const client = new FakeClient();
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });


### PR DESCRIPTION
## Summary

- Clear `cooldownUntil` whenever a session’s BeforeTurn failure changes class.
- Add a regression that opens the timeout circuit, changes the failure to unavailable, and verifies the next call is not blocked by the stale timeout cooldown.

## Root cause

The failure-class transition reset `class` and `consecutive`, but retained the prior class’s `cooldownUntil`. Until the new class reached its own threshold, the old cooldown continued to make the circuit appear open.

## Impact

A new failure mode now starts with a clean circuit state instead of inheriting backoff timing from an unrelated earlier failure.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm run clean:test && pnpm exec tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/context-engine.test.js` — 74/74 passed
- Regression confirmed to fail against the old implementation (`4 !== 5` BeforeTurn RPC calls)
- `git diff --check`

Fixes #349.

– Vale
