### PR TITLE
fix: stop the context-engine unit tests reading and writing live state

### DIFF
--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -13,18 +13,45 @@ import type { PluginRuntime } from "../../src/plugin-runtime.js";
 import type { LibravDBClient } from "../../src/libravdb-client.js";
 
 // ---------------------------------------------------------------------------
-// Clean persisted turn manifests from prior test runs so each run starts
-// with a blank manifest store.
+// Isolate persisted turn manifests for this file.
+//
+// TurnManifestStore writes to $OPENCLAW_STATE_DIR, falling back to the real
+// ~/.openclaw, so these tests read and wrote the developer's live state. The
+// cleanup this replaces tried to contain that by deleting entries prefixed
+// "s1", "conformance-" or "session-", but the store names files
+// sha256(sessionId) + ".manifest.json" -- and none of those prefixes are valid
+// hex, so it never matched anything it had written. Manifests therefore
+// survived between runs, and the two afterTurn tests that expect a fresh
+// session saw their content already covered, reporting "no-new-messages"
+// instead of "queued" on every run after the first.
+//
+// Point the store at a per-process temp directory instead. Nothing outside the
+// test is read or written, and every run starts empty. Set unconditionally: an
+// inherited OPENCLAW_STATE_DIR would reintroduce exactly the cross-run carryover
+// this exists to prevent.
+//
+// Note what those two tests were accidentally reproducing: a manifest that
+// survives while the daemon has no record of the session. The preflight answers
+// "no-new-messages" from the manifest alone without contacting the daemon, so a
+// turn carrying nothing new cannot notice the daemon is empty. A turn with new
+// content does reach the daemon and does trigger the cursor-gap repair, so the
+// state is detected rather than permanent. What the repair then does is the part
+// worth a second look, and it is deliberately not addressed here: a broken
+// assertion in an unrelated test is not coverage of it, and any fix belongs with
+// the repair path rather than with test hygiene.
 // ---------------------------------------------------------------------------
 {
-  const manifestDir = path.join(os.homedir(), ".openclaw", "libravdb-manifests");
-  if (fs.existsSync(manifestDir)) {
-    for (const entry of fs.readdirSync(manifestDir)) {
-      if (entry.startsWith("s1") || entry.startsWith("conformance-") || entry.startsWith("session-")) {
-        fs.rmSync(path.join(manifestDir, entry));
-      }
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "libravdb-unit-state-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  // Best effort: "exit" does not run for signals or a hard crash, so an
+  // interrupted run can leave one directory behind under the OS temp root.
+  process.on("exit", () => {
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      // A leftover temp dir must never fail the run.
     }
-  }
+  });
 }
 
 /**


### PR DESCRIPTION
## Problem

The `context-engine` unit tests read and write the developer's **real** `~/.openclaw`, and two of them fail on every run after the first:

```
✖ context engine afterTurn resolves config userId and passes messages to daemon
✖ context engine afterTurn does not block on daemon ingestion
```

Both expect `{ ok: true, queued: true }` and get `{ ok: true, skipped: true, reason: "no-new-messages" }`.

The suite only passes on a machine that has never run it before. That makes them look like a product bug in `afterTurn`, and it means anyone running the suite locally silently accumulates test manifests in their own state directory — 24 per run.

## Cause

`TurnManifestStore.getManifestDir()` resolves `$OPENCLAW_STATE_DIR` and falls back to the real home directory (`src/manifest.ts`):

```ts
const stateRoot = process.env.OPENCLAW_STATE_DIR?.trim();
return path.join(stateRoot || path.join(os.homedir(), ".openclaw"), "libravdb-manifests");
```

The test file already tried to contain this, deleting entries before each run:

```ts
if (entry.startsWith("s1") || entry.startsWith("conformance-") || entry.startsWith("session-")) {
```

**That cleanup can never match a file the tests wrote.** `getManifestPath` names files `sha256(sessionId) + ".manifest.json"`, and `s`, `o`, `n`, `r`, `m` and `-` are not hexadecimal — no digest can begin with any of those three prefixes. So it was a no-op that read the user's home directory on every run and deleted nothing.

Manifests therefore persisted between runs. On the second run the two tests above find their session's manifest already on disk, the preflight overlap check finds nothing new, and `afterTurn` correctly reports `no-new-messages` instead of `queued`.

## What this PR does

Points the store at a per-process temp directory for this test file, removed on exit as a best effort. Nothing outside the test is read or written and every run starts empty.

It is set unconditionally: an inherited `OPENCLAW_STATE_DIR` would reintroduce exactly the cross-run carryover this exists to prevent.

## Evidence

Before, on a machine that has run the suite once:

```
$ node --test .ts-build/test/unit/context-engine.test.js
✖ context engine afterTurn resolves config userId and passes messages to daemon
✖ context engine afterTurn does not block on daemon ingestion
```

After, same machine, run twice in a row:

```
run 1, full unit suite (23 files)   0 failures
run 2, full unit suite (23 files)   0 failures
~/.openclaw/libravdb-manifests      1208 before, 1208 after
```

Confirming the diagnosis rather than assuming it — the failures follow the state directory, not the code:

```
empty OPENCLAW_STATE_DIR, unpatched source   0 failures
second run against that same dir             the exact 2 failures above
```

## The state these tests were failing in

Worth a second look on its own, and deliberately **not** addressed here.

They were failing against a manifest that survives while the daemon has lost the session. The preflight answers `no-new-messages` from the manifest alone, so a turn carrying nothing new cannot notice the daemon is empty. A turn with new content *does* reach the daemon and *does* trigger the cursor-gap repair, so the state is detected rather than permanent.

It is what that repair then does that deserves attention. It re-seeds from the messages it was handed and writes a manifest containing exactly those. Under the current turn-only `commitTurn` contract that is just the closing turn, so both sides end up agreeing on a session that begins there — with the earlier history absent from each and no later turn able to detect it.

A failing assertion in an unrelated test is not coverage of that, and any fix belongs with the repair path rather than with test hygiene. Raising it here only so it is not lost.

## Notes

AI-assisted: written with Claude (Claude Code). Reviewed adversarially before filing; the split-brain observation above came out of that review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Isolates `context-engine` tests with a per-process temporary `OPENCLAW_STATE_DIR`.
- Removes the previous cleanup logic for `~/.openclaw` manifest files.
- Cleans up the temporary state directory on process exit on a best-effort basis.
- Prevents persisted manifests from affecting repeated test runs.
- Does not address the separate split-brain synchronization bug.

## Complexity

- No Big O complexity regression.
- No cyclomatic complexity regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
