### PR TITLE
fix: remove cli-metadata from openclaw.extensions to stop bogus plugin ID derivation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "README.md",
     "HOOK.md",
     "index.js",
-    "cli-metadata.js",
     "openclaw.plugin.json",
     "package.json",
     "docs/",
@@ -31,8 +30,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./dist/index.js",
-      "./dist/cli-metadata.js"
+      "./dist/index.js"
     ],
     "compat": {
       "pluginApi": ">=2026.3.22",


### PR DESCRIPTION
## Problem

On OpenClaw `2026.8.x` (strict plugin verification), the gateway fails to start with:

```
plugins.slots.memory: plugin not found: libravdb-memory
```

Even though `libravdb-memory` is correctly configured in `plugins.entries` and `plugins.slots`.

## Root cause

`package.json` lists two entries in `openclaw.extensions`:

```json
"extensions": [
  "./dist/index.js",
  "./dist/cli-metadata.js"
]
```

OpenClaw iterates over `extensions` and derives a plugin ID from each entry. The first entry (`index.js`) resolves correctly to `libravdb-memory` via `openclaw.plugin.json`. The second entry (`cli-metadata.js`) causes the loader to register a bogus derived plugin ID (e.g. `libravdb-memory/cli-metadata`), which does not match any configured slot or entry.

On OpenClaw `2026.7.x` the loader tolerated this silently. On `2026.8.x` plugin verification is strict, so the mismatch blocks gateway startup.

## Fix

Remove `./dist/cli-metadata.js` from `openclaw.extensions`. The main entry (`index.ts`) already imports and calls `registerMemoryCliMetadata()` from `cli-descriptors.ts`, so CLI metadata is registered through the single main entry. The separate extension entry is redundant and harmful.

Also removed `cli-metadata.js` from the `files` array since it is no longer a separate extension entry point.

## Verification

- Applied the same fix locally on a production OpenClaw `2026.8.1-beta.2` gateway (agent: clanker).
- After patching `package.json` and restarting, `openclaw plugins doctor` passes, `libravdb-memory` loads at `1.10.21`, `openclaw memory status --deep` returns OK (87 memories), and memory search returns real hits.
- Discord and gateway probes remain green.

## Compatibility

No breaking change. `cli-metadata.js` is still built and shipped (it is imported by `index.ts` at the source level), just not declared as a separate plugin extension entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed `./dist/cli-metadata.js` from `openclaw.extensions` and the published `files` array.
- Kept CLI metadata registration through `index.ts` with `registerMemoryCliMetadata()`.
- Prevented OpenClaw 2026.8.x from deriving an invalid plugin ID.
- Preserved plugin discovery, loading, memory status, search, Discord probes, and gateway probes.
- Verified with OpenClaw 2026.8.1-beta.2.

## Complexity

- No algorithmic change. Big O complexity remains unchanged.
- No cyclomatic complexity regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->