### PR TITLE
fix: prefix memory_search/memory_get to avoid OpenClaw core tool catalog collision

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -11,8 +11,8 @@
     "memory": true,
     "contextEngine": true,
     "tools": [
-      "memory_search",
-      "memory_get",
+      "libravdb_memory_search",
+      "libravdb_memory_get",
       "memory_describe",
       "memory_expand",
       "memory_grep",

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2359,7 +2359,7 @@ export function buildContextEngineFactory(
         (r) => r.id === "__session_continuity__"
       );
       if (!continuityHit) {
-        return '<continuity_context>\nNo prior session context available. Use memory_search to recall previous conversations.\n</continuity_context>';
+        return '<continuity_context>\nNo prior session context available. Use libravdb_memory_search to recall previous conversations.\n</continuity_context>';
       }
 
       let meta: Record<string, unknown> = {};
@@ -2371,7 +2371,7 @@ export function buildContextEngineFactory(
       const summaryId = meta.summary_id as string | undefined;
       if (!summaryId) {
         const sid = (meta.session_id as string | undefined) ?? params.sessionId;
-        return '<continuity_context>\nThe previous session (' + sid + ') was not compacted. Use memory_search with queries about what was discussed to recall context.\n</continuity_context>';
+        return '<continuity_context>\nThe previous session (' + sid + ') was not compacted. Use libravdb_memory_search with queries about what was discussed to recall context.\n</continuity_context>';
       }
 
       const expanded = await params.client.expandSummary({
@@ -2379,7 +2379,7 @@ export function buildContextEngineFactory(
         summaryId,
         maxDepth: 2,
       });
-      if (!expanded.text) return '<continuity_context>\nFailed to expand prior session summary. Use memory_search to recall previous conversations.\n</continuity_context>';
+      if (!expanded.text) return '<continuity_context>\nFailed to expand prior session summary. Use libravdb_memory_search to recall previous conversations.\n</continuity_context>';
 
       return '<continuity_context>\nThe following is a summary of the previous session. Use it for context about what was discussed before the reset.\n' + expanded.text + '\n</continuity_context>';
     } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,8 @@ export function register(api: OpenClawPluginApi) {
   const ownsMemorySlot = memSlot === MEMORY_ID;
   if (runtimeOrNull && ownsMemorySlot) {
     const memoryTools = createLibraVdbMemoryTools(runtimeOrNull.getClient, cfg, logger);
-    api.registerTool?.((ctx) => memoryTools.createSearchTool(ctx), { names: ["memory_search"] });
-    api.registerTool?.((ctx) => memoryTools.createGetTool(ctx), { names: ["memory_get"] });
+    api.registerTool?.((ctx) => memoryTools.createSearchTool(ctx), { names: ["libravdb_memory_search"] });
+    api.registerTool?.((ctx) => memoryTools.createGetTool(ctx), { names: ["libravdb_memory_get"] });
   }
 
   // Recall tools: describe, expand, grep — available when the runtime exists.

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -7,7 +7,7 @@ const MEMORY_PROMPT_HEADER = [
   "Every turn is auto-ingested into the vector store — you do not need",
   "to explicitly save anything. When asked about past conversations,",
   "facts, preferences, decisions, or anything the user might have told",
-  "you before, call `memory_search` once per user question. Do not",
+  "you before, call `libravdb_memory_search` once per user question. Do not",
   "answer from memory until you have called it. Once you have results,",
   "use them — do not re-call in the same turn.",
   "",
@@ -16,7 +16,7 @@ const MEMORY_PROMPT_HEADER = [
   "('who is X', 'what is X', 'do I have X', 'tell me about X', 'what kind of X'):",
   "you MUST call `list_user_cards` or `get_user_card`. This is not optional.",
   "Do NOT answer from memory, context, or training data. Call the tool FIRST.",
-  "If the card is empty, then fall through to `memory_search`. ",
+  "If the card is empty, then fall through to `libravdb_memory_search`. ",
   "FAILURE TO CALL THE TOOL IS A CRITICAL ERROR.",
   "",
   "Conversations are captured automatically. Never say \"I'll remember",
@@ -26,13 +26,13 @@ const MEMORY_PROMPT_HEADER = [
 ] as const;
 
 function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): string[] {
-  if (!availableTools?.has("memory_search")) {
+  if (!availableTools?.has("libravdb_memory_search")) {
     return [];
   }
 
   const lines: string[] = [];
-	const hasSearch = availableTools.has("memory_search");
-	const hasGet = availableTools.has("memory_get");
+	const hasSearch = availableTools.has("libravdb_memory_search");
+	const hasGet = availableTools.has("libravdb_memory_get");
 	const hasDescribe = availableTools.has("memory_describe");
 	const hasExpand = availableTools.has("memory_expand");
 	const hasGrep = availableTools.has("memory_grep");
@@ -49,7 +49,7 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
       hasListCards ? "- `list_user_cards()` — MANDATORY roster check. Call if unsure whether a card exists." : "",
       "Cards are the canonical record. You MUST call these tools. Do NOT answer from",
       "memory, context, or training data without checking the card first.",
-		hasSearch ? "Only use memory_search if the card is empty or missing." : "Use the card result as the available identity record.",
+		hasSearch ? "Only use libravdb_memory_search if the card is empty or missing." : "Use the card result as the available identity record.",
       "",
       "**Autonomous card maintenance:**",
       hasGetCard ? "- When ANY speaker is mentioned with new or changed information (status, relationships, jobs, life events, feelings), call `update_user_card` BEFORE responding. Update the card first, then reply. Do NOT wait to be asked. Build the world picture proactively. Every person the user mentions matters." : "",
@@ -60,14 +60,14 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
 
 	if (hasSearch) {
 		lines.push(
-			"Call `memory_search` once per user question for prior turns, remembered",
+			"Call `libravdb_memory_search` once per user question for prior turns, remembered",
 			"facts, earliest interactions, and channel history. Do not answer memory",
 			"questions from prior transcript claims — perform a search every time.",
 			"After receiving results, use them directly; do not re-call in the same turn.",
 			...(hasGet
       ? [
-        "After a `memory_search` hit, call `memory_get` when exact wording or more context is needed.",
-        "IMPORTANT: If a search snippet is cluttered with metadata, do NOT claim nothing was found. Call `memory_get` on the hit's path to read the full record first. The data is there — expand before giving up."
+        "After a `libravdb_memory_search` hit, call `libravdb_memory_get` when exact wording or more context is needed.",
+        "IMPORTANT: If a search snippet is cluttered with metadata, do NOT claim nothing was found. Call `libravdb_memory_get` on the hit's path to read the full record first. The data is there — expand before giving up."
       ]
       : []),
 			"",
@@ -129,11 +129,11 @@ function buildToolGuidance(availableTools: ReadonlySet<string> | undefined): str
   if (hasExpand) {
 		const traversalSteps = [
 			hasSearch
-				? "1. `memory_search` for the people/events in question to get record IDs"
+				? "1. `libravdb_memory_search` for the people/events in question to get record IDs"
 				: "1. Start from a record ID already present in context or another tool result",
 			"2. `memory_expand` with the most relevant `record_id` to walk typed causal and 6W1H hop edges",
 			hasGet
-				? "3. Follow interesting edges; use `memory_get` for exact detail on connected records"
+				? "3. Follow interesting edges; use `libravdb_memory_get` for exact detail on connected records"
 				: "3. Use the typed edge snippets to decide whether the connected records answer the question",
 			...(hasUserCard ? ["4. Use `get_user_card` to cross-reference identity context"] : []),
 		];

--- a/src/memory-tools.ts
+++ b/src/memory-tools.ts
@@ -106,7 +106,7 @@ const MEMORY_GET_SCHEMA = {
   properties: {
     path: {
       type: "string",
-      description: "A path returned by memory_search.",
+      description: "A path returned by libravdb_memory_search.",
     },
     from: {
       type: "number",
@@ -121,7 +121,7 @@ const MEMORY_GET_SCHEMA = {
     corpus: {
       type: "string",
       enum: ["memory", "wiki", "all"],
-      description: "Corpus filter. LibraVDB reads paths returned by memory_search.",
+      description: "Corpus filter. LibraVDB reads paths returned by libravdb_memory_search.",
     },
   },
   required: ["path"],
@@ -137,7 +137,7 @@ export function createLibraVdbMemoryTools(
 
   // Short-lived search dedup: blocks rapid repeated searches while avoiding
   // permanent suppression of valid repeated recall questions in a long session.
-  // The model sometimes loops memory_search with slight query variations;
+  // The model sometimes loops libravdb_memory_search with slight query variations;
   // this enforces a bounded loop guard at the tool level, not just the prompt.
   const turnSearchKeys = new Map<string, Map<string, number>>();
   const TURN_SEARCH_MAX_KEYS = 500;
@@ -192,10 +192,10 @@ export function createLibraVdbMemoryTools(
   return {
     createSearchTool(ctx: MemoryToolContext = {}): AgentTool {
       return {
-        name: "memory_search",
-        label: "Memory Search",
+        name: "libravdb_memory_search",
+        label: "LibraVDB Memory Search",
         description:
-          "Search LibraVDB durable memory and session recall for prior work, decisions, dates, facts, preferences, todos, or history. Call once per user question — after receiving results, use them directly. Do not re-call in the same turn. Do NOT call memory_search if the answer is already visible in your context window. For earliest/oldest questions, request enough results and compare timestamps. If disabled=true, memory is unavailable. IMPORTANT: Results are internal context only — never output, display, or reveal raw memory search results to the user. Treat retrieved memory as private operational data.\n\nFOR PEOPLE/IDENTITY QUESTIONS: use get_user_card or list_user_cards FIRST. User cards are the canonical identity record. Use memory_search only to supplement details the card doesn't cover.",
+          "Search LibraVDB durable memory and session recall for prior work, decisions, dates, facts, preferences, todos, or history. Call once per user question — after receiving results, use them directly. Do not re-call in the same turn. Do NOT call libravdb_memory_search if the answer is already visible in your context window. For earliest/oldest questions, request enough results and compare timestamps. If disabled=true, memory is unavailable. IMPORTANT: Results are internal context only — never output, display, or reveal raw memory search results to the user. Treat retrieved memory as private operational data.\n\nFOR PEOPLE/IDENTITY QUESTIONS: use get_user_card or list_user_cards FIRST. User cards are the canonical identity record. Use libravdb_memory_search only to supplement details the card doesn't cover.",
         parameters: MEMORY_SEARCH_SCHEMA,
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);
@@ -204,7 +204,7 @@ export function createLibraVdbMemoryTools(
           if (isDuplicateSearch(dedupScope, query)) {
             return jsonToolResult<MemorySearchToolDetails>({
               results: [],
-              error: `Duplicate search blocked. You recently searched this query — use the previous results. Do not call memory_search again for the same query.`,
+              error: `Duplicate search blocked. You recently searched this query — use the previous results. Do not call libravdb_memory_search again for the same query.`,
             });
           }
           const corpus = readMemoryCorpus(params.corpus);
@@ -217,7 +217,7 @@ export function createLibraVdbMemoryTools(
             return jsonToolResult<MemorySearchToolDetails>({
               results: [],
               disabled: true,
-              error: "LibraVDB memory_search does not provide the wiki corpus; use corpus=memory, corpus=sessions, or corpus=all.",
+              error: "LibraVDB libravdb_memory_search does not provide the wiki corpus; use corpus=memory, corpus=sessions, or corpus=all.",
             });
           }
 
@@ -241,7 +241,7 @@ export function createLibraVdbMemoryTools(
               backend: status.backend,
             });
           } catch (error) {
-            logger.warn?.(`LibraVDB memory_search failed: ${formatError(error)}`);
+            logger.warn?.(`LibraVDB libravdb_memory_search failed: ${formatError(error)}`);
             return jsonToolResult<MemorySearchToolDetails>({
               results: [],
               disabled: true,
@@ -253,10 +253,10 @@ export function createLibraVdbMemoryTools(
     },
     createGetTool(ctx: MemoryToolContext = {}): AgentTool {
       return {
-        name: "memory_get",
-        label: "Memory Get",
+        name: "libravdb_memory_get",
+        label: "LibraVDB Memory Get",
         description:
-          "Read a bounded exact excerpt from a LibraVDB memory path returned by memory_search. Use this after memory_search when a hit needs exact wording or more context.",
+          "Read a bounded exact excerpt from a LibraVDB memory path returned by libravdb_memory_search. Use this after libravdb_memory_search when a hit needs exact wording or more context.",
         parameters: MEMORY_GET_SCHEMA,
         execute: async (_toolCallId, rawParams) => {
           const params = asToolParamsRecord(rawParams);
@@ -270,7 +270,7 @@ export function createLibraVdbMemoryTools(
               path: relPath,
               text: "",
               disabled: true,
-              error: "LibraVDB memory_get does not provide the wiki corpus; use paths returned by LibraVDB memory_search.",
+              error: "LibraVDB libravdb_memory_get does not provide the wiki corpus; use paths returned by LibraVDB libravdb_memory_search.",
             });
           }
 
@@ -283,7 +283,7 @@ export function createLibraVdbMemoryTools(
             });
             return jsonToolResult<MemoryGetToolDetails>(result);
           } catch (error) {
-            logger.warn?.(`LibraVDB memory_get failed: ${formatError(error)}`);
+            logger.warn?.(`LibraVDB libravdb_memory_get failed: ${formatError(error)}`);
             return jsonToolResult<MemoryGetToolDetails>({
               path: relPath,
               text: "",

--- a/src/tools/memory-recall.ts
+++ b/src/tools/memory-recall.ts
@@ -72,7 +72,7 @@ const MEMORY_DESCRIBE_SCHEMA = {
   properties: {
     summaryId: {
       type: "string",
-      description: "A summary ID (sum_xxx format) returned by memory_search. Inspect metadata without expanding.",
+      description: "A summary ID (sum_xxx format) returned by libravdb_memory_search. Inspect metadata without expanding.",
     },
     sessionId: {
       type: "string",
@@ -89,11 +89,11 @@ const MEMORY_EXPAND_SCHEMA = {
     summaryIds: {
       type: "array",
       items: { type: "string" },
-      description: "Summary IDs (sum_xxx format) to expand. Use results from memory_search or memory_describe.",
+      description: "Summary IDs (sum_xxx format) to expand. Use results from libravdb_memory_search or memory_describe.",
     },
     record_id: {
       type: "string",
-      description: "Record ID for causal graph traversal. Use exact IDs from memory_search or memory_get results.",
+      description: "Record ID for causal graph traversal. Use exact IDs from libravdb_memory_search or libravdb_memory_get results.",
     },
     maxDepth: {
       type: "number",
@@ -275,7 +275,7 @@ export function createMemoryExpandTool(
       "Expand compacted summaries OR walk causal graph edges from ANY record. " +
       "Summary mode (summaryIds): walk the summary tree up to maxDepth levels. " +
       "Graph mode (record_id): walk causal edges (why_ids/how_ids/hop_targets) " +
-      "from a record ID. Use exact IDs from memory_search or memory_get results — " +
+      "from a record ID. Use exact IDs from libravdb_memory_search or libravdb_memory_get results — " +
       "any ingested turn, memory, or summary has graph edges. " +
       "For large expansions, spawns a sub-agent. " +
       "Use memory_describe first to check if expansion is warranted.",
@@ -533,7 +533,7 @@ const RECALL_GUIDANCE = [
   "Active session recall and summary expansion tools are available:",
   "",
   "**Tool escalation (cheap → expensive):**",
-  "1. `memory_search` — semantic search across all memory/session collections.",
+  "1. `libravdb_memory_search` — semantic search across all memory/session collections.",
   "   Summary hits show `[Summary sum_xxx]: [cue with anchors, decisions, signals]`.",
   "   Use these cues to decide what's worth expanding.",
   "2. `memory_describe` — inspect a summary's metadata (cheap, no expansion).",
@@ -634,7 +634,7 @@ export function createGetUserCardTool(
       "about a person, pet, place, or named thing ('who/what is X', 'do I have X', " +
       "'tell me about X'). Returns the full prose identity card. " +
       "Do NOT answer from memory or training data. Call this tool FIRST. " +
-      "Only fall through to memory_search if the card is empty or missing.",
+      "Only fall through to libravdb_memory_search if the card is empty or missing.",
     parameters: GET_USER_CARD_SCHEMA,
     execute: async (_toolCallId: string, rawParams: unknown): Promise<ToolResult<GetUserCardDetails>> => {
       try {

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -19,8 +19,8 @@ test("manifest and package metadata satisfy checklist structure", async () => {
   assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
   assert.equal(manifest.version, pkg.version);
   assert.deepEqual(manifest.contracts.tools, [
-    "memory_search",
-    "memory_get",
+    "libravdb_memory_search",
+    "libravdb_memory_get",
     "memory_describe",
     "memory_expand",
     "memory_grep",

--- a/test/unit/memory-provider.test.ts
+++ b/test/unit/memory-provider.test.ts
@@ -51,7 +51,7 @@ test("memory prompt section stays synchronous and does not perform rpc lookups",
 
   const memorySection = buildMemoryPromptSection(getRpc, cfg);
   const result = memorySection({
-    availableTools: new Set(["memory_search", "memory_get"]),
+    availableTools: new Set(["libravdb_memory_search", "libravdb_memory_get"]),
   });
 
   assert.doesNotThrow(() => [...result], "host spreads the returned section immediately");
@@ -60,23 +60,23 @@ test("memory prompt section stays synchronous and does not perform rpc lookups",
   assert.equal(rpc.calls.get("search_text") ?? 0, 0, "should not perform search_text calls");
 });
 
-test("memory prompt section guides memory tool use when memory_search is available", async () => {
+test("memory prompt section guides memory tool use when libravdb_memory_search is available", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { topK: 8, alpha: 0.7, beta: 0.2, gamma: 0.1 };
   const getRpc = async () => rpc as never;
 
   const memorySection = buildMemoryPromptSection(getRpc, cfg);
   const result = memorySection({
-    availableTools: new Set(["memory_search", "memory_get"]),
+    availableTools: new Set(["libravdb_memory_search", "libravdb_memory_get"]),
   });
 
   const resultText = result.join("\n");
   assert.ok(resultText.includes("LibraVDB Memory"), "should include memory header");
   assert.ok(resultText.includes("once per user question"), "should guide per-question memory retrieval");
-  assert.ok(resultText.includes("Call `memory_search`"), "should guide explicit recall through memory_search");
+  assert.ok(resultText.includes("Call `libravdb_memory_search`"), "should guide explicit recall through libravdb_memory_search");
   assert.ok(resultText.includes("perform a search every time"), "should prevent stale transcript reuse");
   assert.ok(resultText.includes("auto-ingested"), "should describe auto-ingestion behavior");
-  assert.ok(resultText.includes("call `memory_get`"), "should guide exact recall through memory_get");
+  assert.ok(resultText.includes("call `libravdb_memory_get`"), "should guide exact recall through libravdb_memory_get");
   assert.ok(resultText.includes("vector-backed"), "should describe memory as vector-backed");
   assert.ok(!resultText.includes("recalled_memories"), "should not inject recalled memories directly");
   assert.ok(!resultText.includes("user recall") && !resultText.includes("global recall"), "should not render recall items");
@@ -101,13 +101,13 @@ test("memory prompt section works with citationsMode", async () => {
 test("causal traversal guidance includes the available causal follow-up tools", () => {
   const memorySection = buildMemoryPromptSection(async () => new FakeRpc() as never, { topK: 8 });
 
-  const full = memorySection({ availableTools: new Set(["memory_search", "memory_get", "memory_expand", "get_user_card"]) }).join("\n");
-  assert.match(full, /`memory_search` for the people\/events/);
-  assert.match(full, /use `memory_get` for exact detail/);
+  const full = memorySection({ availableTools: new Set(["libravdb_memory_search", "libravdb_memory_get", "memory_expand", "get_user_card"]) }).join("\n");
+  assert.match(full, /`libravdb_memory_search` for the people\/events/);
+  assert.match(full, /use `libravdb_memory_get` for exact detail/);
   assert.match(full, /`get_user_card` to cross-reference/);
 
-  const noGet = memorySection({ availableTools: new Set(["memory_search", "memory_expand"]) }).join("\n");
+  const noGet = memorySection({ availableTools: new Set(["libravdb_memory_search", "memory_expand"]) }).join("\n");
   assert.match(noGet, /typed edge snippets/);
-  assert.doesNotMatch(noGet, /use `memory_get` for exact detail/);
+  assert.doesNotMatch(noGet, /use `libravdb_memory_get` for exact detail/);
   assert.doesNotMatch(noGet, /`get_user_card` to cross-reference/);
 });

--- a/test/unit/memory-tools.test.ts
+++ b/test/unit/memory-tools.test.ts
@@ -94,7 +94,7 @@ class CorpusPriorityRpc extends FakeRpc {
   }
 }
 
-test("LibraVDB memory tools expose memory_search and memory_get through the runtime bridge", async () => {
+test("LibraVDB memory tools expose libravdb_memory_search and libravdb_memory_get through the runtime bridge", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { userId: "u1", topK: 4 };
   const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
@@ -102,8 +102,8 @@ test("LibraVDB memory tools expose memory_search and memory_get through the runt
   const searchTool = tools.createSearchTool(ctx);
   const getTool = tools.createGetTool(ctx);
 
-  assert.equal(searchTool.name, "memory_search");
-  assert.equal(getTool.name, "memory_get");
+  assert.equal(searchTool.name, "libravdb_memory_search");
+  assert.equal(getTool.name, "libravdb_memory_get");
 
   const search = await searchTool.execute("call-1", {
     query: "earliest memory",
@@ -141,7 +141,7 @@ test("LibraVDB memory tools expose memory_search and memory_get through the runt
   });
 });
 
-test("LibraVDB memory_search supports sessions corpus filtering without memory-core", async () => {
+test("LibraVDB libravdb_memory_search supports sessions corpus filtering without memory-core", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { userId: "u1" };
   const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
@@ -166,7 +166,7 @@ test("LibraVDB memory_search supports sessions corpus filtering without memory-c
   assert.equal(details.results[0]?.snippet, "single collection result");
 });
 
-test("LibraVDB memory_search constrains sessions corpus before top-k ranking", async () => {
+test("LibraVDB libravdb_memory_search constrains sessions corpus before top-k ranking", async () => {
   const rpc = new CorpusPriorityRpc();
   const cfg: PluginConfig = { userId: "u1" };
   const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
@@ -203,7 +203,7 @@ test("LibraVDB memory_search constrains sessions corpus before top-k ranking", a
   ]);
 });
 
-test("LibraVDB memory_search constrains memory corpus before top-k ranking", async () => {
+test("LibraVDB libravdb_memory_search constrains memory corpus before top-k ranking", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { userId: "u1" };
   const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
@@ -228,7 +228,7 @@ test("LibraVDB memory_search constrains memory corpus before top-k ranking", asy
   );
 });
 
-test("LibraVDB memory_search duplicate guard expires instead of blocking the whole session", async () => {
+test("LibraVDB libravdb_memory_search duplicate guard expires instead of blocking the whole session", async () => {
   const rpc = new FakeRpc();
   const cfg: PluginConfig = { userId: "u1" };
   const tools = createLibraVdbMemoryTools(async () => rpc as never, cfg, silentLogger);
@@ -259,7 +259,7 @@ test("LibraVDB memory_search duplicate guard expires instead of blocking the who
   }
 });
 
-test("LibraVDB memory_get reports unknown paths as disabled instead of reading arbitrary files", async () => {
+test("LibraVDB libravdb_memory_get reports unknown paths as disabled instead of reading arbitrary files", async () => {
   const rpc = new FakeRpc();
   const tools = createLibraVdbMemoryTools(async () => rpc as never, { userId: "u1" }, silentLogger);
   const getTool = tools.createGetTool({ agentId: "spartacus" });

--- a/test/unit/slot-conflict.test.ts
+++ b/test/unit/slot-conflict.test.ts
@@ -99,8 +99,8 @@ test("slot check — ours: register succeeds", () => {
     "libravdb-onnx",
   ]);
   assert.deepEqual(api.registrations.tools, [
-    "memory_search",
-    "memory_get",
+    "libravdb_memory_search",
+    "libravdb_memory_get",
     "memory_describe",
     "memory_expand",
     "memory_grep",
@@ -157,7 +157,7 @@ test("slot check — unset: register succeeds with warning", () => {
     "libravdb-bundled",
     "libravdb-onnx",
   ]);
-  // When the memory slot is unset, memory_search / memory_get are not
+  // When the memory slot is unset, libravdb_memory_search / libravdb_memory_get are not
   // registered (ownsMemorySlot is false), but the recall tools still
   // register because they only require a runtime, not slot ownership.
   assert.deepEqual(api.registrations.tools, [


### PR DESCRIPTION
## Problem

OpenClaw >=2026.5.x moved `memory_search` and `memory_get` into the core tool catalog (`tool-catalog.ts`) and the `group:openclaw` policy group. The bundled `memory-core` plugin no longer declares these tools — it only checks `availableTools.has()`.

This colonizes generic tool names that were the de facto community contract for every third-party memory plugin. When a third-party plugin registers `memory_search` and `memory_get` via `api.registerTool()`, the core catalog entries shadow or conflict with the plugin registrations. See:

- [Issue #82977](https://github.com/openclaw/openclaw/issues/82977) — active-memory incompatible with third-party memory plugins
- [PR #75160](https://github.com/openclaw/openclaw/pull/75160) — gateway fallback resolution for memory slot tools

## Fix

Prefix the two conflicting tool names with `libravdb_`:

- `memory_search` → `libravdb_memory_search`
- `memory_get` → `libravdb_memory_get`

All other tools (`memory_describe`, `memory_expand`, `memory_grep`, `update_user_card`, `get_user_card`, `list_user_cards`, `set_rule`, `get_rule`, `list_rules`, `delete_rule`, `set_persona`, `get_persona`) are unaffected.

## Scope

- Tool registration names and descriptions
- Prompt guidance (`memory-provider.ts`)
- Continuity context messages (`context-engine.ts`)
- Tool descriptions and recall guidance (`tools/memory-recall.ts`)
- Plugin manifest contracts (`openclaw.plugin.json`)
- All relevant tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Renamed `memory_search` to `libravdb_memory_search`.
- Renamed `memory_get` to `libravdb_memory_get`.
- Updated tool registration, manifest contracts, descriptions, prompt guidance, continuity messages, error messages, and tests.
- Preserved search and retrieval behavior.
- Prevented name collisions with OpenClaw core tools in versions 2026.5.x and later.

## Complexity

- No Big O complexity regression. The change only renames identifiers and related text.
- No cyclomatic complexity regression. The change adds no branches, loops, or control-flow paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->