### PR TITLE
fix: rename the plugin CLI root from 'memory' to 'libravdb' to stop colliding with core

### DIFF
--- a/POTENTIAL_BUGS.md
+++ b/POTENTIAL_BUGS.md
@@ -114,7 +114,7 @@ last user message if it exists in the new slice.
 
 ## Diagnostic commands
 
-- `openclaw memory status` — current counts, profile, sidecar health
+- `openclaw libravdb status` — current counts, profile, sidecar health
 - `libravdbd status -v --json` — daemon health, cache stats, tenant registry
 - `libravdbd search -k 30 -tenant <key> "query"` — see what the DB has
 - `ls -lt ~/.openclaw/libravdb-manifests/*.manifest.json | head -5` — see

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ brew tap xDarkicex/homebrew-openclaw-libravdb-memory && brew install libravdbd &
 openclaw plugins install @xdarkicex/openclaw-memory-libravdb
 
 # 3. Verify
-openclaw memory status
+openclaw libravdb status
 ```
 
 > ⚡ **Done.** Your agent has persistent vector memory, identity tracking, and causal graph reasoning.
@@ -157,7 +157,7 @@ openclaw plugins list | grep libravdb
 Verify the service and plugin:
 
 ```bash
-openclaw memory status
+openclaw libravdb status
 ```
 
 Healthy output should show `Kernel=running`, stored memory counts, the active
@@ -402,13 +402,13 @@ Before exposing OpenClaw over remote channels, read [Security](./docs/security.m
 ## Operator Quick Refs
 
 ```bash
-openclaw memory status [--deep] [--json]
-openclaw memory index --force
-openclaw memory search "prior context"
-openclaw memory export --user-id <userId>
-openclaw memory flush --user-id <userId>
-openclaw memory journal --limit 50
-openclaw memory dream-promote --user-id <userId> --dream-file ~/DREAMS.md
+openclaw libravdb status [--deep] [--json]
+openclaw libravdb index --force
+openclaw libravdb search "prior context"
+openclaw libravdb export --user-id <userId>
+openclaw libravdb flush --user-id <userId>
+openclaw libravdb journal --limit 50
+openclaw libravdb dream-promote --user-id <userId> --dream-file ~/DREAMS.md
 ```
 
 ### memory kernel CLI (libravdbd v1.6.0+)
@@ -718,7 +718,7 @@ dream-related questions (e.g. "what did I dream about?").
 You can also promote manually without enabling the watcher:
 
 ```bash
-openclaw memory dream-promote --user-id <userId> --dream-file ~/DREAMS.md
+openclaw libravdb dream-promote --user-id <userId> --dream-file ~/DREAMS.md
 ```
 - **Embedding profiles** default to `nomic-embed-text-v1.5` with `bge-small-en-v1.5`
   fallback. See [Embedding profiles](./docs/embedding-profiles.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,7 +105,7 @@ Automatic diary watching:
 Manual run:
 
 ```bash
