### PR TITLE
fix: declare the OpenClaw 2026.8.1 durable-turn contract (engine is currently degraded to legacy on every turn)

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -25,9 +25,28 @@ import { resolveUserCollection } from "./memory-scopes.js";
 import { manifestStore } from "./manifest.js";
 import { TurnMemoryCache, extractQueryHint, isNewUserTurn } from "./turn-cache.js";
 
-/** Host advancement keys already committed, so an exact host retry answers "duplicate". */
+/** Host advancement keys whose turn is durably ingested, so an exact retry answers "duplicate". */
 const committedAdvancementKeys = new Set<string>();
 const COMMITTED_ADVANCEMENT_KEY_LIMIT = 4096;
+
+/**
+ * Commits in flight, keyed by advancementKey. Concurrent calls carrying the
+ * same key join the first call's promise instead of starting a second ingest,
+ * which is what makes the commit atomic per key rather than a racy
+ * check-then-act. Entries are removed once settled, so a failed commit leaves
+ * nothing behind and a host retry starts clean.
+ */
+const inFlightAdvancements = new Map<string, Promise<"committed" | "duplicate">>();
+
+/** Records a durably committed key, evicting oldest-first to stay bounded. */
+function rememberCommittedAdvancementKey(key: string): void {
+  committedAdvancementKeys.add(key);
+  while (committedAdvancementKeys.size > COMMITTED_ADVANCEMENT_KEY_LIMIT) {
+    const oldest = committedAdvancementKeys.values().next().value;
+    if (oldest === undefined) break;
+    committedAdvancementKeys.delete(oldest);
+  }
+}
 
 type KernelCompatibleMessage = {
   role: string;
@@ -290,14 +309,21 @@ interface PostToolContextCache {
 const POST_TOOL_CACHE_MAX_SIZE = 100;
 const postToolRecallCache = new Map<string, PostToolContextCache>();
 
-function enqueueAsyncIngestion(sessionId: string, task: () => Promise<void>): void {
+/**
+ * Appends `task` to the per-session serialized ingestion queue.
+ *
+ * Returns a handle that settles with the task's real outcome, so a caller that
+ * needs to know whether the work actually succeeded (commitTurn) can await it.
+ * The queue chain itself never rejects: one failed task must not poison the
+ * queue for the tasks behind it, and the `.catch` that guarantees that also
+ * marks the returned handle as handled, so ignoring it cannot raise an
+ * unhandled rejection.
+ */
+function enqueueAsyncIngestion(sessionId: string, task: () => Promise<void>): Promise<void> {
   const previous = asyncIngestionQueues.get(sessionId) ?? Promise.resolve();
-  // The task body wraps all work in try/catch with logger.warn, so any
-  // rejection is already logged. This outer catch handles the edge case of
-  // a synchronously-thrown error during task invocation (not promise
-  // rejection) and prevents an unhandled rejection from surfacing.
-  const next = previous.then(task).catch(() => {
-    // Errors are already caught and logged inside the task.
+  const run = previous.then(task);
+  const next = run.catch(() => {
+    // Swallowed for the chain only; `run` still carries the real outcome.
   }).finally(() => {
     // Clean up settled entries to prevent unbounded map growth across sessions.
     if (asyncIngestionQueues.get(sessionId) === next) {
@@ -305,6 +331,7 @@ function enqueueAsyncIngestion(sessionId: string, task: () => Promise<void>): vo
     }
   });
   asyncIngestionQueues.set(sessionId, next);
+  return run;
 }
 
 
@@ -432,6 +459,16 @@ function capRetrievalQuery(text: string): string {
  * code must explicitly import the symbol to call the hook.
  */
 export const FLUSH_ASYNC_INGESTION = Symbol("flushAsyncIngestion");
+
+/**
+ * Internal, symbol-keyed afterTurn argument. When present, afterTurn hands back
+ * the queued ingestion's real outcome so commitTurn can await durability.
+ *
+ * Passed in rather than returned so afterTurn's return value stays exactly what
+ * the host already sees, and symbol-keyed so it cannot collide with any
+ * host-supplied argument.
+ */
+const CAPTURE_INGESTION = Symbol("libravdbCaptureIngestion");
 
 let maxOptimizationMemoCacheSize = 50000;
 const metadataEnvelopeCache = new Map<string, string>();
@@ -3325,10 +3362,20 @@ export function buildContextEngineFactory(
      *
      * The host requires one atomic, idempotent commit per accepted turn, keyed by
      * `advancementKey`, and may retry the same key after a process or plugin failure.
-     * `afterTurn` is already idempotent: it reloads the per-session manifest inside the
-     * serialized ingestion queue and slices off `findOverlapIndex`, so a replayed turn
-     * contributes no new messages. The key set below only short-circuits an exact host
-     * retry so the host is told "duplicate" rather than doing the overlap work again.
+     *
+     * A key is recorded only after the ingestion it names has actually succeeded —
+     * the daemon acknowledged the messages and the manifest was persisted — not when
+     * the work was merely queued. If ingestion fails, nothing is recorded, the error
+     * propagates, and a host retry with the same key runs the work again.
+     *
+     * Concurrent calls carrying the same key are serialized on one in-flight promise,
+     * so exactly one of them performs the ingest. The others resolve to "duplicate"
+     * once it succeeds, or reject with the same error if it fails.
+     *
+     * `afterTurn` remains idempotent underneath this: it reloads the per-session
+     * manifest inside the serialized ingestion queue and slices off `findOverlapIndex`,
+     * so a replayed turn contributes no new messages even across a process restart,
+     * where the in-memory key set is empty.
      */
     async commitTurn(args: {
       advancementKey: string;
@@ -3340,25 +3387,58 @@ export function buildContextEngineFactory(
       runtimeContext?: Record<string, unknown>;
     }): Promise<{ status: "committed" | "duplicate" }> {
       const key = args.advancementKey;
-      if (key && committedAdvancementKeys.has(key)) {
+
+      // Run the turn and wait for the durable part of the ingest to finish.
+      // Errors propagate: a caller that is told nothing must be free to retry.
+      const ingestTurn = async (): Promise<"committed" | "duplicate"> => {
+        // afterTurn returns as soon as the work is queued, so capture the handle
+        // and wait on it: it settles once the daemon has acknowledged the
+        // messages and the manifest has been written. It stays undefined when
+        // afterTurn short-circuited (excluded agent, no new messages), where
+        // there is nothing to wait for and nothing that can fail.
+        let ingestion: Promise<void> | undefined;
+        const result = await this.afterTurn({
+          sessionId: args.sessionId,
+          sessionKey: args.sessionKey,
+          messages: args.messages,
+          prePromptMessageCount: args.prePromptMessageCount,
+          isHeartbeat: args.isHeartbeat,
+          runtimeContext: args.runtimeContext,
+          [CAPTURE_INGESTION]: (handle) => { ingestion = handle; },
+        });
+        if (ingestion) await ingestion;
+        return (result as { skipped?: boolean } | undefined)?.skipped ? "duplicate" : "committed";
+      };
+
+      // Without a key there is nothing to deduplicate against.
+      if (!key) return { status: await ingestTurn() };
+
+      if (committedAdvancementKeys.has(key)) return { status: "duplicate" };
+
+      // Join an identical commit already running rather than starting a second
+      // ingest. If it succeeds this call contributed nothing, so it is a
+      // duplicate; if it fails, both callers see the failure and may retry.
+      const existing = inFlightAdvancements.get(key);
+      if (existing) {
+        await existing;
         return { status: "duplicate" };
       }
-      const result = await this.afterTurn({
-        sessionId: args.sessionId,
-        sessionKey: args.sessionKey,
-        messages: args.messages,
-        prePromptMessageCount: args.prePromptMessageCount,
-        isHeartbeat: args.isHeartbeat,
-        runtimeContext: args.runtimeContext,
-      });
-      if (key) {
-        committedAdvancementKeys.add(key);
-        if (committedAdvancementKeys.size > COMMITTED_ADVANCEMENT_KEY_LIMIT) {
-          const oldest = committedAdvancementKeys.values().next().value;
-          if (oldest !== undefined) committedAdvancementKeys.delete(oldest);
-        }
+
+      const run = ingestTurn();
+      inFlightAdvancements.set(key, run);
+      try {
+        const status = await run;
+        // Recorded only now, with the work durably done. No await separates
+        // this from the delete below, so no racing caller can observe a window
+        // where the key is neither in flight nor committed.
+        rememberCommittedAdvancementKey(key);
+        inFlightAdvancements.delete(key);
+        return { status };
+      } catch (error) {
+        // Leave no trace of a failed commit: the next retry must do real work.
+        inFlightAdvancements.delete(key);
+        throw error;
       }
-      return { status: result && (result as { skipped?: boolean }).skipped ? "duplicate" : "committed" };
     },
 
     async afterTurn(args: {
@@ -3370,6 +3450,7 @@ export function buildContextEngineFactory(
       isHeartbeat?: boolean;
       tokenBudget?: number;
       runtimeContext?: Record<string, unknown>;
+      [CAPTURE_INGESTION]?: (ingestion: Promise<void>) => void;
     }) {
       const sessionId = requireSessionId(args.sessionId, "afterTurn");
       if (isExcludedSession(args.sessionKey, sessionId)) {
@@ -3402,7 +3483,7 @@ export function buildContextEngineFactory(
         return { ok: true, skipped: true, reason: "no-new-messages" };
       }
 
-      enqueueAsyncIngestion(sessionId, async () => {
+      const ingestion = enqueueAsyncIngestion(sessionId, async () => {
         try {
           // Reload manifest inside the serialized queue so state is fresh
           // after any preceding queued tasks have completed.
@@ -3522,39 +3603,61 @@ export function buildContextEngineFactory(
             manifestStore.save(updatedManifest);
           }
 
-          await performAfterTurnPredictiveCompaction({
-            sessionId,
-            messages,
-            tokenBudget: args.tokenBudget,
-            currentTokenCount,
-          });
-          const predictions = result.predictions;
-          if (Array.isArray(predictions) && predictions.length > 0) {
-            if (predictiveContextCache.size >= PREDICTIVE_CACHE_MAX_SIZE) {
-              const oldest = predictiveContextCache.keys().next().value;
-              if (oldest !== undefined) predictiveContextCache.delete(oldest);
+          // Everything above is the durable part of the turn: the daemon has
+          // acknowledged the messages and the manifest has been persisted.
+          // Everything below is best effort. A failure there must not fail the
+          // commit, because asking the host to retry an already-durable turn
+          // is worse than losing a prediction or a warm cache entry.
+          try {
+            await performAfterTurnPredictiveCompaction({
+              sessionId,
+              messages,
+              tokenBudget: args.tokenBudget,
+              currentTokenCount,
+            });
+            const predictions = result.predictions;
+            if (Array.isArray(predictions) && predictions.length > 0) {
+              if (predictiveContextCache.size >= PREDICTIVE_CACHE_MAX_SIZE) {
+                const oldest = predictiveContextCache.keys().next().value;
+                if (oldest !== undefined) predictiveContextCache.delete(oldest);
+              }
+              predictiveContextCache.set(sessionId, predictions);
+              logger.info?.(
+                `LibraVDB predictive graph returned predictions sessionId=${sessionId} ` +
+                `count=${predictions.length}`,
+              );
+            } else {
+              logger.info?.(
+                `LibraVDB predictive graph returned no predictions sessionId=${sessionId}`,
+              );
             }
-            predictiveContextCache.set(sessionId, predictions);
-            logger.info?.(
-              `LibraVDB predictive graph returned predictions sessionId=${sessionId} ` +
-              `count=${predictions.length}`,
-            );
-          } else {
-            logger.info?.(
-              `LibraVDB predictive graph returned no predictions sessionId=${sessionId}`,
+            // Pre-warm embedding cache: the assistant's reply is the strongest
+            // predictor of what the user asks next. Embedding it now means the
+            // daemon's mmap cache is warm when the next BeforeTurnKernel fires.
+            prewarmEmbeddingCache(messages, userId, client);
+          } catch (error) {
+            logger.warn?.(
+              `LibraVDB afterTurn post-ingest step failed sessionId=${sessionId}: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
             );
           }
-          // Pre-warm embedding cache: the assistant's reply is the strongest
-          // predictor of what the user asks next. Embedding it now means the
-          // daemon's mmap cache is warm when the next BeforeTurnKernel fires.
-          prewarmEmbeddingCache(messages, userId, client);
         } catch (error) {
           logger.warn?.(
             `LibraVDB afterTurn failed sessionId=${sessionId}: ` +
             `${error instanceof Error ? error.message : String(error)}`,
           );
+          // Rethrow so commitTurn can distinguish a durable failure from a
+          // success. afterTurn itself stays fire-and-forget via the no-op
+          // handler attached below, so this never surfaces as unhandled.
+          throw error;
         }
       });
+
+      // afterTurn's own contract is fire-and-forget and the task already
+      // logged. commitTurn awaits the handle instead, so it sees real failures.
+      ingestion.catch(() => {});
+
+      args[CAPTURE_INGESTION]?.(ingestion);
 
       return { ok: true, queued: true };
     },

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2764,7 +2764,10 @@ export function buildContextEngineFactory(
     });
   }
 
-  return {
+  // Named so commitTurn can call afterTurn through the closure rather than `this`:
+  // a host that stores or wraps the hook as a bare function would otherwise
+  // leave `this` undefined and break the durable-turn path.
+  const engine = {
     info: {
       id: "libravdb-memory",
       name: "LibraVDB Memory",
@@ -3397,7 +3400,7 @@ export function buildContextEngineFactory(
         // afterTurn short-circuited (excluded agent, no new messages), where
         // there is nothing to wait for and nothing that can fail.
         let ingestion: Promise<void> | undefined;
-        const result = await this.afterTurn({
+        const result = await engine.afterTurn({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           messages: args.messages,
@@ -3756,4 +3759,6 @@ export function buildContextEngineFactory(
       excludedSessionIds.clear();
     },
   };
+
+  return engine;
 }

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -36,7 +36,20 @@ const COMMITTED_ADVANCEMENT_KEY_LIMIT = 4096;
  * check-then-act. Entries are removed once settled, so a failed commit leaves
  * nothing behind and a host retry starts clean.
  */
-const inFlightAdvancements = new Map<string, Promise<"committed" | "duplicate">>();
+const inFlightAdvancements = new Map<string, Promise<CommitOutcome>>();
+
+/**
+ * The result of running one turn through afterTurn. `status` is what the host is
+ * told; only "committed" is produced here, because "duplicate" is a statement
+ * about advancement keys and is decided by key matching, not by running a turn.
+ *
+ * `durable` is the separate question of whether this attempt queued an ingestion
+ * that then completed, and it is what decides whether the key may be remembered
+ * as committed. The two diverge whenever afterTurn short-circuits: an excluded
+ * session, or content the manifest already covers, needs no retry and so still
+ * reports "committed", but this attempt itself committed nothing.
+ */
+type CommitOutcome = { status: "committed"; durable: boolean };
 
 /** Records a durably committed key, evicting oldest-first to stay bounded. */
 function rememberCommittedAdvancementKey(key: string): void {
@@ -3366,14 +3379,39 @@ export function buildContextEngineFactory(
      * The host requires one atomic, idempotent commit per accepted turn, keyed by
      * `advancementKey`, and may retry the same key after a process or plugin failure.
      *
-     * A key is recorded only after the ingestion it names has actually succeeded —
-     * the daemon acknowledged the messages and the manifest was persisted — not when
-     * the work was merely queued. If ingestion fails, nothing is recorded, the error
-     * propagates, and a host retry with the same key runs the work again.
+     * A key is recorded only after the ingestion this call queued has run to
+     * completion — leaving the turn's content in the persisted manifest, whether this
+     * task wrote it or found a preceding one already had — never when the work was
+     * merely queued, and never when afterTurn short-circuited without queuing anything.
+     * If ingestion fails, nothing is recorded, the error propagates, and a host retry
+     * with the same key runs the work again.
+     *
+     * A short-circuit still resolves rather than throwing, because retrying it is not
+     * expected to do better: an excluded session stores nothing and never will, and
+     * content the manifest already covers short-circuits again on the next call for as
+     * long as that manifest survives. The host is told to stop, not that this key
+     * named a commit.
+     *
+     * Known limitations, inherited from afterTurn and not introduced here:
+     * - Overlap detection compares message id hashes where it has them, but a
+     *   multi-message overlap still matches on role and content alone, so two distinct
+     *   turns whose messages are byte-identical dedupe against each other and the
+     *   second is not ingested. It is reported as committed anyway, since replaying it
+     *   would dedupe identically. The stored content is the same either way; what is
+     *   lost is the repeat occurrence.
+     * - A daemon that answers without a cursor is ACKed optimistically, so for those
+     *   the manifest records what was sent rather than what was confirmed.
+     * - A daemon that returns a cursor confirming none of the batch leaves the queued
+     *   task resolving normally, so this reports "committed" for a turn that was never
+     *   stored. That is a defect in afterTurn's cursor reconciliation rather than in
+     *   this contract, and is fixed separately; until that lands, this method is only
+     *   as trustworthy as the ingest beneath it.
      *
      * Concurrent calls carrying the same key are serialized on one in-flight promise,
-     * so exactly one of them performs the ingest. The others resolve to "duplicate"
-     * once it succeeds, or reject with the same error if it fails.
+     * so at most one of them performs the ingest. The others reject with the same
+     * error if it fails. If it succeeds they resolve to "duplicate" when it committed
+     * something, and otherwise to whatever it resolved to — a leader that stored
+     * nothing leaves them no earlier commit to be a duplicate of.
      *
      * `afterTurn` remains idempotent underneath this: it reloads the per-session
      * manifest inside the serialized ingestion queue and slices off `findOverlapIndex`,
@@ -3393,14 +3431,14 @@ export function buildContextEngineFactory(
 
       // Run the turn and wait for the durable part of the ingest to finish.
       // Errors propagate: a caller that is told nothing must be free to retry.
-      const ingestTurn = async (): Promise<"committed" | "duplicate"> => {
+      const ingestTurn = async (): Promise<CommitOutcome> => {
         // afterTurn returns as soon as the work is queued, so capture the handle
-        // and wait on it: it settles once the daemon has acknowledged the
-        // messages and the manifest has been written. It stays undefined when
-        // afterTurn short-circuited (excluded agent, no new messages), where
-        // there is nothing to wait for and nothing that can fail.
+        // and wait on it: it settles once the queued ingest has run to
+        // completion. It stays undefined when afterTurn short-circuited
+        // (excluded agent, no new messages), where there is nothing to wait for
+        // and nothing that can fail.
         let ingestion: Promise<void> | undefined;
-        const result = await engine.afterTurn({
+        await engine.afterTurn({
           sessionId: args.sessionId,
           sessionKey: args.sessionKey,
           messages: args.messages,
@@ -3409,34 +3447,65 @@ export function buildContextEngineFactory(
           runtimeContext: args.runtimeContext,
           [CAPTURE_INGESTION]: (handle) => { ingestion = handle; },
         });
-        if (ingestion) await ingestion;
-        return (result as { skipped?: boolean } | undefined)?.skipped ? "duplicate" : "committed";
+        // The host defines "duplicate" as "this exact advancementKey was already
+        // committed", so it is decided by key matching below and never by
+        // afterTurn's result. afterTurn skips for reasons that are not prior
+        // commits -- an excluded session, or content already present in the
+        // manifest -- and reporting those as "duplicate" told the host a turn
+        // had been committed earlier when it never had. Reaching here means no
+        // further attempt can help, which is what "committed" tells the host;
+        // anything that failed threw before this point.
+        //
+        // Whether to remember the key is the narrower question of whether THIS
+        // call queued ingestion that then completed, and it is answered by the
+        // handle rather than by classifying skip reasons. A reason string is a
+        // fail-open signal: an unrecognized, renamed or absent one would be read
+        // as durable and memoize a commit that never happened. The handle is
+        // present only when afterTurn actually queued work, and awaiting it is
+        // what rules out a failure partway through that work.
+        //
+        // A queued task can still settle having found a preceding task already
+        // persisted the same content, so it did no work of its own; the content
+        // is durable either way, which is what the key records. Synchronous
+        // short-circuits, where no handle exists at all, never memoize. Replaying
+        // such a key costs a manifest reload and overlap scan but no RPC, and
+        // afterTurn is idempotent against the persisted manifest, so it simply
+        // re-derives the same skip. The key set is a fast path, not the
+        // correctness mechanism.
+        if (!ingestion) return { status: "committed", durable: false };
+        await ingestion;
+        return { status: "committed", durable: true };
       };
 
-      // Without a key there is nothing to deduplicate against.
-      if (!key) return { status: await ingestTurn() };
+      // Without a key there is nothing to deduplicate against, and nothing to
+      // remember either: a later call carrying no key could not be matched to
+      // this one anyway.
+      if (!key) return { status: (await ingestTurn()).status };
 
       if (committedAdvancementKeys.has(key)) return { status: "duplicate" };
 
       // Join an identical commit already running rather than starting a second
-      // ingest. If it succeeds this call contributed nothing, so it is a
-      // duplicate; if it fails, both callers see the failure and may retry.
+      // ingest. If it fails, both callers see the failure and may retry.
       const existing = inFlightAdvancements.get(key);
       if (existing) {
-        await existing;
-        return { status: "duplicate" };
+        // Only a leader that actually committed makes this call a duplicate of
+        // something. When the leader stored nothing -- an excluded session, or
+        // content the manifest already covered -- there is no earlier commit to
+        // be a duplicate of, so report what the leader reported.
+        const outcome = await existing;
+        return { status: outcome.durable ? "duplicate" : outcome.status };
       }
 
       const run = ingestTurn();
       inFlightAdvancements.set(key, run);
       try {
-        const status = await run;
-        // Recorded only now, with the work durably done. No await separates
-        // this from the delete below, so no racing caller can observe a window
-        // where the key is neither in flight nor committed.
-        rememberCommittedAdvancementKey(key);
+        const outcome = await run;
+        // Recorded only now, and only when this call's own ingestion settled.
+        // No await separates this from the delete below, so no racing caller can
+        // observe a window where the key is neither in flight nor committed.
+        if (outcome.durable) rememberCommittedAdvancementKey(key);
         inFlightAdvancements.delete(key);
-        return { status };
+        return { status: outcome.status };
       } catch (error) {
         // Leave no trace of a failed commit: the next retry must do real work.
         inFlightAdvancements.delete(key);

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -25,6 +25,10 @@ import { resolveUserCollection } from "./memory-scopes.js";
 import { manifestStore } from "./manifest.js";
 import { TurnMemoryCache, extractQueryHint, isNewUserTurn } from "./turn-cache.js";
 
+/** Host advancement keys already committed, so an exact host retry answers "duplicate". */
+const committedAdvancementKeys = new Set<string>();
+const COMMITTED_ADVANCEMENT_KEY_LIMIT = 4096;
+
 type KernelCompatibleMessage = {
   role: string;
   content: string;
@@ -2724,7 +2728,17 @@ export function buildContextEngineFactory(
   }
 
   return {
-    info: { id: "libravdb-memory", name: "LibraVDB Memory", ownsCompaction: true },
+    info: {
+      id: "libravdb-memory",
+      name: "LibraVDB Memory",
+      ownsCompaction: true,
+      // OpenClaw >= 2026.8.1 requires these before it will run a plugin context engine
+      // for a durable logical turn. See openclaw/openclaw#119325.
+      transcriptSemantics: {
+        currentTurnFence: "before-current-turn-entry-v1",
+        turnAdvancementIdempotency: "atomic-idempotent-v1",
+      },
+    },
     ownsCompaction: true,
     async bootstrap(args: { sessionId: string; sessionKey?: string; userId?: string }) {
       const sessionId = requireSessionId(args.sessionId, "bootstrap");
@@ -3306,6 +3320,47 @@ export function buildContextEngineFactory(
       };
       return await runCompaction(runArgs);
     },
+    /**
+     * OpenClaw >= 2026.8.1 durable turn advancement.
+     *
+     * The host requires one atomic, idempotent commit per accepted turn, keyed by
+     * `advancementKey`, and may retry the same key after a process or plugin failure.
+     * `afterTurn` is already idempotent: it reloads the per-session manifest inside the
+     * serialized ingestion queue and slices off `findOverlapIndex`, so a replayed turn
+     * contributes no new messages. The key set below only short-circuits an exact host
+     * retry so the host is told "duplicate" rather than doing the overlap work again.
+     */
+    async commitTurn(args: {
+      advancementKey: string;
+      sessionId: string;
+      sessionKey?: string;
+      messages: OpenClawCompatibleMessage[];
+      prePromptMessageCount?: number;
+      isHeartbeat?: boolean;
+      runtimeContext?: Record<string, unknown>;
+    }): Promise<{ status: "committed" | "duplicate" }> {
+      const key = args.advancementKey;
+      if (key && committedAdvancementKeys.has(key)) {
+        return { status: "duplicate" };
+      }
+      const result = await this.afterTurn({
+        sessionId: args.sessionId,
+        sessionKey: args.sessionKey,
+        messages: args.messages,
+        prePromptMessageCount: args.prePromptMessageCount,
+        isHeartbeat: args.isHeartbeat,
+        runtimeContext: args.runtimeContext,
+      });
+      if (key) {
+        committedAdvancementKeys.add(key);
+        if (committedAdvancementKeys.size > COMMITTED_ADVANCEMENT_KEY_LIMIT) {
+          const oldest = committedAdvancementKeys.values().next().value;
+          if (oldest !== undefined) committedAdvancementKeys.delete(oldest);
+        }
+      }
+      return { status: result && (result as { skipped?: boolean }).skipped ? "duplicate" : "committed" };
+    },
+
     async afterTurn(args: {
       sessionId: string;
       sessionKey?: string;

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3341,7 +3341,6 @@ type CommitTurnEngine = {
     sessionId: string;
     sessionKey?: string;
     messages: ReturnType<typeof makeMessage>[];
-    prePromptMessageCount?: number;
   }) => Promise<{ status: "committed" | "duplicate" }>;
 };
 
@@ -3360,7 +3359,6 @@ test("commitTurn works when the host holds it as a bare, unbound function", asyn
       sessionId: "s1-commit-unbound",
       sessionKey: "sk-commit-unbound",
       messages: [makeMessage("user", "unbound"), makeMessage("assistant", "call")],
-      prePromptMessageCount: 0,
     });
     await flushIngestion(engine);
 
@@ -3379,7 +3377,6 @@ test("commitTurn serializes concurrent calls with the same advancementKey", asyn
       sessionId: "s1-commit-concurrent",
       sessionKey: "sk-commit-concurrent",
       messages,
-      prePromptMessageCount: 0,
     });
 
     const [a, b, c] = await Promise.all([call(), call(), call()]);
@@ -3419,7 +3416,6 @@ test("commitTurn does not record the key when ingestion fails, and a retry succe
       sessionId: "s1-commit-retry",
       sessionKey: "sk-commit-retry",
       messages,
-      prePromptMessageCount: 0,
     });
 
     // The durable write failed, so the failure must propagate rather than be
@@ -3461,7 +3457,6 @@ test("commitTurn concurrent callers all see the failure when the shared ingest f
       sessionId: "s1-commit-shared-failure",
       sessionKey: "sk-commit-shared-failure",
       messages,
-      prePromptMessageCount: 0,
     });
 
     const settled = await Promise.allSettled([call(), call()]);
@@ -3474,3 +3469,132 @@ test("commitTurn concurrent callers all see the failure when the shared ingest f
     await flushIngestion(engine);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Absence assertions for the durable-commit contract.
+//
+// The host treats "duplicate" as "this exact advancementKey was already
+// committed" and deletes the outbox row either way, so a status that overstates
+// what happened loses the turn permanently. These assert that "duplicate" is
+// never reported for a key that was never committed, and that a turn the daemon
+// did not confirm is rejected rather than reported as a success. The earlier
+// tests only covered the happy paths.
+// ---------------------------------------------------------------------------
+
+test("commitTurn never reports duplicate for an excluded session", async () => {
+  const engine = buildContextEngineFactory(throwingRuntime(), {
+    userId: "fixed-user",
+    excludeAgents: ["fastbot"],
+  });
+
+  const result = await (engine as unknown as CommitTurnEngine).commitTurn({
+    advancementKey: "adv-excluded-1",
+    sessionId: "s1-commit-excluded",
+    sessionKey: "agent:fastbot:session:s1-commit-excluded",
+    messages: [makeMessage("user", "excluded"), makeMessage("assistant", "reply")],
+  });
+
+  // Nothing was ever stored under this key, so claiming a prior commit would be
+  // false. Exclusion is permanent, so the host must also not be told to retry.
+  assert.notEqual(
+    result.status,
+    "duplicate",
+    "an excluded turn was never committed before, so it cannot be a duplicate",
+  );
+  assert.equal(result.status, "committed");
+
+  // Nor may the key be remembered as committed: nothing is stored under it. A
+  // replay of the same key must therefore still not report a prior commit.
+  const replay = await (engine as unknown as CommitTurnEngine).commitTurn({
+    advancementKey: "adv-excluded-1",
+    sessionId: "s1-commit-excluded",
+    sessionKey: "agent:fastbot:session:s1-commit-excluded",
+    messages: [makeMessage("user", "excluded"), makeMessage("assistant", "reply")],
+  });
+  assert.notEqual(
+    replay.status,
+    "duplicate",
+    "an excluded key must not be recorded as committed, so a replay is not a duplicate",
+  );
+});
+
+test("commitTurn never reports duplicate when concurrent excluded calls share a key", async () => {
+  const engine = buildContextEngineFactory(throwingRuntime(), {
+    userId: "fixed-user",
+    excludeAgents: ["fastbot"],
+  });
+
+  const call = () => (engine as unknown as CommitTurnEngine).commitTurn({
+    advancementKey: "adv-excluded-concurrent",
+    sessionId: "s1-commit-excluded-concurrent",
+    sessionKey: "agent:fastbot:session:s1-commit-excluded-concurrent",
+    messages: [makeMessage("user", "excluded"), makeMessage("assistant", "reply")],
+  });
+
+  // The second caller joins the first one's in-flight promise instead of
+  // starting its own ingest. Joining a leader that stored nothing makes it a
+  // duplicate of nothing, so the join must not manufacture a prior commit.
+  const [a, b] = await Promise.all([call(), call()]);
+
+  for (const [label, result] of [["leader", a], ["joiner", b]] as const) {
+    assert.notEqual(
+      result.status,
+      "duplicate",
+      `${label} reported a prior commit for an excluded turn that was never stored`,
+    );
+    assert.equal(result.status, "committed");
+  }
+});
+
+test("commitTurn reports duplicate only for a replayed key, never for repeated content", async () => {
+  await withTempStateDir(async () => {
+    const client = new FakeClient();
+    const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+    const identical = () => [makeMessage("user", "ok"), makeMessage("assistant", "ok")];
+
+    const first = await (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-distinct-1",
+      sessionId: "s1-commit-distinct",
+      sessionKey: "sk-commit-distinct",
+      messages: identical(),
+    });
+    await flushIngestion(engine);
+
+    const second = await (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-distinct-2",
+      sessionId: "s1-commit-distinct",
+      sessionKey: "sk-commit-distinct",
+      messages: identical(),
+    });
+    await flushIngestion(engine);
+
+    // This asserts the status contract, not storage. afterTurn dedupes by
+    // content, so the second turn is not separately ingested -- a pre-existing
+    // limitation documented on commitTurn. What must not happen is reporting it
+    // as "duplicate", which claims this advancementKey was committed before.
+    assert.notEqual(
+      second.status,
+      "duplicate",
+      "a new advancementKey must never be reported as a duplicate of earlier content",
+    );
+    assert.equal(first.status, "committed");
+    assert.equal(second.status, "committed");
+
+    // The assertions above pass vacuously if commitTurn simply never returns
+    // "duplicate". Replaying a key that did durable work must still report one,
+    // which is what establishes that key matching is the only route to it.
+    const replay = await (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-distinct-1",
+      sessionId: "s1-commit-distinct",
+      sessionKey: "sk-commit-distinct",
+      messages: identical(),
+    });
+    await flushIngestion(engine);
+    assert.equal(
+      replay.status,
+      "duplicate",
+      "a replayed advancementKey must still be reported as a duplicate",
+    );
+  });
+});
+

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3345,6 +3345,29 @@ type CommitTurnEngine = {
   }) => Promise<{ status: "committed" | "duplicate" }>;
 };
 
+test("commitTurn works when the host holds it as a bare, unbound function", async () => {
+  await withTempStateDir(async () => {
+    const client = new FakeClient();
+    const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+
+    // A host may store the hook rather than call it as a method. OpenClaw binds it today
+    // (`params.engine.commitTurn?.bind(params.engine)`), but nothing in the contract
+    // requires that, and an unbound call must not throw on `this`.
+    const detached = (engine as unknown as CommitTurnEngine).commitTurn;
+
+    const result = await detached({
+      advancementKey: "adv-unbound-1",
+      sessionId: "s1-commit-unbound",
+      sessionKey: "sk-commit-unbound",
+      messages: [makeMessage("user", "unbound"), makeMessage("assistant", "call")],
+      prePromptMessageCount: 0,
+    });
+    await flushIngestion(engine);
+
+    assert.equal(result.status, "committed");
+  });
+});
+
 test("commitTurn serializes concurrent calls with the same advancementKey", async () => {
   await withTempStateDir(async () => {
     const client = new FakeClient();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3290,3 +3290,164 @@ test("excludeSubagents off by default: a subagent is granted a normal expansion 
   );
 
 });
+
+// ---------------------------------------------------------------------------
+// commitTurn: atomic per-key idempotency (OpenClaw >= 2026.8.1 durable turn)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs `fn` against a throwaway state dir.
+ *
+ * These tests assert on whether the daemon was called, which depends on the
+ * per-session manifest being empty. The default manifest dir is the user's real
+ * ~/.openclaw/libravdb-manifests, so a manifest left by an earlier run makes
+ * afterTurn short-circuit with "no-new-messages" and the assertions flip. Point
+ * the store at a fresh temp dir so each run starts from nothing and nothing is
+ * written outside the test.
+ */
+async function withTempStateDir(fn: () => Promise<void>): Promise<void> {
+  const previous = process.env.OPENCLAW_STATE_DIR;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "libravdb-commitTurn-"));
+  process.env.OPENCLAW_STATE_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    if (previous === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Makes afterTurnKernel fail the next `times` calls, then succeed. */
+function failAfterTurnKernel(client: FakeClient, times: number): { calls: () => number } {
+  let seen = 0;
+  const original = client.afterTurnKernel.bind(client);
+  (client as unknown as {
+    afterTurnKernel: (params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  }).afterTurnKernel = async (params) => {
+    seen += 1;
+    if (seen <= times) {
+      client.calls.push({ method: "afterTurnKernel", params });
+      throw new Error("daemon unavailable");
+    }
+    return original(params);
+  };
+  return { calls: () => seen };
+}
+
+type CommitTurnEngine = {
+  commitTurn: (args: {
+    advancementKey: string;
+    sessionId: string;
+    sessionKey?: string;
+    messages: ReturnType<typeof makeMessage>[];
+    prePromptMessageCount?: number;
+  }) => Promise<{ status: "committed" | "duplicate" }>;
+};
+
+test("commitTurn serializes concurrent calls with the same advancementKey", async () => {
+  await withTempStateDir(async () => {
+    const client = new FakeClient();
+    const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+    const messages = [makeMessage("user", "concurrent"), makeMessage("assistant", "same key")];
+
+    const call = () => (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-concurrent-1",
+      sessionId: "s1-commit-concurrent",
+      sessionKey: "sk-commit-concurrent",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    const [a, b, c] = await Promise.all([call(), call(), call()]);
+    await flushIngestion(engine);
+
+    // Exactly one call performs the ingest; the others join it and report duplicate.
+    const statuses = [a.status, b.status, c.status].sort();
+    assert.deepEqual(
+      statuses,
+      ["committed", "duplicate", "duplicate"],
+      `expected one committed and two duplicates, got ${JSON.stringify(statuses)}`,
+    );
+
+    const ingests = client.calls.filter((x) => x.method === "afterTurnKernel");
+    assert.equal(
+      ingests.length,
+      1,
+      `the same advancementKey must ingest once, saw ${ingests.length} afterTurnKernel calls`,
+    );
+
+    // A later retry of the same key short-circuits without touching the daemon.
+    const retry = await call();
+    assert.equal(retry.status, "duplicate");
+    assert.equal(client.calls.filter((x) => x.method === "afterTurnKernel").length, 1);
+  });
+});
+
+test("commitTurn does not record the key when ingestion fails, and a retry succeeds", async () => {
+  await withTempStateDir(async () => {
+    const client = new FakeClient();
+    const probe = failAfterTurnKernel(client, 1);
+    const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+    const messages = [makeMessage("user", "retry me"), makeMessage("assistant", "after failure")];
+
+    const call = () => (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-retry-1",
+      sessionId: "s1-commit-retry",
+      sessionKey: "sk-commit-retry",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    // The durable write failed, so the failure must propagate rather than be
+    // swallowed — the host cannot retry a turn it was told succeeded.
+    await assert.rejects(
+      call(),
+      /daemon unavailable/,
+      "a failed ingestion must reject rather than report committed",
+    );
+
+    // The key was not recorded, so the retry does real work instead of being
+    // told duplicate and losing the turn forever.
+    const retry = await call();
+    assert.equal(
+      retry.status,
+      "committed",
+      "retry after a failed ingestion must re-run, not report duplicate",
+    );
+    await flushIngestion(engine);
+
+    assert.equal(probe.calls(), 2, "the daemon should have been called once per attempt");
+
+    // Now that it has succeeded, the key is recorded and a further retry is a duplicate.
+    const third = await call();
+    assert.equal(third.status, "duplicate");
+    assert.equal(probe.calls(), 2, "a duplicate must not reach the daemon");
+  });
+});
+
+test("commitTurn concurrent callers all see the failure when the shared ingest fails", async () => {
+  await withTempStateDir(async () => {
+    const client = new FakeClient();
+    failAfterTurnKernel(client, 1);
+    const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+    const messages = [makeMessage("user", "shared failure"), makeMessage("assistant", "propagate")];
+
+    const call = () => (engine as unknown as CommitTurnEngine).commitTurn({
+      advancementKey: "adv-shared-failure",
+      sessionId: "s1-commit-shared-failure",
+      sessionKey: "sk-commit-shared-failure",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    const settled = await Promise.allSettled([call(), call()]);
+    assert.equal(settled[0]?.status, "rejected", "the leader must reject");
+    assert.equal(settled[1]?.status, "rejected", "a joiner must see the leader's failure, not success");
+
+    // Nothing was recorded, so the key is still retryable.
+    const retry = await call();
+    assert.equal(retry.status, "committed");
+    await flushIngestion(engine);
+  });
+});


### PR DESCRIPTION
## Problem

On OpenClaw **2026.8.1**, this plugin's context engine is never used. Every turn logs:

```
[context-engine] Context engine "libravdb-memory" degraded to "legacy" for this logical turn:
atomic idempotent turn advancement is not declared.
```

The plugin loads, registers in `full` mode, and is then silently bypassed — nothing is ingested. It worked on 2026.6.x.

## Cause: OpenClaw changed the context-engine contract, deliberately

[openclaw/openclaw#119325](https://github.com/openclaw/openclaw/pull/119325) (merged 2026-08-07, in 2026.8.1) added a required durable-turn contract for context engines:

- `info.transcriptSemantics.currentTurnFence: "before-current-turn-entry-v1"`
- `info.transcriptSemantics.turnAdvancementIdempotency: "atomic-idempotent-v1"`
- a `commitTurn()` method

The host enforces it in `resolveSelectionIssue()` (`src/agents/harness/context-engine-logical-turn.ts`): an engine missing either field, or missing `commitTurn`, is degraded to `legacy` for the whole logical turn.

This is intentional and is now canon, not an accident:

- OpenClaw's own docs were updated in the same PR (`docs/concepts/context-engine.md`): *"Without the full declaration and method, OpenClaw uses the legacy context path for the whole logical turn… OpenClaw tries the configured engine again on the next logical turn."*
- Their review bot blocked the PR at **P1** specifically because it bundled *"a new public context-engine contract"* with unrelated work, and recorded **"Owner decision: Required"**. The PR body then states: *"Maintainer decision: retain the combined ContextEngine transcript/`commitTurn` contract in this PR."* It was merged on that basis.

So the fallback to `legacy` is working as designed; the plugin simply has not adopted the contract yet.

Current `info` (`src/context-engine.ts`) declares neither field, and there is no `commitTurn`:

```ts
info: { id: "libravdb-memory", name: "LibraVDB Memory", ownsCompaction: true },
```

## What this PR does

1. Declares both `transcriptSemantics` fields.
2. Adds `commitTurn()`, delegating to the existing `afterTurn`.

`afterTurn` is already atomic and idempotent for this purpose: it reloads the per-session manifest *inside* the serialized ingestion queue and slices from `manifestStore.findOverlapIndex`, so a replayed turn contributes no new messages. `commitTurn` therefore satisfies "atomic, idempotent, keyed by `advancementKey`" without reworking ingestion. A bounded `Set` of seen `advancementKey`s short-circuits an exact host retry so the host is answered `duplicate` rather than repeating the overlap scan.

No behavior change on older OpenClaw versions: the extra `info` fields are inert, and `commitTurn` is only called by hosts that look for it.

## Evidence

**Typecheck and build clean:**

```
$ node node_modules/typescript/bin/tsc --noEmit       # exit 0
$ tsc -p tsconfig.build.json && node scripts/bundle-entrypoint.mjs
$ grep -c transcriptSemantics dist/index.js           # 1
$ grep -c commitTurn dist/index.js                    # 1
```

**Live on OpenClaw 2026.8.1.** I applied this same change to the built `dist/index.js` of the installed 1.10.21 and restarted the gateway.

| | turns | degradations |
|---|---|---|
| stock 1.10.21 | 3 | 3 — *"atomic idempotent turn advancement is not declared"* |
| with this change | 3 | **0** — engine selected, `LibraVDB bootstrap` ran, codex wrote a `context-engine thread binding` |

It has been running on my production instance since, with no degradation warnings.

## Important caveat — this is necessary but not sufficient

Two things remain, neither caused by this plugin and neither fixed here:

1. **A host bug blocks the receipt path.** On 2026.8.1 the host also degrades every *fresh* turn with *"current-turn transcript admission receipt is unavailable"*, because it checks for the receipt during turn preparation, before the user turn is persisted. That affects **every** third-party context engine, including a minimal reference engine that implements the contract in full. Filed as [openclaw/openclaw#121460](https://github.com/openclaw/openclaw/issues/121460) with a fix in [openclaw/openclaw#121461](https://github.com/openclaw/openclaw/pull/121461). Until that lands, this PR alone will not restore ingestion — you need both.
2. **I have not yet observed `commitTurn` or `afterTurn` actually firing** under the Codex app-server runtime even with both fixes applied: no session manifest is written. I am still investigating whether that is a further host issue or something on the plugin side, and will follow up. I did not want to overstate this PR: it removes the contract-based degradation, which I have measured; it is not yet proof that ingestion is fully restored on that runtime.

## Also worth knowing

`info.acceptedHostParams` is still undeclared. OpenClaw's docs say undeclared engines receive the pre-host-field legacy parameter set only **through 2026-08-12**, after which they receive every current host field. That may need attention separately.

AI-assisted: investigated, implemented and tested with Claude (Claude Code).

---

## Update — durability defects found by review, now fixed

Depends on #375.

An adversarial review of this PR found that it promoted `afterTurn`'s **advisory** semantics into a **durability** contract. `afterTurn` may skip, dedupe by content, or short-circuit. That was harmless while it only drove logging; it is load-bearing once `commitTurn` maps the result to `{committed|duplicate}`, because the host deletes the durable outbox row for **both** values and never retries either.

The concrete defect: an **excluded session** returned `"duplicate"` for work that was never committed, and memoized the `advancementKey` as though it had been. So `"duplicate"` could mean "intentionally ignored and never stored" rather than "already committed", and the turn was gone.

### What changed

- Resolving now means only "no further attempt will help", which is `"committed"`. `"duplicate"` is decided **solely by `advancementKey` matching** — the host's own definition of the word — and never inferred from `afterTurn`'s result.
- Recording a key is gated separately on this call having queued an ingestion that then completed, tested via the **ingestion handle** rather than by classifying skip-reason strings. Reason strings fail open: an unrecognized, renamed or absent one would read as durable and memoize a commit that never happened.
- A caller joining an in-flight commit reports `"duplicate"` only when the leader actually committed, so two concurrent excluded calls can no longer manufacture a prior commit between them.
- Skips no longer memoize at all. That costs a manifest reload and overlap scan on a replayed key but no RPC, and `afterTurn` is idempotent against the persisted manifest, so it re-derives the same skip. The key set is a fast path, not the correctness mechanism.

### Tests assert the absences

The earlier tests covered only the happy paths, so they could not have caught this:

- no `"duplicate"` for an excluded session, including on a replay of the same key
- no `"duplicate"` when two **concurrent** excluded calls share a key
- `"duplicate"` still reachable by replaying a key that did commit — so the two negative assertions above cannot pass vacuously

All three fail on the previous head and pass here.

### Dependency on #375

`commitTurn` is only as trustworthy as the ingest beneath it. Two defects in `afterTurn` are **not** fixed here because they exist on `main` independently of this contract and are not this PR's concern — they are #375:

- a daemon cursor confirming **none** of the batch still resolves normally, so this can report `"committed"` for a turn that was never stored
- `bootstrap` deletes the in-flight `asyncIngestionQueues` entry, breaking per-session serialization

The first is recorded as a known limitation on the method's own documentation, so it stays visible if this lands first.

### Also documented rather than changed

Both predate this PR and belong to `afterTurn`:

- overlap detection compares message id hashes where it has them, but a multi-message overlap still matches on role and content alone, so two distinct turns whose messages are byte-identical dedupe and the second is not ingested
- a daemon answering without a cursor is ACKed optimistically, so the manifest records what was *sent* rather than what was *confirmed*

### Review

Six adversarial passes on this change. Two of them found defects **in the fix for the previous pass's finding** — a reason-string gate that failed open, and an in-flight join that returned `"duplicate"` unconditionally — so one re-review after acting on findings would not have been enough here.

AI-assisted throughout: written with Claude (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added OpenClaw 2026.8.1 transcript semantics:
  - `currentTurnFence: "before-current-turn-entry-v1"`
  - `turnAdvancementIdempotency: "atomic-idempotent-v1"`
- Added `commitTurn()` with atomic, per-`advancementKey` idempotency.
- Concurrent calls with the same key share one durable ingestion operation.
- Keys are recorded only after durable ingestion succeeds.
- Durable ingestion failures propagate and remain retryable.
- Predictive compaction, caching, and embedding pre-warm failures remain best effort.
- Added bounded oldest-first key tracking with a maximum of 4096 entries.
- Repeated keys return `"duplicate"`.
- Added tests for concurrent calls, retries, and shared failure propagation.
- Added an internal ingestion-promise capture hook for `afterTurn`.
- Typecheck and build results are clean.

## Complexity

- Committed-key and in-flight-key lookups use average **O(1)** time.
- Key insertion and deletion are **O(1)** amortized.
- Bounded eviction is **O(1)** per evicted key, or **O(k)** for `k` evicted keys.
- Concurrent duplicate calls use **O(1)** additional state per active key.
- Committed-key state uses **O(min(n, 4096))** space, where `n` is the number of unique advancement keys.
- `commitTurn()` has higher cyclomatic complexity because it handles duplicate detection, in-flight coordination, durable failure propagation, retry cleanup, and successful commit recording.
- `afterTurn()` has higher cyclomatic complexity because it separates durable ingestion from best-effort post-ingest work and captures ingestion outcomes.
- Async ingestion queue handling adds branching for task outcome reporting while keeping queue chains non-rejecting.

## Caveats

- An OpenClaw receipt-path issue can still prevent ingestion.
- `commitTurn()` and `afterTurn()` have not yet been observed under the Codex app-server runtime.
- `acceptedHostParams` remains undeclared separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
