### PR TITLE
fix: stop afterTurn silently losing ingestion durability

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2738,7 +2738,13 @@ export function buildContextEngineFactory(
       predictiveContextCache.delete(sessionId);
       postToolRecallCache.delete(sessionId);
       turnCache.invalidateSession(sessionId);
-      asyncIngestionQueues.delete(sessionId);
+      // Deliberately NOT clearing asyncIngestionQueues here. The queue entry is
+      // the per-session serialization point, and bootstrap can run while an
+      // ingestion from the previous turn is still in flight. Dropping the entry
+      // lets the next enqueueAsyncIngestion start from a fresh Promise.resolve()
+      // and run concurrently with the task it just orphaned, so two tasks load
+      // the same manifest, compute the same overlap and both ingest. Entries
+      // remove themselves once settled, so there is nothing to clean up.
       const userId = resolveUserId({
         userIdOverride: args.userId,
         sessionKey: args.sessionKey,
@@ -3447,15 +3453,27 @@ export function buildContextEngineFactory(
               // Normal path: reconcile to what the daemon actually confirmed.
               const confirmedIndex = daemonCursor.lastProcessedIndex;
               const ackCount = Math.max(0, confirmedIndex - startIndex + 1);
-              if (ackCount > 0) {
-                const ackedMessages = ingestMessages.slice(0, ackCount);
-                const updatedManifest = manifestStore.appendACKedMessages(
-                  manifest,
-                  ackedMessages,
-                  startIndex,
+              if (ackCount === 0) {
+                // The cursor the daemon returned sits before this batch, so it
+                // confirmed none of these messages. Falling through here left
+                // the manifest un-advanced with no diagnostic, so the same
+                // messages were re-sent on every subsequent turn and the
+                // session could never make progress. Fail instead: the catch
+                // below turns this into the same warning every other ingest
+                // failure produces, and skips the post-ingest best-effort work
+                // that would otherwise run for a turn that was never stored.
+                throw new Error(
+                  `[LibraVDB] Daemon confirmed no messages for session ${sessionId} ` +
+                  `(lastProcessedIndex=${confirmedIndex}, batch started at ${startIndex}).`,
                 );
-                manifestStore.save(updatedManifest);
               }
+              const ackedMessages = ingestMessages.slice(0, ackCount);
+              const updatedManifest = manifestStore.appendACKedMessages(
+                manifest,
+                ackedMessages,
+                startIndex,
+              );
+              manifestStore.save(updatedManifest);
             }
           } else if (!repairedCursorGap && ingestMessages.length > 0) {
             // Legacy daemon (no cursor in response): optimistic ACK.

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3317,3 +3317,115 @@ test("excludeSubagents off by default: a subagent is granted a normal expansion 
   );
 
 });
+
+// ---------------------------------------------------------------------------
+// Ingestion durability.
+//
+// afterTurn's queued task is the only thing that makes a turn durable, and both
+// tests below cover ways it could quietly fail to: reporting a batch as ingested
+// that the daemon never confirmed, and losing the per-session serialization that
+// keeps two tasks from ingesting the same messages twice.
+// ---------------------------------------------------------------------------
+
+/** Lets queued ingestion tasks advance without depending on wall-clock timing. */
+async function tick(times = 3): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}
+
+test("afterTurn fails loudly when the daemon confirms none of the batch", async () => {
+  const client = new FakeClient();
+  // lastProcessedIndex sits before this batch, so the daemon has confirmed
+  // none of it and there is nothing to append to the manifest.
+  client.afterTurnResponse = {
+    ok: true,
+    turnCount: 1,
+    cursor: { lastProcessedIndex: -1, sessionVersion: 1, manifestTailHash: "deadbeef" },
+  };
+  const warnings: string[] = [];
+  const logger = {
+    error: () => {},
+    info: () => {},
+    warn: (message: string) => { warnings.push(message); },
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, logger);
+
+  await engine.afterTurn({
+    sessionId: "s1-unconfirmed-batch",
+    sessionKey: "sk-unconfirmed-batch",
+    messages: [makeMessage("user", "unconfirmed"), makeMessage("assistant", "reply")],
+  });
+  await flushIngestion(engine);
+
+  assert.ok(
+    warnings.some((w) => /Daemon confirmed no messages/.test(w)),
+    `an unconfirmed batch must be reported, got: ${JSON.stringify(warnings)}`,
+  );
+
+  // Absence assertion: the post-ingest best-effort steps must not run for a
+  // turn that was never stored. prewarmEmbeddingCache is the observable one.
+  assert.equal(
+    client.calls.filter((c) => c.method === "searchTextCollections").length,
+    0,
+    "post-ingest work ran for a turn the daemon did not confirm",
+  );
+});
+
+test("bootstrap does not orphan an ingestion that is still in flight", async () => {
+  const client = new FakeClient();
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const releases: Array<() => void> = [];
+  (client as unknown as {
+    afterTurnKernel: (params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  }).afterTurnKernel = async (params) => {
+    client.calls.push({ method: "afterTurnKernel", params });
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise<void>((resolve) => { releases.push(resolve); });
+    inFlight -= 1;
+    return { ok: true, turnCount: 1 };
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const sessionId = "s1-bootstrap-orphan";
+  const sessionKey = "sk-bootstrap-orphan";
+
+  await engine.afterTurn({
+    sessionId,
+    sessionKey,
+    messages: [makeMessage("user", "a"), makeMessage("assistant", "b")],
+  });
+  await tick();
+  assert.equal(releases.length, 1, "the first ingestion should be in flight");
+
+  // bootstrap runs on a session whose previous turn is still ingesting.
+  await engine.bootstrap({ sessionId, sessionKey });
+
+  await engine.afterTurn({
+    sessionId,
+    sessionKey,
+    messages: [
+      makeMessage("user", "a"),
+      makeMessage("assistant", "b"),
+      makeMessage("user", "c"),
+      makeMessage("assistant", "d"),
+    ],
+  });
+  await tick();
+
+  // The queue entry is the per-session serialization point. Dropping it lets
+  // this second task start from a fresh promise and run alongside the first,
+  // so both load the same manifest and ingest overlapping messages.
+  assert.equal(
+    maxInFlight,
+    1,
+    "bootstrap orphaned the in-flight ingestion and a second one ran concurrently",
+  );
+
+  for (let i = 0; i < 5 && releases.length > 0; i += 1) {
+    releases.shift()?.();
+    await tick();
+  }
+  await flushIngestion(engine);
+});

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -13,18 +13,45 @@ import type { PluginRuntime } from "../../src/plugin-runtime.js";
 import type { LibravDBClient } from "../../src/libravdb-client.js";
 
 // ---------------------------------------------------------------------------
-// Clean persisted turn manifests from prior test runs so each run starts
-// with a blank manifest store.
+// Isolate persisted turn manifests for this file.
+//
+// TurnManifestStore writes to $OPENCLAW_STATE_DIR, falling back to the real
+// ~/.openclaw, so these tests read and wrote the developer's live state. The
+// cleanup this replaces tried to contain that by deleting entries prefixed
+// "s1", "conformance-" or "session-", but the store names files
+// sha256(sessionId) + ".manifest.json" -- and none of those prefixes are valid
+// hex, so it never matched anything it had written. Manifests therefore
+// survived between runs, and the two afterTurn tests that expect a fresh
+// session saw their content already covered, reporting "no-new-messages"
+// instead of "queued" on every run after the first.
+//
+// Point the store at a per-process temp directory instead. Nothing outside the
+// test is read or written, and every run starts empty. Set unconditionally: an
+// inherited OPENCLAW_STATE_DIR would reintroduce exactly the cross-run carryover
+// this exists to prevent.
+//
+// Note what those two tests were accidentally reproducing: a manifest that
+// survives while the daemon has no record of the session. The preflight answers
+// "no-new-messages" from the manifest alone without contacting the daemon, so a
+// turn carrying nothing new cannot notice the daemon is empty. A turn with new
+// content does reach the daemon and does trigger the cursor-gap repair, so the
+// state is detected rather than permanent. What the repair then does is the part
+// worth a second look, and it is deliberately not addressed here: a broken
+// assertion in an unrelated test is not coverage of it, and any fix belongs with
+// the repair path rather than with test hygiene.
 // ---------------------------------------------------------------------------
 {
-  const manifestDir = path.join(os.homedir(), ".openclaw", "libravdb-manifests");
-  if (fs.existsSync(manifestDir)) {
-    for (const entry of fs.readdirSync(manifestDir)) {
-      if (entry.startsWith("s1") || entry.startsWith("conformance-") || entry.startsWith("session-")) {
-        fs.rmSync(path.join(manifestDir, entry));
-      }
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "libravdb-unit-state-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  // Best effort: "exit" does not run for signals or a hard crash, so an
+  // interrupted run can leave one directory behind under the OS temp root.
+  process.on("exit", () => {
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      // A leftover temp dir must never fail the run.
     }
-  }
+  });
 }
 
 /**


### PR DESCRIPTION
Depends on #374. This branch is stacked on it, so the diff shown here contains that PR's commit as well — **review only the second commit**, `fix: stop afterTurn silently losing ingestion durability`. Its tests need #374's state isolation to be reproducible. Rebasing once #374 lands will reduce this to a single commit.

## Problem

Two independent ways the queued ingestion task can fail to make a turn durable without saying so.

**1. A batch the daemon confirmed none of is treated as ingested.**

When the daemon returns a cursor whose `lastProcessedIndex` sits before the batch just sent, it has confirmed none of those messages. The reconciliation computes `ackCount = 0` and falls straight through its guard:

```ts
const ackCount = Math.max(0, confirmedIndex - startIndex + 1);
if (ackCount > 0) {
  // ...append to manifest
}
```

Nothing is appended, nothing is logged, and execution continues into the post-ingest steps. The manifest never advances, so the same messages are re-sent on every subsequent turn — indefinitely, with no diagnostic explaining why the session makes no progress.

**2. `bootstrap` orphans an ingestion that is still in flight.**

```ts
asyncIngestionQueues.delete(sessionId);
```

That entry is the per-session serialization point, and `bootstrap` can run while the previous turn is still ingesting. Dropping it lets the next `enqueueAsyncIngestion` start from a fresh `Promise.resolve()` and run alongside the task it just orphaned. Both then load the same manifest, compute the same overlap, and ingest the same messages.

The delete is not needed for cleanup either — entries already remove themselves in a `.finally()` once settled.

## What this PR does

1. Throws when `ackCount === 0`. The existing `catch` reports it exactly as it reports every other ingest failure, and it stops execution reaching the post-ingest best-effort work for a turn that was never stored.
2. Leaves the queue entry alone in `bootstrap`.

## Evidence

Each new test fails only against its own fix, so neither is passing for the wrong reason:

```
reverting only the ackCount fix    ->  only "afterTurn fails loudly when the daemon confirms none of the batch" fails
reverting only the bootstrap fix   ->  only "bootstrap does not orphan an ingestion that is still in flight" fails
both reverted                      ->  both fail
patched, full unit suite (23 files)->  0 failures
```

The unconfirmed-batch test also asserts an absence — `prewarmEmbeddingCache` must not run for a turn the daemon did not confirm:

```ts
assert.equal(
  client.calls.filter((c) => c.method === "searchTextCollections").length,
  0,
  "post-ingest work ran for a turn the daemon did not confirm",
);
```

The concurrency test is deterministic rather than timing-dependent: ordering is controlled by explicit unresolved promises, with `setImmediate` used only to let already-scheduled continuations run. It asserts maximum observed concurrency is 1; without the fix it is 2.

## Risk

The throw is the higher-risk half, so it was checked against every path where `ackCount` could legitimately be 0:

- **Seed ingest / first turn / empty manifest** — `startIndex` is explicitly `0`, so zero ACK requires the daemon to return `lastProcessedIndex < 0` alongside a non-empty tail hash, which does mean nothing was acknowledged.
- **Cursor-gap repair** — a missing or empty `manifestTailHash` takes the repair branch earlier and never reaches this code.
- **Legacy daemon** — no cursor in the response takes the optimistic-ACK branch; unreachable.
- **Heartbeat turns** — same protocol; no new messages is handled by preflight before ingestion.
- **Excluded sessions** — return before anything is queued.
- **Incremental ingest** — `startIndex` always derives from the manifest's last acknowledged index; `prePromptMessageCount` cannot move it once the manifest is non-empty.

## Notes

AI-assisted: written with Claude (Claude Code). Reviewed adversarially before filing.