-openclaw memory dream-promote --user-id <userId> --dream-file ~/DREAMS.md
+openclaw libravdb dream-promote --user-id <userId> --dream-file ~/DREAMS.md
 ```
 
 Dream diary files must live under the operator's home directory or the configured
@@ -114,20 +114,20 @@ promotion RPC, so admission gates and provenance metadata are identical.
 
 ## Memory CLI
 
-The plugin registers `openclaw memory` commands when the host exposes the plugin
+The plugin registers `openclaw libravdb` commands when the host exposes the plugin
 CLI API.
 
 | Command | Purpose |
 |---|---|
-| `openclaw memory status` | Show vector service health, counts, active thresholds, and model readiness. Use `--deep` to probe authored collection search health. |
-| `openclaw memory index --force` | Refresh delegated vector service index state for OpenClaw memory CLI compatibility. |
-| `openclaw memory search "query"` | Search LibraVDB memory through the active memory runtime bridge. |
-| `openclaw memory export --user-id <userId>` | Stream stored memories as newline-delimited JSON for one durable namespace. |
-| `openclaw memory export --session-key <sessionKey>` | Export a namespace derived from a session key. |
-| `openclaw memory flush --user-id <userId>` | Delete one durable user namespace after confirmation. |
-| `openclaw memory flush --session-key <sessionKey>` | Delete a namespace derived from a session key after confirmation. |
-| `openclaw memory journal --limit 50` | Inspect bounded lifecycle hints recorded by the vector service. |
-| `openclaw memory dream-promote --user-id <userId> --dream-file <path>` | Promote vetted dream diary bullets from a file under the operator home directory or `OPENCLAW_STATE_DIR`. |
+| `openclaw libravdb status` | Show vector service health, counts, active thresholds, and model readiness. Use `--deep` to probe authored collection search health. |
+| `openclaw libravdb index --force` | Refresh delegated vector service index state for OpenClaw memory CLI compatibility. |
+| `openclaw libravdb search "query"` | Search LibraVDB memory through the active memory runtime bridge. |
+| `openclaw libravdb export --user-id <userId>` | Stream stored memories as newline-delimited JSON for one durable namespace. |
+| `openclaw libravdb export --session-key <sessionKey>` | Export a namespace derived from a session key. |
+| `openclaw libravdb flush --user-id <userId>` | Delete one durable user namespace after confirmation. |
+| `openclaw libravdb flush --session-key <sessionKey>` | Delete a namespace derived from a session key after confirmation. |
+| `openclaw libravdb journal --limit 50` | Inspect bounded lifecycle hints recorded by the vector service. |
+| `openclaw libravdb dream-promote --user-id <userId> --dream-file <path>` | Promote vetted dream diary bullets from a file under the operator home directory or `OPENCLAW_STATE_DIR`. |
 
 Use `--yes` with `flush` only when you intentionally want to skip the
 confirmation prompt.

--- a/docs/install.md
+++ b/docs/install.md
@@ -238,7 +238,7 @@ vector service supervision as separate lifecycle decisions.
 After the plugin and vector service are both in place, run:
 
 ```bash
-openclaw memory status
+openclaw libravdb status
 ```
 
 Healthy output should show that:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ Assign `libravdb-memory` to the OpenClaw memory and context-engine slots:
 }
 ```
 
-The memory slot owns `openclaw memory ...` and memory-runtime calls. The
+The memory slot owns `openclaw libravdb ...` and memory-runtime calls. The
 context-engine slot enables automatic bootstrap, ingest, after-turn, and recall
 hooks during sessions.
 
@@ -178,7 +178,7 @@ database aside first, then let the vector service create a fresh ONNX-backed sto
 Run:
 
 ```bash
-openclaw memory status
+openclaw libravdb status
 ```
 
 Expected output shape:
@@ -219,7 +219,7 @@ Common causes:
 Check the vector service first:
 
 ```bash
-openclaw memory status
+openclaw libravdb status
 brew services restart libravdbd
 ```
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -95,6 +95,16 @@ delete during uninstall.
 
 ## 5. Post-Uninstall Check
 
-After cleanup, `openclaw libravdb status` should no longer show this plugin as the
-active memory provider, and the vector service endpoint should no longer be reachable
-unless you intentionally kept it running for another workflow.
+Do **not** verify with `openclaw libravdb status`. The plugin only registers its CLI when it
+owns the memory slot, so after a successful uninstall that command is simply unknown — an
+"unknown command" error is the expected result, not a status report. (Before the CLI root was
+renamed this check was worse: `openclaw memory status` fell through to OpenClaw's own `memory`
+command and appeared to succeed, falsely confirming an uninstall that had not happened.)
+
+Check two things instead:
+
+1. **The slot is released.** `plugins.slots.memory` in `~/.openclaw/openclaw.json` should no
+   longer be `libravdb-memory`, and `openclaw plugins list` should no longer show the plugin as
+   enabled.
+2. **The vector service is gone.** Probe the endpoint from your config directly — it should refuse
+   the connection, unless you intentionally kept the daemon running for another workflow.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -95,6 +95,6 @@ delete during uninstall.
 
 ## 5. Post-Uninstall Check
 
