### PR TITLE
fix: preserve compacted context across logical turns

### DIFF
--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -2887,7 +2887,7 @@ export function buildContextEngineFactory(
         };
       }
 
-      const assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
+      let assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
       let cachedCompactedProjection = compactedProjectionState.snapshots.get(sessionId);
       if (cachedCompactedProjection) {
         if (
@@ -2897,9 +2897,8 @@ export function buildContextEngineFactory(
             cachedCompactedProjection.sourceStartIndex,
           ) !== cachedCompactedProjection.boundarySignature
         ) {
-          compactedProjectionState.snapshots.delete(sessionId);
-          compactedProjectionSessions.delete(sessionId);
-          postToolRecallCache.delete(sessionId);
+          clearCompactedProjectionState(compactedProjectionState, sessionId);
+          assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
           cachedCompactedProjection = undefined;
         }
       }

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1160,6 +1160,33 @@ function hasCompactedSessionContext(text: string): boolean {
   return HAS_COMPACTED_SESSION_CONTEXT_RE.test(text);
 }
 
+function extractCompactedSessionContext(text: string): string | undefined {
+  return text.match(COMPACTED_SESSION_CONTEXT_RE)?.join("\n") || undefined;
+}
+
+type CompactedProjectionSnapshot = {
+  context: string;
+  sourceStartIndex: number;
+  boundarySignature: string;
+};
+
+export type CompactedProjectionState = {
+  snapshots: Map<string, CompactedProjectionSnapshot>;
+  lifecycleTokens: Map<string, object>;
+};
+
+export function createCompactedProjectionState(): CompactedProjectionState {
+  return { snapshots: new Map(), lifecycleTokens: new Map() };
+}
+
+export function clearCompactedProjectionState(
+  state: CompactedProjectionState,
+  sessionId: string,
+): void {
+  state.snapshots.delete(sessionId);
+  state.lifecycleTokens.delete(sessionId);
+}
+
 function sanitizeDaemonSystemPromptAddition(text: string): string {
   return demoteDaemonAuthoredContextBlocks(
     sanitizeToolCallPatterns(canonicalizeCompactedSessionContextBlocks(text)),
@@ -1323,6 +1350,20 @@ export function normalizeKernelMessages(
       return normalized;
     })
     .filter((message) => message.role === "user" || message.content.trim().length > 0);
+}
+
+function buildProjectionBoundarySignature(
+  messages: OpenClawCompatibleMessage[],
+  sourceStartIndex: number,
+): string {
+  // ponytail: OpenClaw histories are append-only; use a durable transcript
+  // revision instead if the host ever permits arbitrary mid-prefix edits.
+  const boundary = messages.slice(Math.max(0, sourceStartIndex - 4), sourceStartIndex);
+  return createHash("sha256").update(JSON.stringify({ sourceStartIndex, boundary: boundary.map((message) => ({
+    role: message.role,
+    content: message.content,
+    id: typeof message.id === "string" ? message.id : undefined,
+  })) })).digest("hex");
 }
 
 function buildBeforeTurnSignature(messages: OpenClawCompatibleMessage[]): string | null {
@@ -1976,6 +2017,7 @@ export function buildContextEngineFactory(
   runtime: PluginRuntime,
   cfg: PluginConfig,
   logger: LoggerLike = console,
+  compactedProjectionState: CompactedProjectionState = createCompactedProjectionState(),
 ) {
   if (cfg?.optimizationMemoCacheSize !== undefined) {
     setOptimizationMemoCacheSize(cfg.optimizationMemoCacheSize);
@@ -2062,6 +2104,30 @@ export function buildContextEngineFactory(
         `LibraVDB activated daemon-owned compacted projection sessionId=${sessionId} source=${source}`,
       );
     }
+  }
+
+  function rememberCompactedProjection(
+    sessionId: string,
+    context: string,
+    sourceStartIndex: number,
+    boundarySignature: string,
+  ): void {
+    const snapshots = compactedProjectionState.snapshots;
+    snapshots.delete(sessionId);
+    if (snapshots.size >= POST_TOOL_CACHE_MAX_SIZE) {
+      const oldest = snapshots.keys().next().value;
+      if (oldest !== undefined) snapshots.delete(oldest);
+    }
+    snapshots.set(sessionId, { context, sourceStartIndex, boundarySignature });
+  }
+
+  function getProjectionLifecycleToken(sessionId: string): object {
+    let token = compactedProjectionState.lifecycleTokens.get(sessionId);
+    if (!token) {
+      token = {};
+      compactedProjectionState.lifecycleTokens.set(sessionId, token);
+    }
+    return token;
   }
 
   function enforceAssembleBudget(
@@ -2650,6 +2716,7 @@ export function buildContextEngineFactory(
     tokenBudget?: number;
     currentTokenCount?: number;
   }): Promise<OpenClawCompatibleCompactResult> {
+    const lifecycleToken = getProjectionLifecycleToken(args.sessionId);
     const request = buildCompactSessionRequest(args);
     try {
       const client = await runtime.getClient();
@@ -2659,7 +2726,11 @@ export function buildContextEngineFactory(
         logger,
         ...(threshold != null ? { threshold } : {}),
       });
-      if (result.ok && result.compacted) {
+      if (
+        result.ok &&
+        result.compacted &&
+        compactedProjectionState.lifecycleTokens.get(args.sessionId) === lifecycleToken
+      ) {
         activateCompactedProjection(args.sessionId, "compact");
       }
       return result;
@@ -2813,7 +2884,24 @@ export function buildContextEngineFactory(
         };
       }
 
-      let compactionProjectionActive = compactedProjectionSessions.has(sessionId);
+      const assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
+      let cachedCompactedProjection = compactedProjectionState.snapshots.get(sessionId);
+      if (cachedCompactedProjection) {
+        if (
+          args.messages.length < cachedCompactedProjection.sourceStartIndex ||
+          buildProjectionBoundarySignature(
+            args.messages,
+            cachedCompactedProjection.sourceStartIndex,
+          ) !== cachedCompactedProjection.boundarySignature
+        ) {
+          compactedProjectionState.snapshots.delete(sessionId);
+          compactedProjectionSessions.delete(sessionId);
+          postToolRecallCache.delete(sessionId);
+          cachedCompactedProjection = undefined;
+        }
+      }
+      let compactionProjectionActive =
+        compactedProjectionSessions.has(sessionId) || cachedCompactedProjection !== undefined;
 
       const userId = resolveUserId({
         userIdOverride: args.userId,
@@ -2827,7 +2915,9 @@ export function buildContextEngineFactory(
       const recentMessages = selectTurnAlignedSourceSuffix(args.messages, normalizeWindow);
       const messages = normalizeKernelMessages(recentMessages);
       const projectedSourceMessages = () => compactionProjectionActive
-        ? recentMessages
+        ? cachedCompactedProjection
+          ? args.messages.slice(cachedCompactedProjection.sourceStartIndex)
+          : recentMessages
         : args.messages;
       const buildAssembleFallback = (): OpenClawCompatibleAssembleResult => {
         if (!compactionProjectionActive) {
@@ -2835,8 +2925,10 @@ export function buildContextEngineFactory(
         }
         return enforceCompactedProjectionBudgetInvariant({
           messages: projectedSourceMessages(),
-          estimatedTokens: approximateMessagesTokens(projectedSourceMessages()),
-          systemPromptAddition: "",
+          estimatedTokens:
+            approximateMessagesTokens(projectedSourceMessages()) +
+            approximateTokenCount(cachedCompactedProjection?.context ?? ""),
+          systemPromptAddition: cachedCompactedProjection?.context ?? "",
           promptAuthority: "assembled",
         }, args.tokenBudget);
       };
@@ -2879,6 +2971,15 @@ export function buildContextEngineFactory(
           force: true,
           currentTokenCount: currentContextTokens,
         });
+        if (compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken) {
+          logger.warn?.(`LibraVDB discarded stale compaction result after session lifecycle change sessionId=${sessionId}`);
+          return ensureReplaySafeUserTurn(
+            buildBudgetFallbackContext(args.messages, args.tokenBudget),
+            args.messages,
+            logger,
+            args.tokenBudget,
+          );
+        }
         logPredictiveCompactionOutcome({
           logger,
           phase: "assemble",
@@ -2890,7 +2991,8 @@ export function buildContextEngineFactory(
           compacted: compactionResult.compacted,
           reason: compactionResult.reason,
         });
-        compactionProjectionActive = compactedProjectionSessions.has(sessionId);
+        compactionProjectionActive =
+          compactedProjectionSessions.has(sessionId) || cachedCompactedProjection !== undefined;
         if (!compactionResult.ok && !compactionProjectionActive) {
           logger.info?.(
             `LibraVDB predictive compaction blocked assemble path at ${currentContextTokens} tokens ` +
@@ -2981,7 +3083,12 @@ export function buildContextEngineFactory(
             compactionProjectionActive = true;
           }
           const sourceProjection = projectedSourceMessages();
-          const mockResp = { messages: sourceProjection, systemPromptAddition: cachedSystemPrompt };
+          const mockResp = {
+            messages: sourceProjection,
+            systemPromptAddition: cachedSystemPrompt,
+            estimatedTokens:
+              approximateMessagesTokens(sourceProjection) + approximateTokenCount(cachedSystemPrompt),
+          };
           enforced = enforceAssembleBudget(
             normalizeAssembleResult(
               mockResp,
@@ -3080,16 +3187,46 @@ export function buildContextEngineFactory(
               setTimeout(() => reject(new Error(`AssembleContextInternal timed out after ${assembleTimeout}ms`)), assembleTimeout)
             ),
           ]);
+          const daemonCompactedProjectionContext =
+            typeof resp.systemPromptAddition === "string"
+              ? extractCompactedSessionContext(resp.systemPromptAddition)
+              : undefined;
           if (
-            typeof resp.systemPromptAddition === "string" &&
-            hasCompactedSessionContext(resp.systemPromptAddition)
+            daemonCompactedProjectionContext &&
+            compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken
           ) {
+            cachedCompactedProjection = undefined;
+            const sourceStartIndex = args.messages.length - recentMessages.length;
+            const boundarySignature = buildProjectionBoundarySignature(args.messages, sourceStartIndex);
+            rememberCompactedProjection(
+              sessionId,
+              daemonCompactedProjectionContext,
+              sourceStartIndex,
+              boundarySignature,
+            );
             activateCompactedProjection(sessionId, "assemble");
             compactionProjectionActive = true;
           }
           const sourceProjection = projectedSourceMessages();
+          const restoredCompactedContext =
+            cachedCompactedProjection && !daemonCompactedProjectionContext
+              ? cachedCompactedProjection.context
+              : undefined;
+          const restoredSystemPromptAddition = restoredCompactedContext
+            ? appendSystemPromptAddition(restoredCompactedContext, resp.systemPromptAddition)
+            : undefined;
           const assembled = normalizeAssembleResult(
-            resp,
+            restoredCompactedContext
+              ? {
+                  ...resp,
+                  systemPromptAddition: restoredSystemPromptAddition,
+                  estimatedTokens: Math.max(
+                    typeof resp.estimatedTokens === "number" ? resp.estimatedTokens : 0,
+                    approximateMessagesTokens(sourceProjection) +
+                      approximateTokenCount(restoredSystemPromptAddition ?? ""),
+                  ),
+                }
+              : resp,
             sourceProjection,
             compactionProjectionActive ? "assembled" : PROMPT_AUTHORITY_PREASSEMBLY_MAY_OVERFLOW,
           );
@@ -3193,14 +3330,6 @@ export function buildContextEngineFactory(
             }
           }
 
-          if (postToolRecallCache.size >= POST_TOOL_CACHE_MAX_SIZE) {
-            const oldest = postToolRecallCache.keys().next().value;
-            if (oldest !== undefined) postToolRecallCache.delete(oldest);
-          }
-          postToolRecallCache.set(sessionId, {
-            lastUserIndex,
-            systemPromptAddition: enforced.systemPromptAddition,
-          });
         }
 
         // tokenBudgetMax stage 2 (enforcer): truncate the combined injection to
@@ -3236,13 +3365,57 @@ export function buildContextEngineFactory(
         // The returned transcript is always an untouched source projection.
         // Once daemon compaction owns history, OpenClaw must precheck this
         // assembled suffix rather than the unwindowed session transcript.
-        return ensureReplaySafeUserTurn(enforced, args.messages, logger, args.tokenBudget);
+        const lifecycleChanged =
+          compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken;
+        const compactedContextMissing =
+          compactionProjectionActive &&
+          extractCompactedSessionContext(enforced.systemPromptAddition) === undefined;
+        if (lifecycleChanged || compactedContextMissing) {
+          logger.warn?.(
+            `LibraVDB discarded ${lifecycleChanged ? "stale" : "incomplete"} compacted projection ` +
+            `sessionId=${sessionId}`,
+          );
+          return ensureReplaySafeUserTurn(
+            buildBudgetFallbackContext(args.messages, args.tokenBudget),
+            args.messages,
+            logger,
+            args.tokenBudget,
+          );
+        }
+        const replaySafe = ensureReplaySafeUserTurn(enforced, args.messages, logger, args.tokenBudget);
+        if (
+          compactionProjectionActive &&
+          extractCompactedSessionContext(replaySafe.systemPromptAddition) === undefined
+        ) {
+          logger.warn?.(`LibraVDB discarded compacted projection after user-turn repair sessionId=${sessionId}`);
+          return ensureReplaySafeUserTurn(
+            buildBudgetFallbackContext(args.messages, args.tokenBudget),
+            args.messages,
+            logger,
+            args.tokenBudget,
+          );
+        }
+        if (postToolRecallCache.size >= POST_TOOL_CACHE_MAX_SIZE) {
+          const oldest = postToolRecallCache.keys().next().value;
+          if (oldest !== undefined) postToolRecallCache.delete(oldest);
+        }
+        postToolRecallCache.set(sessionId, {
+          lastUserIndex,
+          systemPromptAddition: replaySafe.systemPromptAddition,
+        });
+        return replaySafe;
       } catch (error) {
         logger.warn?.(
           `LibraVDB assemble failed, using budget-clamped fallback context: ${error instanceof Error ? error.message : String(error)}`,
         );
+        const fallback = compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken
+          ? buildAssembleFallback()
+          : buildBudgetFallbackContext(args.messages, args.tokenBudget);
         return ensureReplaySafeUserTurn(
-          buildAssembleFallback(),
+          compactionProjectionActive &&
+            extractCompactedSessionContext(fallback.systemPromptAddition) === undefined
+            ? buildBudgetFallbackContext(args.messages, args.tokenBudget)
+            : fallback,
           args.messages,
           logger,
           args.tokenBudget,

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1173,11 +1173,17 @@ type CompactedProjectionSnapshot = {
 export type CompactedProjectionState = {
   snapshots: Map<string, CompactedProjectionSnapshot>;
   lifecycleTokens: Map<string, object>;
+  projectionTokens: Map<string, object>;
   activeSessions: Set<string>;
 };
 
 export function createCompactedProjectionState(): CompactedProjectionState {
-  return { snapshots: new Map(), lifecycleTokens: new Map(), activeSessions: new Set() };
+  return {
+    snapshots: new Map(),
+    lifecycleTokens: new Map(),
+    projectionTokens: new Map(),
+    activeSessions: new Set(),
+  };
 }
 
 export function clearCompactedProjectionState(
@@ -1186,6 +1192,7 @@ export function clearCompactedProjectionState(
 ): void {
   state.snapshots.delete(sessionId);
   state.lifecycleTokens.delete(sessionId);
+  state.projectionTokens.delete(sessionId);
   state.activeSessions.delete(sessionId);
   postToolRecallCache.delete(sessionId);
 }
@@ -2133,6 +2140,15 @@ export function buildContextEngineFactory(
     return token;
   }
 
+  function getProjectionToken(sessionId: string): object {
+    let token = compactedProjectionState.projectionTokens.get(sessionId);
+    if (!token) {
+      token = {};
+      compactedProjectionState.projectionTokens.set(sessionId, token);
+    }
+    return token;
+  }
+
   function enforceAssembleBudget(
     result: OpenClawCompatibleAssembleResult,
     tokenBudget: number | undefined,
@@ -2712,19 +2728,27 @@ export function buildContextEngineFactory(
     }
   }
 
-  async function runCompaction(args: {
-    sessionId: string;
-    force?: boolean;
-    targetSize?: number;
-    tokenBudget?: number;
-    currentTokenCount?: number;
-  }): Promise<OpenClawCompatibleCompactResult> {
-    const lifecycleToken = getProjectionLifecycleToken(args.sessionId);
+  async function runCompaction(
+    args: {
+      sessionId: string;
+      force?: boolean;
+      targetSize?: number;
+      tokenBudget?: number;
+      currentTokenCount?: number;
+      lifecycleToken?: object;
+    },
+    onProjectionChanged?: (token: object) => void,
+  ): Promise<OpenClawCompatibleCompactResult> {
+    const lifecycleToken = args.lifecycleToken ?? getProjectionLifecycleToken(args.sessionId);
+    if (compactedProjectionState.lifecycleTokens.get(args.sessionId) !== lifecycleToken) {
+      return { ok: false, compacted: false, reason: "session lifecycle changed" };
+    }
     const request = buildCompactSessionRequest(args);
     try {
       const client = await runtime.getClient();
       const threshold = getDynamicCompactThreshold(args.tokenBudget);
-      const result = normalizeCompactResult(await client.compactSession(request), {
+      const response = await client.compactSession(request);
+      const result = normalizeCompactResult(response, {
         tokensBefore: args.currentTokenCount,
         logger,
         ...(threshold != null ? { threshold } : {}),
@@ -2734,6 +2758,12 @@ export function buildContextEngineFactory(
         result.compacted &&
         compactedProjectionState.lifecycleTokens.get(args.sessionId) === lifecycleToken
       ) {
+        if (response.didCompact === true) {
+          const projectionToken = {};
+          compactedProjectionState.snapshots.delete(args.sessionId);
+          compactedProjectionState.projectionTokens.set(args.sessionId, projectionToken);
+          onProjectionChanged?.(projectionToken);
+        }
         activateCompactedProjection(args.sessionId, "compact");
       }
       return result;
@@ -2751,6 +2781,7 @@ export function buildContextEngineFactory(
     messages: OpenClawCompatibleMessage[];
     tokenBudget?: number;
     currentTokenCount?: number;
+    lifecycleToken: object;
   }): Promise<void> {
     const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
     const currentContextTokens = resolveAfterTurnPredictiveCompactionTokenCount({
@@ -2783,6 +2814,7 @@ export function buildContextEngineFactory(
       tokenBudget: args.tokenBudget,
       force: true,
       currentTokenCount: currentContextTokens,
+      lifecycleToken: args.lifecycleToken,
     });
     logPredictiveCompactionOutcome({
       logger,
@@ -2888,6 +2920,7 @@ export function buildContextEngineFactory(
       }
 
       let assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
+      let assembleProjectionToken = getProjectionToken(sessionId);
       let cachedCompactedProjection = compactedProjectionState.snapshots.get(sessionId);
       if (cachedCompactedProjection) {
         if (
@@ -2899,6 +2932,7 @@ export function buildContextEngineFactory(
         ) {
           clearCompactedProjectionState(compactedProjectionState, sessionId);
           assembleLifecycleToken = getProjectionLifecycleToken(sessionId);
+          assembleProjectionToken = getProjectionToken(sessionId);
           cachedCompactedProjection = undefined;
         }
       }
@@ -2966,15 +3000,26 @@ export function buildContextEngineFactory(
           targetSize: predictiveTargetSize,
           tokenBudget: args.tokenBudget,
         });
-        const compactionResult = await runCompaction({
-          sessionId,
-          targetSize: predictiveTargetSize,
-          tokenBudget: args.tokenBudget,
-          force: true,
-          currentTokenCount: currentContextTokens,
-        });
-        if (compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken) {
-          logger.warn?.(`LibraVDB discarded stale compaction result after session lifecycle change sessionId=${sessionId}`);
+        const compactionResult = await runCompaction(
+          {
+            sessionId,
+            targetSize: predictiveTargetSize,
+            tokenBudget: args.tokenBudget,
+            force: true,
+            currentTokenCount: currentContextTokens,
+          },
+          (projectionToken) => {
+            assembleProjectionToken = projectionToken;
+            cachedCompactedProjection = undefined;
+          },
+        );
+        if (
+          compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken ||
+          compactedProjectionState.projectionTokens.get(sessionId) !== assembleProjectionToken
+        ) {
+          logger.warn?.(
+            `LibraVDB discarded stale compaction result after session state change sessionId=${sessionId}`,
+          );
           return ensureReplaySafeUserTurn(
             buildBudgetFallbackContext(args.messages, args.tokenBudget),
             args.messages,
@@ -3195,7 +3240,8 @@ export function buildContextEngineFactory(
               : undefined;
           if (
             daemonCompactedProjectionContext &&
-            compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken
+            compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken &&
+            compactedProjectionState.projectionTokens.get(sessionId) === assembleProjectionToken
           ) {
             cachedCompactedProjection = undefined;
             const sourceStartIndex = args.messages.length - recentMessages.length;
@@ -3367,14 +3413,15 @@ export function buildContextEngineFactory(
         // The returned transcript is always an untouched source projection.
         // Once daemon compaction owns history, OpenClaw must precheck this
         // assembled suffix rather than the unwindowed session transcript.
-        const lifecycleChanged =
-          compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken;
+        const stateChanged =
+          compactedProjectionState.lifecycleTokens.get(sessionId) !== assembleLifecycleToken ||
+          compactedProjectionState.projectionTokens.get(sessionId) !== assembleProjectionToken;
         const compactedContextMissing =
           compactionProjectionActive &&
           extractCompactedSessionContext(enforced.systemPromptAddition) === undefined;
-        if (lifecycleChanged || compactedContextMissing) {
+        if (stateChanged || compactedContextMissing) {
           logger.warn?.(
-            `LibraVDB discarded ${lifecycleChanged ? "stale" : "incomplete"} compacted projection ` +
+            `LibraVDB discarded ${stateChanged ? "stale" : "incomplete"} compacted projection ` +
             `sessionId=${sessionId}`,
           );
           return ensureReplaySafeUserTurn(
@@ -3410,7 +3457,10 @@ export function buildContextEngineFactory(
         logger.warn?.(
           `LibraVDB assemble failed, using budget-clamped fallback context: ${error instanceof Error ? error.message : String(error)}`,
         );
-        const fallback = compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken
+        const stateCurrent =
+          compactedProjectionState.lifecycleTokens.get(sessionId) === assembleLifecycleToken &&
+          compactedProjectionState.projectionTokens.get(sessionId) === assembleProjectionToken;
+        const fallback = stateCurrent
           ? buildAssembleFallback()
           : buildBudgetFallbackContext(args.messages, args.tokenBudget);
         return ensureReplaySafeUserTurn(
@@ -3522,6 +3572,7 @@ export function buildContextEngineFactory(
         return { ok: true, skipped: true, reason: "no-new-messages" };
       }
 
+      const lifecycleToken = getProjectionLifecycleToken(sessionId);
       enqueueAsyncIngestion(sessionId, async () => {
         try {
           // Reload manifest inside the serialized queue so state is fresh
@@ -3647,6 +3698,7 @@ export function buildContextEngineFactory(
             messages,
             tokenBudget: args.tokenBudget,
             currentTokenCount,
+            lifecycleToken,
           });
           const predictions = result.predictions;
           if (Array.isArray(predictions) && predictions.length > 0) {

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -1173,10 +1173,11 @@ type CompactedProjectionSnapshot = {
 export type CompactedProjectionState = {
   snapshots: Map<string, CompactedProjectionSnapshot>;
   lifecycleTokens: Map<string, object>;
+  activeSessions: Set<string>;
 };
 
 export function createCompactedProjectionState(): CompactedProjectionState {
-  return { snapshots: new Map(), lifecycleTokens: new Map() };
+  return { snapshots: new Map(), lifecycleTokens: new Map(), activeSessions: new Set() };
 }
 
 export function clearCompactedProjectionState(
@@ -1185,6 +1186,8 @@ export function clearCompactedProjectionState(
 ): void {
   state.snapshots.delete(sessionId);
   state.lifecycleTokens.delete(sessionId);
+  state.activeSessions.delete(sessionId);
+  postToolRecallCache.delete(sessionId);
 }
 
 function sanitizeDaemonSystemPromptAddition(text: string): string {
@@ -2024,7 +2027,7 @@ export function buildContextEngineFactory(
   }
 
   const predictiveContextCache = new Map<string, import("./types.js").PredictedContext[]>();
-  const compactedProjectionSessions = new Set<string>();
+  const compactedProjectionSessions = compactedProjectionState.activeSessions;
   const PREDICTIVE_CACHE_MAX_SIZE = 100;
   // BeforeTurnKernel state
   const turnCache = new TurnMemoryCache(100);
@@ -3763,7 +3766,6 @@ export function buildContextEngineFactory(
         }
       }
       predictiveContextCache.clear();
-      compactedProjectionSessions.clear();
       postToolRecallCache.clear();
       asyncIngestionQueues.clear();
       triggerCache.clear();

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -3575,6 +3575,10 @@ export function buildContextEngineFactory(
       const lifecycleToken = getProjectionLifecycleToken(sessionId);
       enqueueAsyncIngestion(sessionId, async () => {
         try {
+          const lifecycleIsCurrent = () =>
+            compactedProjectionState.lifecycleTokens.get(sessionId) === lifecycleToken;
+          if (!lifecycleIsCurrent()) return;
+
           // Reload manifest inside the serialized queue so state is fresh
           // after any preceding queued tasks have completed.
           const manifest = manifestStore.load(sessionId, logger);
@@ -3607,6 +3611,7 @@ export function buildContextEngineFactory(
             };
 
           const client = await runtime.getClient();
+          if (!lifecycleIsCurrent()) return;
           const currentTokenCount = normalizeCurrentTokenCount(
             typeof args.runtimeContext?.currentTokenCount === "number"
               ? args.runtimeContext.currentTokenCount
@@ -3621,6 +3626,7 @@ export function buildContextEngineFactory(
             isHeartbeat: args.isHeartbeat,
             ...(cursor ? { cursor } : {}),
           } as unknown as Parameters<typeof client.afterTurnKernel>[0]);
+          if (!lifecycleIsCurrent()) return;
 
           updateContinuityCache(args.sessionKey ?? sessionId, ingestMessages);
 
@@ -3658,6 +3664,7 @@ export function buildContextEngineFactory(
                   messages: seedMessages,
                   isHeartbeat: args.isHeartbeat,
                 } as unknown as Parameters<typeof client.afterTurnKernel>[0]);
+                if (!lifecycleIsCurrent()) return;
                 manifestStore.save(
                   manifestStore.appendACKedMessages(emptyManifest, seedMessages, 0),
                 );
@@ -3700,6 +3707,7 @@ export function buildContextEngineFactory(
             currentTokenCount,
             lifecycleToken,
           });
+          if (!lifecycleIsCurrent()) return;
           const predictions = result.predictions;
           if (Array.isArray(predictions) && predictions.length > 0) {
             if (predictiveContextCache.size >= PREDICTIVE_CACHE_MAX_SIZE) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { resolveIdentity, resolveTenantKey, resolveReadTenants } from "./identit
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { registerMemoryCli } from "./cli.js";
 import { registerMemoryCliMetadata } from "./cli-descriptors.js";
-import { buildContextEngineFactory, clearSessionTrigger, extractSpeakers, normalizeKernelMessage, setSessionTrigger } from "./context-engine.js";
+import { buildContextEngineFactory, clearCompactedProjectionState, clearSessionTrigger, createCompactedProjectionState, extractSpeakers, normalizeKernelMessage, setSessionTrigger } from "./context-engine.js";
 import { createBeforeResetHook, createSessionEndHook } from "./lifecycle-hooks.js";
 import { createDreamPromotionHandle } from "./dream-promotion.js";
 import { createMarkdownIngestionHandle } from "./markdown-ingest.js";
@@ -181,6 +181,7 @@ export function register(api: OpenClawPluginApi) {
   // TypeScript can't narrow through the ternary, so re-bind and guard.
   const runtime = runtimeOrNull;
   if (!runtime) return; // unreachable but satisfies the type checker
+  const compactedProjectionState = createCompactedProjectionState();
 
   if (!memSlot) {
     logger.warn?.("[libravdb-memory] plugins.slots.memory is unset; set it to \"libravdb-memory\" for memory to work.");
@@ -219,7 +220,7 @@ export function register(api: OpenClawPluginApi) {
 
   api.registerContextEngine(
     MEMORY_ID,
-    () => buildContextEngineFactory(runtime, cfg, logger),
+    () => buildContextEngineFactory(runtime, cfg, logger, compactedProjectionState),
   );
 
   // Register the daemon's extractive summarization as a pluggable
@@ -385,12 +386,23 @@ export function register(api: OpenClawPluginApi) {
     }
   });
 
-  api.on("session_end", async (_event, ctx) => {
-    const sessionId = (ctx as Record<string, unknown> | undefined)?.sessionId as string | undefined;
-    if (sessionId) clearSessionTrigger(sessionId);
+  api.on("session_end", async (event, ctx) => {
+    const sessionId = (
+      (event as Record<string, unknown> | undefined)?.sessionId ??
+      (ctx as Record<string, unknown> | undefined)?.sessionId
+    ) as string | undefined;
+    if (sessionId) {
+      clearSessionTrigger(sessionId);
+      clearCompactedProjectionState(compactedProjectionState, sessionId);
+    }
   });
 
-  api.on("before_reset", createBeforeResetHook(runtime, logger));
+  const beforeResetHook = createBeforeResetHook(runtime, logger);
+  api.on("before_reset", async (event, ctx) => {
+    const sessionId = (ctx as Record<string, unknown> | undefined)?.sessionId as string | undefined;
+    if (sessionId) clearCompactedProjectionState(compactedProjectionState, sessionId);
+    await beforeResetHook(event, ctx);
+  });
   api.on("session_end", createSessionEndHook(runtime, logger));
   api.on("gateway_stop", async () => {
     await runtime.shutdown();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1604,6 +1604,90 @@ test("session cleanup deactivates an existing engine and clears its post-tool pr
   assert.doesNotMatch(afterReset.systemPromptAddition, /Projection before reset/u);
 });
 
+test("boundary divergence fences an older overlapping assembly from restoring stale projection", async () => {
+  const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sessionId = "s1-boundary-divergence-race";
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 500,
+    systemPromptAddition:
+      "<compacted_session_context>\nInitial projection\n</compacted_session_context>",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  await engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  assert.equal(state.snapshots.has(sessionId), true);
+
+  let releaseOlder!: () => void;
+  let markOlderStarted!: () => void;
+  const olderStarted = new Promise<void>((resolve) => {
+    markOlderStarted = resolve;
+  });
+  const olderRelease = new Promise<void>((resolve) => {
+    releaseOlder = resolve;
+  });
+  let overlappingCalls = 0;
+  (client as unknown as {
+    assembleContextInternal: (params: Record<string, unknown>) => Promise<unknown>;
+  }).assembleContextInternal = async (params) => {
+    client.calls.push({ method: "assembleContextInternal", params });
+    overlappingCalls += 1;
+    if (overlappingCalls === 1) {
+      markOlderStarted();
+      await olderRelease;
+      return {
+        messages: [],
+        estimatedTokens: 500,
+        systemPromptAddition:
+          "<compacted_session_context>\nObsolete projection\n</compacted_session_context>",
+      };
+    }
+    return {
+      messages: [],
+      estimatedTokens: 500,
+      systemPromptAddition:
+        "<compacted_session_context>\nFresh projection\n</compacted_session_context>",
+    };
+  };
+
+  const olderPending = engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  await olderStarted;
+
+  const divergentMessages = [...sourceMessages];
+  divergentMessages[19] = makeMessage("assistant", "changed boundary history", "message-19");
+  const afterDivergence = await engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: divergentMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  releaseOlder();
+  const olderResult = await olderPending;
+
+  assert.equal(afterDivergence.promptAuthority, "assembled");
+  assert.equal(olderResult.promptAuthority, "preassembly_may_overflow");
+  assert.match(state.snapshots.get(sessionId)?.context ?? "", /Fresh projection/u);
+  assert.equal(state.activeSessions.has(sessionId), true);
+  assert.deepEqual(olderResult.messages, sourceMessages);
+  assert.doesNotMatch(olderResult.systemPromptAddition, /Obsolete projection/u);
+});
+
 test("engine replacement does not persist ambiguous compaction or cross a lifecycle race", async () => {
   const client = new FakeClient();
   const state = createCompactedProjectionState();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -7,6 +7,7 @@ import { buildContextEngineFactory, clearCompactedProjectionState, createCompact
 import fs from "node:fs";
 import { execSync } from "node:child_process";
 import { resolveIdentity } from "../../src/identity.js";
+import { manifestStore } from "../../src/manifest.js";
 import type { PluginConfig, SearchResult } from "../../src/types.js";
 
 import type { PluginRuntime } from "../../src/plugin-runtime.js";
@@ -1784,20 +1785,24 @@ test("reset during predictive compaction cannot activate stale projection state"
   assert.equal(state.snapshots.size, 0);
 });
 
-test("queued afterTurn compaction cannot reactivate projection state after reset", async () => {
+test("queued afterTurn work cannot repopulate session state after reset", async () => {
   const client = new FakeClient();
   const state = createCompactedProjectionState();
-  const sessionId = "s1-after-turn-reset-race";
+  const sessionId = `s1-after-turn-reset-race-${process.pid}-${Date.now()}`;
   let releaseAfterTurn!: () => void;
+  let afterTurnCalls = 0;
   const afterTurnStarted = new Promise<void>((resolve) => {
     (client as unknown as {
       afterTurnKernel: (params: Record<string, unknown>) => Promise<unknown>;
     }).afterTurnKernel = async (params) => {
       client.calls.push({ method: "afterTurnKernel", params });
-      resolve();
-      await new Promise<void>((release) => {
-        releaseAfterTurn = release;
-      });
+      afterTurnCalls += 1;
+      if (afterTurnCalls === 1) {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseAfterTurn = release;
+        });
+      }
       return { ok: true };
     };
   });
@@ -1811,12 +1816,21 @@ test("queued afterTurn compaction cannot reactivate projection state after reset
     runtimeContext: { currentTokenCount: 50_000 },
   });
   await afterTurnStarted;
+  await engine.afterTurn({
+    sessionId,
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "queued behind the stale turn")],
+    tokenBudget: 100_000,
+    runtimeContext: { currentTokenCount: 50_000 },
+  });
 
   clearCompactedProjectionState(state, sessionId);
   releaseAfterTurn();
   await flushIngestion(engine);
 
+  assert.equal(client.calls.filter((call) => call.method === "afterTurnKernel").length, 1);
   assert.equal(client.calls.some((call) => call.method === "compactSession"), false);
+  assert.equal(manifestStore.load(sessionId).turns.length, 0);
   assert.equal(state.activeSessions.has(sessionId), false);
   assert.equal(state.snapshots.has(sessionId), false);
 });

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1541,6 +1541,69 @@ test("daemon compacted projection survives engine replacement until session stat
   assert.equal(afterReset.messages.length, appendedMessages.length);
 });
 
+test("session cleanup deactivates an existing engine and clears its post-tool projection", async () => {
+  const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sessionId = "s1-reset-active-engine";
+  const sourceMessages = [
+    ...Array.from({ length: 70 }, (_, index) =>
+      makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+    ),
+    makeMessage("user", "run tool", "message-70"),
+    {
+      role: "assistant",
+      id: "message-71",
+      content: [{ type: "toolCall", name: "lookup", arguments: {} }],
+    },
+    makeMessage("toolResult", "tool result", "message-72"),
+  ];
+  client.compactResponse = { ok: true, didCompact: true };
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 500,
+    systemPromptAddition:
+      "<compacted_session_context>\nProjection before reset\n</compacted_session_context>",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+
+  await engine.compact({ sessionId, force: true, tokenBudget: 100_000 });
+  const beforeReset = await engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "run tool",
+    tokenBudget: 100_000,
+  });
+  assert.equal(state.activeSessions.has(sessionId), true);
+  assert.match(beforeReset.systemPromptAddition, /Projection before reset/u);
+
+  const assembleCallsBeforeReset = client.calls.filter(
+    (call) => call.method === "assembleContextInternal",
+  ).length;
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 0,
+    systemPromptAddition: "<memory_context>fresh context</memory_context>",
+  };
+  clearCompactedProjectionState(state, sessionId);
+  const afterReset = await engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "run tool",
+    tokenBudget: 100_000,
+  });
+
+  assert.equal(state.activeSessions.has(sessionId), false);
+  assert.equal(
+    client.calls.filter((call) => call.method === "assembleContextInternal").length,
+    assembleCallsBeforeReset + 1,
+  );
+  assert.equal(afterReset.promptAuthority, "preassembly_may_overflow");
+  assert.deepEqual(afterReset.messages, sourceMessages);
+  assert.doesNotMatch(afterReset.systemPromptAddition, /Projection before reset/u);
+});
+
 test("engine replacement does not persist ambiguous compaction or cross a lifecycle race", async () => {
   const client = new FakeClient();
   const state = createCompactedProjectionState();

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -1784,18 +1784,85 @@ test("reset during predictive compaction cannot activate stale projection state"
   assert.equal(state.snapshots.size, 0);
 });
 
-test("successful predictive compaction without a complete marker fails closed", async () => {
+test("queued afterTurn compaction cannot reactivate projection state after reset", async () => {
   const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sessionId = "s1-after-turn-reset-race";
+  let releaseAfterTurn!: () => void;
+  const afterTurnStarted = new Promise<void>((resolve) => {
+    (client as unknown as {
+      afterTurnKernel: (params: Record<string, unknown>) => Promise<unknown>;
+    }).afterTurnKernel = async (params) => {
+      client.calls.push({ method: "afterTurnKernel", params });
+      resolve();
+      await new Promise<void>((release) => {
+        releaseAfterTurn = release;
+      });
+      return { ok: true };
+    };
+  });
+  client.compactResponse = { ok: true, didCompact: true };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  await engine.afterTurn({
+    sessionId,
+    sessionKey: "sk1",
+    messages: [makeMessage("user", "queued before reset")],
+    tokenBudget: 100_000,
+    runtimeContext: { currentTokenCount: 50_000 },
+  });
+  await afterTurnStarted;
+
+  clearCompactedProjectionState(state, sessionId);
+  releaseAfterTurn();
+  await flushIngestion(engine);
+
+  assert.equal(client.calls.some((call) => call.method === "compactSession"), false);
+  assert.equal(state.activeSessions.has(sessionId), false);
+  assert.equal(state.snapshots.has(sessionId), false);
+});
+
+test("successful predictive compaction does not restore an older cached marker", async () => {
+  const client = new FakeClient();
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 500,
+    systemPromptAddition:
+      "<compacted_session_context>\nOlder projection\n</compacted_session_context>",
+  };
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  const state = createCompactedProjectionState();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  await engine.assemble({
+    sessionId: "s1-compaction-without-marker",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  assert.equal(state.snapshots.has("s1-compaction-without-marker"), true);
+
+  const olderSnapshot = state.snapshots.get("s1-compaction-without-marker");
+  client.compactResponse = {
+    didCompact: false,
+    skippedNoNewTurns: true,
+    lastCompactedTurn: 37n,
+  };
+  const unchanged = await engine.compact({
+    sessionId: "s1-compaction-without-marker",
+    tokenBudget: 100_000,
+    currentTokenCount: 50_000,
+  });
+  assert.equal(unchanged.compacted, true);
+  assert.strictEqual(state.snapshots.get("s1-compaction-without-marker"), olderSnapshot);
+
   client.compactResponse = { ok: true, didCompact: true };
   client.assembleResponse = {
     messages: [],
     estimatedTokens: 0,
     systemPromptAddition: "",
   };
-  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
-    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
-  );
-  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
   const assembled = await engine.assemble({
     sessionId: "s1-compaction-without-marker",
     sessionKey: "sk1",
@@ -1808,6 +1875,68 @@ test("successful predictive compaction without a complete marker fails closed", 
   assert.equal(assembled.promptAuthority, "preassembly_may_overflow");
   assert.equal(assembled.messages.length, sourceMessages.length);
   assert.equal(assembled.systemPromptAddition, "");
+  assert.equal(state.snapshots.has("s1-compaction-without-marker"), false);
+});
+
+test("successful compaction fences an overlapping assembly holding an older marker", async () => {
+  const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sessionId = "s1-overlapping-compaction";
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 500,
+    systemPromptAddition:
+      "<compacted_session_context>\nOlder projection\n</compacted_session_context>",
+  };
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  await engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+
+  let releaseAssemble!: () => void;
+  const assembleStarted = new Promise<void>((resolve) => {
+    (client as unknown as {
+      assembleContextInternal: (params: Record<string, unknown>) => Promise<unknown>;
+    }).assembleContextInternal = async (params) => {
+      client.calls.push({ method: "assembleContextInternal", params });
+      resolve();
+      await new Promise<void>((release) => {
+        releaseAssemble = release;
+      });
+      return {
+        messages: [],
+        estimatedTokens: 500,
+        systemPromptAddition:
+          "<compacted_session_context>\nLate stale projection\n</compacted_session_context>",
+      };
+    };
+  });
+  const pending = engine.assemble({
+    sessionId,
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  await assembleStarted;
+
+  client.compactResponse = { ok: true, didCompact: true };
+  const compacted = await engine.compact({ sessionId, force: true, tokenBudget: 100_000 });
+  assert.equal(compacted.compacted, true);
+  releaseAssemble();
+  const assembled = await pending;
+
+  assert.equal(assembled.promptAuthority, "preassembly_may_overflow");
+  assert.deepEqual(assembled.messages, sourceMessages);
+  assert.doesNotMatch(assembled.systemPromptAddition, /Late stale projection/u);
+  assert.equal(state.snapshots.has(sessionId), false);
 });
 
 test("context engine assemble drops consecutive duplicate provider replay messages", async () => {

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 
-import { buildContextEngineFactory, FLUSH_ASYNC_INGESTION } from "../../src/context-engine.js";
+import { buildContextEngineFactory, clearCompactedProjectionState, createCompactedProjectionState, FLUSH_ASYNC_INGESTION } from "../../src/context-engine.js";
 import fs from "node:fs";
 import { execSync } from "node:child_process";
 import { resolveIdentity } from "../../src/identity.js";
@@ -1287,7 +1287,7 @@ test("successful daemon compaction makes an exact turn-aligned source suffix aut
   assert.match(assembled.systemPromptAddition, /<compacted_session_context>/u);
 });
 
-test("compacted projection budget clamp preserves the complete live tool bundle", async () => {
+test("incomplete compacted marker falls back while preserving the complete live tool bundle", async () => {
   const client = new FakeClient();
   client.compactResponse = {
     ok: true,
@@ -1346,11 +1346,12 @@ test("compacted projection budget clamp preserves the complete live tool bundle"
   });
 
   assert.equal(assembled.promptAuthority, "assembled");
-  assert.deepEqual(assembled.messages, [liveUser, liveToolCall, liveToolResult, liveAnswer]);
-  assert.strictEqual(assembled.messages[0], liveUser);
-  assert.strictEqual(assembled.messages[1], liveToolCall);
-  assert.strictEqual(assembled.messages[2], liveToolResult);
-  assert.strictEqual(assembled.messages[3], liveAnswer);
+  assert.deepEqual(assembled.messages.slice(-4), [liveUser, liveToolCall, liveToolResult, liveAnswer]);
+  assert.strictEqual(assembled.messages.at(-4), liveUser);
+  assert.strictEqual(assembled.messages.at(-3), liveToolCall);
+  assert.strictEqual(assembled.messages.at(-2), liveToolResult);
+  assert.strictEqual(assembled.messages.at(-1), liveAnswer);
+  assert.equal(assembled.systemPromptAddition, "");
   assert.ok(assembled.estimatedTokens <= 800);
 });
 
@@ -1379,6 +1380,287 @@ test("daemon compacted context marker restores assembled authority after plugin 
   assert.equal(assembled.promptAuthority, "assembled");
   assert.ok(assembled.messages.length < sourceMessages.length);
   assert.strictEqual(assembled.messages.at(-1), sourceMessages.at(-1));
+});
+
+test("daemon compacted projection survives engine replacement until session state is cleared", async () => {
+  const client = new FakeClient();
+  client.compactResponse = {
+    ok: true,
+    didCompact: true,
+    summaryText: "Compacted prefix",
+    tokensAfter: 500,
+  };
+  const compactedProjectionState = createCompactedProjectionState();
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+
+  const engineA = buildContextEngineFactory(
+    fakeRuntime(client),
+    { userId: "fixed-user" },
+    console,
+    compactedProjectionState,
+  );
+  const compacted = await engineA.compact({
+    sessionId: "s1-replaced-engine",
+    force: true,
+    tokenBudget: 100_000,
+    currentTokenCount: 90_000,
+  });
+  assert.equal(compacted.compacted, true);
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 500,
+    systemPromptAddition:
+      "<compacted_session_context>\nDurable daemon projection\n</compacted_session_context>",
+  };
+  const firstAssembled = await engineA.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  assert.match(firstAssembled.systemPromptAddition, /Durable daemon projection/u);
+  await engineA.dispose();
+
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 0,
+    systemPromptAddition: `<memory_context>${"noise ".repeat(200)}</memory_context>`,
+  };
+  client.compactResponse = { ok: true, didCompact: false };
+
+  const engineB = buildContextEngineFactory(
+    fakeRuntime(client),
+    { userId: "fixed-user", tokenBudgetMax: 100 },
+    console,
+    compactedProjectionState,
+  );
+  const appendedMessages = [
+    ...sourceMessages,
+    makeMessage("user", "message 70", "message-70"),
+    makeMessage("assistant", "message 71", "message-71"),
+    makeMessage("user", "message 72", "message-72"),
+    makeMessage("assistant", "message 73", "message-73"),
+  ];
+  const assembled = await engineB.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: appendedMessages,
+    prompt: "message 72",
+    tokenBudget: 100_000,
+    currentTokenCount: 50_000,
+  });
+
+  assert.equal(client.calls.filter((call) => call.method === "compactSession").length, 2);
+  assert.equal(assembled.promptAuthority, "assembled");
+  assert.deepEqual(assembled.messages, appendedMessages.slice(20));
+  assert.ok(assembled.systemPromptAddition.startsWith("<compacted_session_context>"));
+  assert.match(assembled.systemPromptAddition, /Durable daemon projection/u);
+  assert.ok(assembled.estimatedTokens > 500);
+
+  const callsBeforePostTool = client.calls.filter(
+    (call) => call.method === "assembleContextInternal",
+  ).length;
+  const postToolMessages = [
+    ...appendedMessages,
+    makeMessage("user", "run tool", "message-74"),
+    {
+      role: "assistant",
+      id: "message-75",
+      content: [{ type: "toolCall", name: "lookup", arguments: {} }],
+    },
+    makeMessage("toolResult", "tool result", "message-76"),
+  ];
+  const postTool = await engineB.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: postToolMessages,
+    prompt: "run tool",
+    tokenBudget: 100_000,
+  });
+  assert.equal(
+    client.calls.filter((call) => call.method === "assembleContextInternal").length,
+    callsBeforePostTool,
+  );
+  assert.match(postTool.systemPromptAddition, /Durable daemon projection/u);
+  assert.deepEqual(postTool.messages, postToolMessages.slice(20));
+
+  const tightBudgetEngine = buildContextEngineFactory(
+    fakeRuntime(client),
+    { userId: "fixed-user", tokenBudgetMax: 5 },
+    console,
+    compactedProjectionState,
+  );
+  const afterMarkerTruncation = await tightBudgetEngine.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: appendedMessages,
+    prompt: "message 72",
+    tokenBudget: 100_000,
+  });
+  assert.equal(afterMarkerTruncation.promptAuthority, "preassembly_may_overflow");
+  assert.equal(afterMarkerTruncation.messages.length, appendedMessages.length);
+
+  const divergentState = createCompactedProjectionState();
+  divergentState.snapshots = new Map(compactedProjectionState.snapshots);
+  const divergentEngine = buildContextEngineFactory(
+    fakeRuntime(client),
+    { userId: "fixed-user" },
+    console,
+    divergentState,
+  );
+  const divergentMessages = [...appendedMessages];
+  divergentMessages[19] = makeMessage("assistant", "changed boundary history", "message-19");
+  const afterDivergence = await divergentEngine.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: divergentMessages,
+    prompt: "message 72",
+    tokenBudget: 100_000,
+  });
+  assert.equal(afterDivergence.promptAuthority, "preassembly_may_overflow");
+  assert.equal(afterDivergence.messages.length, divergentMessages.length);
+
+  clearCompactedProjectionState(compactedProjectionState, "s1-replaced-engine");
+  const engineC = buildContextEngineFactory(
+    fakeRuntime(client),
+    { userId: "fixed-user" },
+    console,
+    compactedProjectionState,
+  );
+  const afterReset = await engineC.assemble({
+    sessionId: "s1-replaced-engine",
+    sessionKey: "sk1",
+    messages: appendedMessages,
+    prompt: "message 72",
+    tokenBudget: 100_000,
+  });
+  assert.equal(afterReset.promptAuthority, "preassembly_may_overflow");
+  assert.equal(afterReset.messages.length, appendedMessages.length);
+});
+
+test("engine replacement does not persist ambiguous compaction or cross a lifecycle race", async () => {
+  const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  client.compactResponse = { ok: true, didCompact: true };
+  const engineA = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  await engineA.compact({
+    sessionId: "s1-projection-race",
+    force: true,
+    tokenBudget: 100_000,
+    currentTokenCount: 90_000,
+  });
+  await engineA.dispose();
+
+  const engineB = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  const withoutMarker = await engineB.assemble({
+    sessionId: "s1-projection-race",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  assert.equal(withoutMarker.promptAuthority, "preassembly_may_overflow");
+  assert.equal(withoutMarker.messages.length, sourceMessages.length);
+
+  let releaseAssemble!: () => void;
+  const assembleStarted = new Promise<void>((resolve) => {
+    (client as unknown as { assembleContextInternal: () => Promise<unknown> }).assembleContextInternal = async () => {
+      resolve();
+      await new Promise<void>((release) => {
+        releaseAssemble = release;
+      });
+      return {
+        messages: [],
+        estimatedTokens: 500,
+        systemPromptAddition:
+          "<compacted_session_context>\nLate stale projection\n</compacted_session_context>",
+      };
+    };
+  });
+  const pending = engineB.assemble({
+    sessionId: "s1-projection-race",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+  });
+  await assembleStarted;
+  const sessionToken = state.lifecycleTokens.get("s1-projection-race");
+  clearCompactedProjectionState(state, "unrelated-session");
+  assert.strictEqual(state.lifecycleTokens.get("s1-projection-race"), sessionToken);
+  clearCompactedProjectionState(state, "s1-projection-race");
+  releaseAssemble();
+  const afterRace = await pending;
+  assert.equal(afterRace.promptAuthority, "preassembly_may_overflow");
+  assert.equal(afterRace.messages.length, sourceMessages.length);
+  assert.equal(state.snapshots.size, 0);
+});
+
+test("reset during predictive compaction cannot activate stale projection state", async () => {
+  const client = new FakeClient();
+  const state = createCompactedProjectionState();
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  let releaseCompaction!: () => void;
+  const compactionStarted = new Promise<void>((resolve) => {
+    (client as unknown as { compactSession: () => Promise<unknown> }).compactSession = async () => {
+      resolve();
+      await new Promise<void>((release) => {
+        releaseCompaction = release;
+      });
+      return { ok: true, didCompact: true };
+    };
+  });
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" }, console, state);
+  const pending = engine.assemble({
+    sessionId: "s1-compaction-reset-race",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+    currentTokenCount: 50_000,
+  });
+  await compactionStarted;
+  clearCompactedProjectionState(state, "s1-compaction-reset-race");
+  releaseCompaction();
+  const assembled = await pending;
+
+  assert.equal(assembled.promptAuthority, "preassembly_may_overflow");
+  assert.equal(assembled.messages.length, sourceMessages.length);
+  assert.equal(state.snapshots.size, 0);
+});
+
+test("successful predictive compaction without a complete marker fails closed", async () => {
+  const client = new FakeClient();
+  client.compactResponse = { ok: true, didCompact: true };
+  client.assembleResponse = {
+    messages: [],
+    estimatedTokens: 0,
+    systemPromptAddition: "",
+  };
+  const sourceMessages = Array.from({ length: 70 }, (_, index) =>
+    makeMessage(index % 2 === 0 ? "user" : "assistant", `message ${index}`, `message-${index}`)
+  );
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user" });
+  const assembled = await engine.assemble({
+    sessionId: "s1-compaction-without-marker",
+    sessionKey: "sk1",
+    messages: sourceMessages,
+    prompt: "message 68",
+    tokenBudget: 100_000,
+    currentTokenCount: 50_000,
+  });
+
+  assert.equal(assembled.promptAuthority, "preassembly_may_overflow");
+  assert.equal(assembled.messages.length, sourceMessages.length);
+  assert.equal(assembled.systemPromptAddition, "");
 });
 
 test("context engine assemble drops consecutive duplicate provider replay messages", async () => {


### PR DESCRIPTION
Related: #378

AI-assisted: OpenAI Codex implemented and tested this change. Claude Code (personal Opus and Sonnet) performed independent adversarial reviews. Public incident evidence is in #378; local review logs contain machine paths and are not published.

## What Problem This Solves

The context engine is created again for each logical turn. After compaction, the previous engine held the compacted projection only in its own memory. A later turn could therefore lose that projection and replay the full session transcript. In the observed incident, provider input rose from about 102k tokens to 511,940 tokens in one turn.

## Why This Change Was Made

This change keeps the last valid compacted projection in registration-scoped, process-local state. It records only a complete daemon-generated `<compacted_session_context>` marker, its source boundary, and a bounded boundary signature. Fresh engines can restore that projection while per-session lifecycle tokens reject late work from reset, ended, or superseded runs.

Compacted authority now fails closed. An actual daemon compaction invalidates the prior snapshot and rotates a projection-generation token, fencing assemblies that still hold the older projection. A daemon no-op that confirms the session is already compacted retains the valid snapshot. Queued after-turn work captures its lifecycle token before entering the queue, so a reset cannot let stale work reactivate compacted state.

This is a plugin-side mitigation. It does not establish durable daemon recovery across process restarts, so the broader issue remains open.

## User Impact

Ordinary new turns and superseded heartbeat turns retain the compacted projection instead of unexpectedly resending the full session. Stale projections cannot be restored after a newer compaction or a reset. This avoids large input-token and cost spikes. No configuration change is required.

## Evidence

- The branch includes current upstream `main` at `c883cf7`.
- On the previous PR head, the cached-marker/markerless-assembly regression and the overlapping-assembly regression both failed (0/2): each incorrectly returned `assembled` using stale authority. The queued after-turn/reset regression also failed (0/1) by reactivating compacted projection state after reset.
- On `14f7ec1`, all three regressions pass (3/3). Actual compaction invalidates the cached snapshot, overlapping assemblies are projection-generation fenced, and queued pre-reset work cannot call compaction or reactivate state.
- Full context-engine unit suite: 99/99 passed.
- Integration suites for checklist validation, dream promotion, host flow, and Markdown ingestion: 49/49 passed.
- `tsc --noEmit`, test compilation, and the production build passed.
- Independent read-only Codex adversarial reviews found two additional races during development. Both were fixed, regression-tested, and re-reviewed; the final review returned `SAFE`.
- The documented `pnpm check` and `npm run test:integration` wrappers stopped before running tests because this machine's pnpm policy rejects ignored dependency build scripts (`@google/genai`, `esbuild`, `koffi`, `openclaw`, `protobufjs`, and `sharp`). The underlying TypeScript, unit, and integration commands above passed without changing that dependency policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Persist the latest valid daemon-generated compacted context in registration-scoped process-local state.
- Restore the compacted projection when a context engine is recreated.
- Validate compaction markers, source boundaries, boundary signatures, projection tokens, and lifecycle tokens.
- Clear shared state and local caches after invalid responses, boundary divergence, reset, session end, or superseded runs.
- Clear projection state from already-created engines.
- Preserve live-tool context and session suffixes during assembly.
- Add tests for persistence, races, divergence, incomplete markers, cleanup, and failed-closed behavior.
- TypeScript checks and focused and integration suites passed.
- Documented wrapper commands did not run tests because the machine’s pnpm policy rejects ignored dependency build scripts.
- The state is process-local and does not provide recovery across process restarts.

## Complexity review

- Projection validation, boundary-signature generation, restoration, and transcript assembly remain **O(n)** in the number of session messages or marker content.
- State lookup, lifecycle-token checks, projection-token checks, and cleanup remain **O(1)** per session, excluding transcript and cache processing.
- No clear Big O regression is evident.
- Cyclomatic complexity increases in `context-engine.ts`, especially in compaction validation, projection invalidation, restoration, fallback handling, and lifecycle fencing.
- The implementation adds branches for race handling, reset handling, boundary divergence, stale projections, errors, and cleanup.
- The change increases control-flow complexity and review effort without changing the expected asymptotic complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->