-After cleanup, `openclaw memory status` should no longer show this plugin as the
+After cleanup, `openclaw libravdb status` should no longer show this plugin as the
 active memory provider, and the vector service endpoint should no longer be reachable
 unless you intentionally kept it running for another workflow.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -29,7 +29,7 @@
   },
   "activation": {
     "onCommands": [
-      "memory"
+      "libravdb"
     ]
   },
   "configSchema": {

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -470,7 +470,7 @@ verify_openclaw_memory_status_with_retry() {
     return 0
   fi
   for ((i=1; i<=attempts; i++)); do
-    if openclaw memory status >/dev/null 2>&1; then
+    if openclaw libravdb status >/dev/null 2>&1; then
       info "OpenClaw memory status passed on attempt ${i}/${attempts}."
       return 0
     fi
@@ -532,7 +532,7 @@ This script will:
 1) Install and start the local 'libravdbd' daemon.
 2) Install the OpenClaw plugin package '${PLUGIN_PACKAGE}'.
 3) Update '${HOME}/.openclaw/openclaw.json' so both plugin slots use '${PLUGIN_ID}'.
-4) Run 'openclaw memory status' to verify connectivity.
+4) Run 'openclaw libravdb status' to verify connectivity.
 
 No task/memory/spec databases in this repository are modified by this installer.
 EOF
@@ -569,7 +569,7 @@ Daemon: ${daemon_bin:-not-found} (${daemon_version})
 Plugin package: ${PLUGIN_PACKAGE}
 Config file: ${HOME}/.openclaw/openclaw.json
 Config backup: ${LAST_CONFIG_BACKUP:-not-created}
-Next check: openclaw memory status
+Next check: openclaw libravdb status
 EOF
 }
 
@@ -823,15 +823,15 @@ main() {
     warn "Skipped openclaw.json update. You must set plugin slots manually."
   fi
 
-  info "Verifying installation with: openclaw memory status"
+  info "Verifying installation with: openclaw libravdb status"
   if verify_openclaw_memory_status_with_retry; then
     if [[ "$DRY_RUN" -eq 0 ]]; then
-      openclaw memory status
+      openclaw libravdb status
     fi
     print_summary
   else
     warn "Verification reported an error."
-    warn "Check daemon status and sidecar endpoint in ~/.openclaw/openclaw.json, then rerun: openclaw memory status"
+    warn "Check daemon status and sidecar endpoint in ~/.openclaw/openclaw.json, then rerun: openclaw libravdb status"
     exit 1
   fi
 }

--- a/src/cli-descriptors.ts
+++ b/src/cli-descriptors.ts
@@ -3,7 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 export const PLUGIN_ID = "libravdb-memory";
 
 export const MEMORY_CLI_DESCRIPTOR = {
-  name: "memory",
+  name: "libravdb",
   description: "Manage LibraVDB memory",
   hasSubcommands: true,
 } as const;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,11 +109,11 @@ export function registerMemoryCli(
 
   api.registerCli(
     ({ program }) => {
-      const root = ensureCommand(program, "memory")
+      const root = ensureCommand(program, "libravdb")
         .description("Manage LibraVDB memory");
 
       if (!isFullMode) {
-        // Non-full modes register structure only so `openclaw memory --help` works.
+        // Non-full modes register structure only so `openclaw libravdb --help` works.
         // No runtime available — do not attach action handlers.
         ensureCommand(root, "status").description("Show sidecar health, record counts, and active thresholds");
         ensureCommand(root, "index").description("Rebuild LibraVDB memory vector index (requires --force)");

--- a/test/integration/checklist-validation.test.ts
+++ b/test/integration/checklist-validation.test.ts
@@ -16,7 +16,7 @@ test("manifest and package metadata satisfy checklist structure", async () => {
     Object.keys(manifest).sort(),
     ["activation", "configSchema", "contracts", "description", "id", "kind", "name", "version"],
   );
-  assert.deepEqual(manifest.activation, { onCommands: ["memory"] });
+  assert.deepEqual(manifest.activation, { onCommands: ["libravdb"] });
   assert.equal(manifest.version, pkg.version);
   assert.deepEqual(manifest.contracts.tools, [
     "libravdb_memory_search",

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -103,6 +103,12 @@ function buildMemoryCommand(runtime: PluginRuntime, cfg: PluginConfig = {}): Fak
 
   const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
+  // The point of the rename: this plugin must not claim the root that OpenClaw core owns.
+  assert.equal(
+    program.commands.find((command) => command.name() === "memory"),
+    undefined,
+    "plugin must not register a root named 'memory' — core owns it",
+  );
   return memory;
 }
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -101,7 +101,7 @@ function buildMemoryCommand(runtime: PluginRuntime, cfg: PluginConfig = {}): Fak
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
   return memory;
 }
@@ -120,7 +120,7 @@ test("CLI metadata registers the memory descriptor only when LibraVDB owns the m
   assert.equal(registered.length, 1);
   assert.deepEqual(registered[0]?.opts?.descriptors, [
     {
-      name: "memory",
+      name: "libravdb",
       description: "Manage LibraVDB memory",
       hasSubcommands: true,
     },
@@ -152,7 +152,7 @@ test("full CLI registration exposes standard memory commands and LibraVDB operat
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
   assert.deepEqual(
     memory.commands.map((command) => command.name()),
@@ -297,7 +297,7 @@ test("status command shuts the plugin runtime down after printing status", async
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
   const status = memory.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
@@ -351,7 +351,7 @@ test("status --index requires --force before rebuilding", async () => {
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const status = memory?.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
 
@@ -423,7 +423,7 @@ test("status --index --force rebuilds before printing status", async () => {
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const status = memory?.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
 
@@ -501,7 +501,7 @@ test("search command applies the status gate threshold by default", async () => 
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const search = memory?.commands.find((command) => command.name() === "search");
   assert.ok(search?.handler);
 
@@ -567,7 +567,7 @@ test("search command honors an explicit min-score below the default threshold", 
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const search = memory?.commands.find((command) => command.name() === "search");
   assert.ok(search?.handler);
 
@@ -625,7 +625,7 @@ test("status --deep probes authored collection search health", async () => {
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const status = memory?.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
 
@@ -691,7 +691,7 @@ test("status --deep reports invalid user collection without probing it", async (
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const status = memory?.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
 
@@ -760,7 +760,7 @@ test("status --deep includes authored probe rows in table output", async () => {
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const status = memory?.commands.find((command) => command.name() === "status");
   assert.ok(status?.handler);
 
@@ -831,7 +831,7 @@ test("index command uses an extended timeout for rebuild_index", async () => {
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   const index = memory?.commands.find((command) => command.name() === "index");
   assert.ok(index?.handler);
 
@@ -864,7 +864,7 @@ test("non-full CLI registration exposes command structure without action handler
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
   assert.deepEqual(
     memory.commands.map((command) => command.name()),
@@ -913,7 +913,7 @@ test("discovery registration exposes runtime-backed memory commands for lazy CLI
   const program = new FakeCommand("openclaw");
   cli.builder({ program });
 
-  const memory = program.commands.find((command) => command.name() === "memory");
+  const memory = program.commands.find((command) => command.name() === "libravdb");
   assert.ok(memory);
 
   const status = memory.commands.find((command) => command.name() === "status");


### PR DESCRIPTION
Fixes xDarkicex/homebrew-openclaw-libravdb-memory#6

## Problem

OpenClaw core registers a `memory` CLI command. This plugin registers the same root, and core wins. Three consequences on a current host (measured on 2026.8.1):

1. **Four core subcommands are shadowed** — `openclaw memory index|promote|promote-explain|rem-backfill|rem-harness` were unreachable while this plugin was enabled.
2. **The plugin's own CLI is unreachable** — none of `status|index|search|flush|export|journal|dream-promote` can be invoked.
3. **Every gateway startup logs an error:**

```
[plugins] cli command already registered: memory (memory-core)
  (plugin=libravdb-memory, source=.../@xdarkicex/openclaw-memory-libravdb/dist/index.js)
```

## What this changes

Renames the CLI root to `libravdb` in **both** places that declare it — they have to agree, because the host uses the descriptor for collision detection and the builder for the actual command tree:

- `src/cli-descriptors.ts` — `MEMORY_CLI_DESCRIPTOR.name`
- `src/cli.ts` — `ensureCommand(program, …)`

and the three things that follow from it:

- `openclaw.plugin.json` — `activation.onCommands: ["memory"] → ["libravdb"]`, so lazy activation still triggers on the command that now exists
- `test/unit/cli.test.ts`, `test/integration/checklist-validation.test.ts` — the assertions that pin the root
- 33 references across `README.md`, `docs/*`, `POTENTIAL_BUGS.md` and `scripts/auto-install.sh`

**Deliberately unchanged**, because they are capability, slot and tool identifiers rather than the CLI namespace: `kind: ["memory", "context-engine"]`, `contracts.memory`, `plugins.slots.memory`, and the `memory_describe` / `memory_expand` / `libravdb_memory_*` tool names.

`libravdb` is a suggestion, not a demand — it matches `libravdbd`, the package name and the tool prefix. Rename it to whatever you prefer; the point is that the two declaration sites agree and neither is `memory`.

## ⚠️ This is a breaking CLI rename

Plugin commands move from `openclaw memory …` to `openclaw libravdb …`. Shell scripts, aliases, runbooks and monitoring checks need updating. A compatibility alias under `memory` is not viable, since that root is the collision being fixed.

Also worth coordinating: `scripts/auto-install.sh` now verifies with `openclaw libravdb status`. It installs the unversioned package, so if the script ships before the matching npm release it would install an older plugin that only registers `memory` and then fail verification. Pinning a minimum version there may be worth doing separately — I have not done it in this PR.

## Evidence

**Both declarations agree in the built bundle:**

```
$ tsc -p tsconfig.build.json && node scripts/bundle-entrypoint.mjs
$ grep -o 'MEMORY_CLI_DESCRIPTOR = {\s*name: "[a-z]*"' dist/index.js   → libravdb
$ grep -o 'ensureCommand(program, "[a-z]*")'            dist/index.js   → libravdb
$ grep -c 'ensureCommand(program, "memory")'            dist/index.js   → 0
```

**The startup collision is gone.** Installed the built bundle on a disposable OpenClaw 2026.8.1 profile with `plugins.slots.memory = libravdb-memory` and started a gateway:

```
$ grep -c "cli command already registered" gateway.log
0
LibraVDB registering mode=full
http server listening (14 plugins …)
```

Before this change the same startup logged the collision every time.

**Core's `memory` is fully unshadowed** — all core subcommands are reachable again with the plugin enabled:

```
$ openclaw memory --help
Usage: openclaw memory [options] [command]
Search, inspect, and reindex memory files
Commands:
  index             Reindex memory files
  promote           Rank short-term recalls and optionally append top entries to MEMORY.md
  promote-explain   Explain a specific promotion candidate and its score breakdown
  rem-backfill      Write grounded historical REM summaries into DREAMS.md for UI review
  rem-harness       Preview REM reflections, candidate truths, and deep …
```

**Tests:** `tsc --noEmit` clean; `test/unit/cli.test.ts` 15 pass / 0 fail; `checklist-validation` 0 fail.

⚠️ **Two `context-engine` unit tests fail — but they fail identically on unmodified `main`**, verified by stashing this change and re-running (89 pass / 2 fail both ways). They are unrelated to this PR.

## What I could not verify

I could **not** confirm `openclaw libravdb …` resolving end-to-end on my host. Reaching the plugin's CLI requires the `./dist/cli-metadata.js` entry, and with both entries listed my host's OpenClaw assigns the plugin an entry-scoped id (`libravdb-memory/index`), which breaks slot matching for unrelated reasons — so the plugin CLI was unreachable there before and after this change. What I have demonstrated is that the collision disappears, core is unshadowed, and both declaration sites now agree. If you can test the resolved command tree on a clean install, that is the gap worth closing.

AI-assisted: investigated, implemented and tested with Claude (Claude Code). Two adversarial review passes; the first found that `openclaw.plugin.json` and the tests were missed, which is why they are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Renames the plugin CLI root from `memory` to `libravdb` to remove the collision with OpenClaw core.

- Updates CLI registration, activation, command building, tests, scripts, and documentation.
- Preserves capability identifiers, plugin slots, contracts, tool names, and subcommand behavior.
- Restores access to OpenClaw core `memory` commands.
- TypeScript checks and relevant tests pass.
- End-to-end `openclaw libravdb …` resolution remains unverified because of an unrelated entry-scoped plugin ID issue.

## Complexity

- Big O complexity: unchanged. The changes rename command strings and do not alter command-processing algorithms.
- Cyclomatic complexity: unchanged. No new branches or control-flow paths were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->