### PR TITLE
fix: harden markdown ingestion readiness and pruning

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -444,6 +444,11 @@
         ],
         "default": "mtime"
       },
+      "markdownIngestionWalkTimeoutMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Per-root stall timeout for markdown ingestion, in milliseconds. Measured as time since the last filesystem call returned, NOT a budget for the whole walk: a large or slow root that keeps making progress is never interrupted. A root that goes this long without a single completed filesystem call is treated as blocked and quarantined for the lifetime of the process."
+      },
       "markdownIngestionMaxTokensPerFile": {
         "type": "number",
         "default": 128000

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -454,8 +454,17 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
             // still is: union what we did see into knownFiles, otherwise a
             // file first discovered during a partial walk is never tracked
             // and a later complete scan cannot prune it when it is deleted.
+            // Only files that still hold a document count -- syncing may have
+            // established a deletion (vanished between readdir and read, or
+            // grown oversized), and re-adding those would make the next
+            // complete scan delete an already-deleted document. Every deletion
+            // path clears fileStates, so it is the authority on what exists.
             for (const file of currentFiles) {
-              rootState.knownFiles.add(file);
+              if (this.fileStates.has(file)) {
+                rootState.knownFiles.add(file);
+              } else {
+                rootState.knownFiles.delete(file);
+              }
             }
           } else {
             await this.pruneDeletedFiles(rootState, currentFiles, stats);

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -97,6 +97,13 @@ interface RootState {
    */
   walkCompletions: number;
   /**
+   * Paths whose document this scan retired. Recorded explicitly rather than
+   * inferred from fileStates, so the partial-walk reconciliation removes only
+   * what it actually deleted and never drops tracking for a file that merely
+   * has no local state yet.
+   */
+  retiredThisScan: Set<string>;
+  /**
    * Set when a directory in this walk could not be enumerated for a reason
    * other than ENOENT. The resulting file set is partial through no fault of
    * the filesystem's contents, so it must not drive the prune pass.
@@ -408,6 +415,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       knownFiles: this.snapshotFilesForRoot(resolved),
       walkCompletions: 0,
       walkIncomplete: false,
+      retiredThisScan: new Set<string>(),
       quarantined: false,
       directoryWatchers: new Map<string, FsWatcherLike>(),
     };
@@ -439,6 +447,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
           const candidates: FileCandidate[] = [];
           rootState.walkCompletions = 0;
           rootState.walkIncomplete = false;
+          rootState.retiredThisScan.clear();
           const walked = await this.walkDirectoryWithTimeout(rootState, currentFiles, stats, candidates);
           if (!walked) {
             // The walk is still blocked in a syscall that may never return.
@@ -454,16 +463,17 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
             // still is: union what we did see into knownFiles, otherwise a
             // file first discovered during a partial walk is never tracked
             // and a later complete scan cannot prune it when it is deleted.
-            // Only files that still hold a document count -- syncing may have
-            // established a deletion (vanished between readdir and read, or
-            // grown oversized), and re-adding those would make the next
-            // complete scan delete an already-deleted document. Every deletion
-            // path clears fileStates, so it is the authority on what exists.
+            // Files this scan retired (vanished between readdir and read, or
+            // grown past the per-file cap) must NOT be re-added, or the next
+            // complete scan would delete an already-deleted document.
+            // Everything else stays tracked, including candidates left unsynced
+            // by backpressure: those may still hold a document, and dropping
+            // them would orphan it.
             for (const file of currentFiles) {
-              if (this.fileStates.has(file)) {
-                rootState.knownFiles.add(file);
-              } else {
+              if (rootState.retiredThisScan.has(file)) {
                 rootState.knownFiles.delete(file);
+              } else {
+                rootState.knownFiles.add(file);
               }
             }
           } else {
@@ -697,6 +707,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         stats.filesDeferred++;
         if (await this.deleteCachedSourceDocument(candidate.path)) {
           stats.filesDeleted++;
+          rootState.retiredThisScan.add(candidate.path);
         }
         continue;
       }
@@ -706,6 +717,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
           mtimeMs: candidate.mtimeMs,
           ctimeMs: candidate.ctimeMs,
         });
+        if (result === "deleted") {
+          rootState.retiredThisScan.add(candidate.path);
+        }
         recordSyncResult(stats, result);
       } catch (error) {
         stats.syncErrors++;

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -11,6 +11,9 @@ import { IngestQueue } from "./ingest-queue.js";
 import type { ClientGetter } from "./plugin-runtime.js";
 
 const DEFAULT_DEBOUNCE_MS = 150;
+// Generous for a filesystem walk (a healthy 800-file root walks in milliseconds);
+// exists to bound walks over directories whose syscalls never return.
+const DEFAULT_WALK_TIMEOUT_MS = 60_000;
 const DEFAULT_TOKENIZER_ID = "markdown-ingest:v1";
 const MARKDOWN_INGEST_VERSION = 3;
 const HASH_BACKEND = "wasm-fnv1a64";
@@ -84,6 +87,16 @@ interface RootState {
   };
   knownFiles: Set<string>;
   directoryWatchers: Map<string, FsWatcherLike>;
+  /**
+   * Set when a directory walk of this root exceeded the walk timeout. Directory
+   * enumeration can block in an uninterruptible syscall (observed on iCloud
+   * Drive paths when file-provider consent is missing: each open blocks ~20s
+   * then fails EINTR, retried forever by libuv), and every blocked call
+   * permanently occupies a libuv threadpool thread. A quarantined root is never
+   * scanned or watched again for the lifetime of this process; a restart
+   * retries it once.
+   */
+  quarantined: boolean;
 }
 
 interface FileState extends MarkdownIngestionSnapshot {
@@ -100,6 +113,7 @@ interface GenericMarkdownSourceConfig {
   snapshotPath?: string;
   priorityMode?: "mtime" | "ctime" | "size" | "fifo";
   maxTokensPerFile?: number;
+  walkTimeoutMs?: number;
 }
 
 interface ScanStats {
@@ -124,7 +138,7 @@ interface FileCandidate {
 }
 
 type SyncMarkdownResult = "ingested" | "unchanged" | "deleted" | "skipped";
-type StreamReadResult = { text: string; fileHash: string } | "too_large" | null;
+type StreamReadResult = { text: string; fileHash: string } | "too_large" | "read_error" | null;
 
 interface MarkdownSnapshotFile {
   version: number;
@@ -190,6 +204,7 @@ export function createMarkdownIngestionHandle(
           snapshotPath: resolveMarkdownSnapshotPath("generic", cfg.markdownIngestionSnapshotPath),
           priorityMode: cfg.markdownIngestionPriorityMode,
           maxTokensPerFile: cfg.markdownIngestionMaxTokensPerFile,
+          walkTimeoutMs: cfg.markdownIngestionWalkTimeoutMs,
         },
         getClient,
         logger,
@@ -211,6 +226,7 @@ export function createMarkdownIngestionHandle(
           snapshotPath: resolveMarkdownSnapshotPath("obsidian", cfg.markdownIngestionObsidianSnapshotPath),
           priorityMode: cfg.markdownIngestionPriorityMode,
           maxTokensPerFile: cfg.markdownIngestionMaxTokensPerFile,
+          walkTimeoutMs: cfg.markdownIngestionWalkTimeoutMs,
         },
         getClient,
         logger,
@@ -271,6 +287,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly snapshotPath: string;
   private readonly priorityMode: "mtime" | "ctime" | "size" | "fifo";
   private readonly maxTokensPerFile: number;
+  private readonly walkTimeoutMs: number;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
   private readonly activeScans = new Set<Promise<void>>();
@@ -299,6 +316,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     this.includePatterns = config.include?.length ? config.include : [];
     this.excludePatterns = config.exclude?.length ? config.exclude : DEFAULT_MARKDOWN_INGEST_EXCLUDES;
     this.debounceMs = config.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.walkTimeoutMs = Math.max(1, Math.trunc(config.walkTimeoutMs ?? DEFAULT_WALK_TIMEOUT_MS));
     this.fsApi = fsApi;
     this.getClient = getClient;
     this.logger = logger;
@@ -373,6 +391,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         resumeFromPath: null,
       },
       knownFiles: this.snapshotFilesForRoot(resolved),
+      quarantined: false,
       directoryWatchers: new Map<string, FsWatcherLike>(),
     };
     this.states.set(resolved, created);
@@ -384,6 +403,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       return;
     }
     const rootState = this.getRootState(root);
+    if (rootState.quarantined) {
+      return;
+    }
     if (rootState.scanState.scanning) {
       rootState.scanState.dirty = true;
       return;
@@ -398,7 +420,14 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         try {
           const currentFiles = new Set<string>();
           const candidates: FileCandidate[] = [];
-          await this.walkDirectory(rootState, rootState.root, currentFiles, stats, candidates);
+          const walked = await this.walkDirectoryWithTimeout(rootState, currentFiles, stats, candidates);
+          if (!walked) {
+            // The walk is still blocked in a syscall that may never return.
+            // Everything below assumes a COMPLETE currentFiles set — pruning
+            // against a partial one would delete documents for files that were
+            // never reached. Skip it all; the root is quarantined.
+            return;
+          }
           await this.syncCandidates(rootState, candidates, stats);
           if (!this.stopping) {
           await this.pruneDeletedFiles(rootState, currentFiles, stats);
@@ -410,7 +439,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         rootState.scanState.scanning = false;
         if (rootState.scanState.dirty) {
           rootState.scanState.dirty = false;
-          if (!this.stopping) {
+          if (!this.stopping && !rootState.quarantined) {
             this.scheduleRootScan(rootState);
           }
         }
@@ -426,7 +455,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   private scheduleRootScan(rootState: RootState, delayMs?: number): void {
-    if (!this.started || this.stopping) {
+    if (!this.started || this.stopping || rootState.quarantined) {
       return;
     }
     if (rootState.scanState.scanning) {
@@ -444,6 +473,48 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }, Math.max(this.debounceMs, delayMs ?? 0));
   }
 
+  /**
+   * Runs walkDirectory bounded by the walk timeout. Returns true when the walk
+   * completed. On timeout the root is quarantined and false is returned; the
+   * orphaned walk cannot be cancelled (the blocking syscall is uninterruptible)
+   * but it checks the quarantine flag between steps, so it goes quiet instead
+   * of continuing to enumerate — and, critically, instead of issuing further
+   * calls into a directory that eats a threadpool thread per attempt.
+   */
+  private async walkDirectoryWithTimeout(
+    rootState: RootState,
+    currentFiles: Set<string>,
+    stats: ScanStats,
+    candidates: FileCandidate[],
+  ): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timedOut = new Promise<"timeout">((resolve) => {
+      timer = setTimeout(() => resolve("timeout"), this.walkTimeoutMs);
+    });
+    const walk = this.walkDirectory(rootState, rootState.root, currentFiles, stats, candidates)
+      .then(() => "walked" as const);
+    try {
+      const winner = await Promise.race([walk, timedOut]);
+      if (winner === "timeout") {
+        rootState.quarantined = true;
+        this.logger.error?.(
+          `[markdown-ingest] directory walk of ${rootState.root} did not complete within ` +
+          `${this.walkTimeoutMs}ms and the root has been quarantined for this process. ` +
+          `No files under it will be ingested or pruned until the next restart. This usually ` +
+          `means enumeration is blocking in the OS (for iCloud Drive paths: missing ` +
+          `file-provider consent for this binary).`,
+        );
+        // The abandoned walk still holds real work; keep failures from
+        // surfacing as unhandled rejections.
+        walk.then(() => {}, () => {});
+        return false;
+      }
+      return true;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   private async walkDirectory(
     rootState: RootState,
     dir: string,
@@ -456,8 +527,14 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       return;
     }
 
+    if (rootState.quarantined) {
+      return;
+    }
     stats.directoriesScanned++;
     await this.ensureDirectoryWatcher(rootState, dir);
+    if (rootState.quarantined) {
+      return;
+    }
 
     let entries: FsDirentLike[];
     try {
@@ -471,7 +548,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
 
     for (const entry of entries) {
-      if (this.stopping) {
+      if (this.stopping || rootState.quarantined) {
         return;
       }
       const child = path.join(dir, entry.name);
@@ -489,7 +566,17 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       stats.filesIncluded++;
       const stat = await this.safeStatWithCtime(child);
-      if (!stat) {
+      if (stat === "missing") {
+        // Genuinely gone between readdir and stat; leaving it out of
+        // currentFiles lets pruneDeletedFiles retire its document.
+        continue;
+      }
+      if (stat === "error") {
+        // Transient failure (EINTR, EPERM, EIO...): we know nothing about the
+        // file's fate, so protect its document from the prune pass and let a
+        // later scan retry it.
+        currentFiles.add(child);
+        stats.syncErrors++;
         continue;
       }
       currentFiles.add(child);
@@ -653,11 +740,17 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     // Re-check existence when initialStat is provided — the file may have been
     // deleted between the scan pass and the sync pass.
     const stat = initialStat ?? (await this.safeStatWithCtime(filePath));
-    if (!stat) {
+    if (stat === "missing") {
       await this.deleteSourceDocument(sourceDoc);
       this.fileStates.delete(sourceDoc);
       this.snapshotDirty = true;
       return "deleted";
+    }
+    if (stat === "error") {
+      // Unknown state is not deletion evidence; keep the document and let a
+      // later scan retry.
+      this.logger.warn?.(`[markdown-ingest] stat failed for ${sourceDoc}; keeping existing document`);
+      return "skipped";
     }
 
     const cached = this.fileStates.get(sourceDoc);
@@ -671,6 +764,13 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       if (cached && await this.deleteCachedSourceDocument(sourceDoc)) {
         return "deleted";
       }
+      return "skipped";
+    }
+    if (streamed === "read_error") {
+      // The file exists (it just passed stat) but could not be read. That is a
+      // transient condition, not deletion evidence; the old behavior here
+      // deleted the document from the daemon on ANY read failure.
+      this.logger.warn?.(`[markdown-ingest] read failed for ${sourceDoc}; keeping existing document`);
       return "skipped";
     }
     if (!streamed) {
@@ -851,11 +951,15 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
   }
 
-  private async safeStatWithCtime(filePath: string): Promise<{ size: number; mtimeMs: number; ctimeMs: number } | null> {
+  private async safeStatWithCtime(
+    filePath: string,
+  ): Promise<{ size: number; mtimeMs: number; ctimeMs: number } | "missing" | "error"> {
     try {
       return await this.fsApi.stat(filePath);
-    } catch {
-      return null;
+    } catch (error) {
+      // Only a confirmed ENOENT means the file is gone. Any other failure is a
+      // transient condition that must never be treated as deletion evidence.
+      return formatError(error).includes("ENOENT") ? "missing" : "error";
     }
   }
 
@@ -887,8 +991,10 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         text: chunks.join(""),
         fileHash: hash.toString(16).padStart(16, "0"),
       };
-    } catch {
-      return null;
+    } catch (error) {
+      // null (-> delete) only for a confirmed ENOENT; anything else is
+      // transient and must not retire the document.
+      return formatError(error).includes("ENOENT") ? null : "read_error";
     } finally {
       if (stream) {
         await stream.close().catch(() => {});

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -487,18 +487,35 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     stats: ScanStats,
     candidates: FileCandidate[],
   ): Promise<boolean> {
+    // Stall detector, not a total-time cap: a large or cold root that keeps
+    // completing operations is never quarantined, however long the full walk
+    // takes. Quarantine fires only when NO filesystem operation completes for
+    // walkTimeoutMs straight -- the signature of a blocked syscall.
     let timer: ReturnType<typeof setTimeout> | null = null;
-    const timedOut = new Promise<"timeout">((resolve) => {
-      timer = setTimeout(() => resolve("timeout"), this.walkTimeoutMs);
-    });
+    let resolveStalled: (v: "stalled") => void = () => {};
+    const stalled = new Promise<"stalled">((resolve) => { resolveStalled = resolve; });
+    const progress = () => stats.directoriesScanned + stats.markdownFilesSeen;
+    let lastProgress = progress();
+    const arm = () => {
+      timer = setTimeout(() => {
+        const now = progress();
+        if (now === lastProgress) {
+          resolveStalled("stalled");
+          return;
+        }
+        lastProgress = now;
+        arm();
+      }, this.walkTimeoutMs);
+    };
+    arm();
     const walk = this.walkDirectory(rootState, rootState.root, currentFiles, stats, candidates)
       .then(() => "walked" as const);
     try {
-      const winner = await Promise.race([walk, timedOut]);
-      if (winner === "timeout") {
+      const winner = await Promise.race([walk, stalled]);
+      if (winner === "stalled") {
         rootState.quarantined = true;
         this.logger.error?.(
-          `[markdown-ingest] directory walk of ${rootState.root} did not complete within ` +
+          `[markdown-ingest] directory walk of ${rootState.root} made no progress for ` +
           `${this.walkTimeoutMs}ms and the root has been quarantined for this process. ` +
           `No files under it will be ingested or pruned until the next restart. This usually ` +
           `means enumeration is blocking in the OS (for iCloud Drive paths: missing ` +
@@ -747,10 +764,10 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       return "deleted";
     }
     if (stat === "error") {
-      // Unknown state is not deletion evidence; keep the document and let a
-      // later scan retry.
-      this.logger.warn?.(`[markdown-ingest] stat failed for ${sourceDoc}; keeping existing document`);
-      return "skipped";
+      // Unknown state is not deletion evidence; keep the document. Thrown so
+      // the caller's catch counts it as a sync error -- a persistent failure
+      // must show up in scan stats, not disappear into the skipped count.
+      throw new Error(`stat failed transiently for ${sourceDoc}; keeping existing document`);
     }
 
     const cached = this.fileStates.get(sourceDoc);
@@ -769,9 +786,10 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     if (streamed === "read_error") {
       // The file exists (it just passed stat) but could not be read. That is a
       // transient condition, not deletion evidence; the old behavior here
-      // deleted the document from the daemon on ANY read failure.
-      this.logger.warn?.(`[markdown-ingest] read failed for ${sourceDoc}; keeping existing document`);
-      return "skipped";
+      // deleted the document from the daemon on ANY read failure. Thrown so it
+      // lands in the caller's sync-error accounting rather than vanishing into
+      // the skipped count.
+      throw new Error(`read failed transiently for ${sourceDoc}; keeping existing document`);
     }
     if (!streamed) {
       await this.deleteSourceDocument(sourceDoc);
@@ -959,7 +977,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     } catch (error) {
       // Only a confirmed ENOENT means the file is gone. Any other failure is a
       // transient condition that must never be treated as deletion evidence.
-      return formatError(error).includes("ENOENT") ? "missing" : "error";
+      return isEnoent(error) ? "missing" : "error";
     }
   }
 
@@ -994,7 +1012,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     } catch (error) {
       // null (-> delete) only for a confirmed ENOENT; anything else is
       // transient and must not retire the document.
-      return formatError(error).includes("ENOENT") ? null : "read_error";
+      return isEnoent(error) ? null : "read_error";
     } finally {
       if (stream) {
         await stream.close().catch(() => {});
@@ -1158,6 +1176,22 @@ function resolveMarkdownSnapshotPath(kind: string, configuredPath?: string): str
 
 function isMarkdownIngestionEnabled(cfg: PluginConfig, roots: string[]): boolean {
   return cfg.markdownIngestionEnabled === true && roots.length > 0;
+}
+
+/**
+ * True only for a confirmed ENOENT, checked via the error code through the
+ * cause chain. Never string-matches the message: a wrapped or localized error
+ * whose text merely mentions ENOENT must not count as proof of deletion.
+ */
+function isEnoent(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 8 && current; depth += 1) {
+    if (typeof current === "object" && (current as { code?: unknown }).code === "ENOENT") {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 function createRealFsApi(): FsApi {

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -1120,7 +1120,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     try {
       raw = await fsp.readFile(this.snapshotPath, "utf8");
     } catch (error) {
-      if (!formatError(error).includes("ENOENT")) {
+      if (!isEnoent(error)) {
         this.logger.warn?.(`[markdown-ingest] failed to read snapshot ${this.snapshotPath}: ${formatError(error)}`);
       }
       return;

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -88,6 +88,21 @@ interface RootState {
   knownFiles: Set<string>;
   directoryWatchers: Map<string, FsWatcherLike>;
   /**
+   * Incremented after each filesystem call of THIS root's walk returns. The
+   * stall detector watches it rather than the scan stats, which count
+   * attempts. Per-root rather than per-adapter: watcher-triggered scans can
+   * overlap across roots, and a shared counter would let a busy root mask a
+   * stalled sibling indefinitely. Only one walk runs per root at a time
+   * (scanState.scanning), so a single counter per root is sufficient.
+   */
+  walkCompletions: number;
+  /**
+   * Set when a directory in this walk could not be enumerated for a reason
+   * other than ENOENT. The resulting file set is partial through no fault of
+   * the filesystem's contents, so it must not drive the prune pass.
+   */
+  walkIncomplete: boolean;
+  /**
    * Set when a directory walk of this root exceeded the walk timeout. Directory
    * enumeration can block in an uninterruptible syscall (observed on iCloud
    * Drive paths when file-provider consent is missing: each open blocks ~20s
@@ -288,13 +303,6 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly priorityMode: "mtime" | "ctime" | "size" | "fifo";
   private readonly maxTokensPerFile: number;
   private readonly walkTimeoutMs: number;
-  /**
-   * Incremented after each filesystem call in a walk RETURNS. The stall
-   * detector watches this rather than the scan stats, which count attempts:
-   * a root is only quarantined when nothing completes, never merely because
-   * one slow call is outstanding.
-   */
-  private walkCompletions = 0;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
   private readonly activeScans = new Set<Promise<void>>();
@@ -398,6 +406,8 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         resumeFromPath: null,
       },
       knownFiles: this.snapshotFilesForRoot(resolved),
+      walkCompletions: 0,
+      walkIncomplete: false,
       quarantined: false,
       directoryWatchers: new Map<string, FsWatcherLike>(),
     };
@@ -427,6 +437,8 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         try {
           const currentFiles = new Set<string>();
           const candidates: FileCandidate[] = [];
+          rootState.walkCompletions = 0;
+          rootState.walkIncomplete = false;
           const walked = await this.walkDirectoryWithTimeout(rootState, currentFiles, stats, candidates);
           if (!walked) {
             // The walk is still blocked in a syscall that may never return.
@@ -437,8 +449,10 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
           }
           await this.syncCandidates(rootState, candidates, stats);
           if (!this.stopping) {
-          await this.pruneDeletedFiles(rootState, currentFiles, stats);
-          rootState.knownFiles = currentFiles;
+          if (!rootState.walkIncomplete) {
+            await this.pruneDeletedFiles(rootState, currentFiles, stats);
+            rootState.knownFiles = currentFiles;
+          }
           await this.saveSnapshotIfDirty();
           this.logScanStats(rootState.root, stats, Date.now() - startedAt);
         }
@@ -501,7 +515,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     let timer: ReturnType<typeof setTimeout> | null = null;
     let resolveStalled: (v: "stalled") => void = () => {};
     const stalled = new Promise<"stalled">((resolve) => { resolveStalled = resolve; });
-    const progress = () => this.walkCompletions;
+    const progress = () => rootState.walkCompletions;
     let lastProgress = progress();
     const arm = () => {
       timer = setTimeout(() => {
@@ -563,13 +577,22 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     let entries: FsDirentLike[];
     try {
       entries = await this.fsApi.readdir(dir);
-      this.walkCompletions += 1;
+      rootState.walkCompletions += 1;
     } catch (error) {
-      this.walkCompletions += 1;
-      const message = formatError(error);
-      if (!message.includes("ENOENT")) {
-        this.logger.warn?.(`[markdown-ingest] readdir failed for ${dir}: ${message}`);
+      rootState.walkCompletions += 1;
+      if (isEnoent(error)) {
+        // The directory really is gone; its files are legitimately absent from
+        // the walk and the prune pass should retire their documents.
+        return;
       }
+      // Anything else (EPERM, EIO, EINTR...) means we cannot see what is in
+      // there. Marking the walk partial keeps the prune pass from deleting
+      // every document under this directory on a transient error.
+      rootState.walkIncomplete = true;
+      this.logger.warn?.(
+        `[markdown-ingest] readdir failed for ${dir}: ${formatError(error)}; ` +
+        `skipping prune for this scan to avoid retiring documents we cannot see`,
+      );
       return;
     }
 
@@ -592,7 +615,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       stats.filesIncluded++;
       const stat = await this.safeStatWithCtime(child);
-      this.walkCompletions += 1;
+      rootState.walkCompletions += 1;
       if (stat === "missing") {
         // Genuinely gone between readdir and stat; leaving it out of
         // currentFiles lets pruneDeletedFiles retire its document.

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -288,6 +288,13 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private readonly priorityMode: "mtime" | "ctime" | "size" | "fifo";
   private readonly maxTokensPerFile: number;
   private readonly walkTimeoutMs: number;
+  /**
+   * Incremented after each filesystem call in a walk RETURNS. The stall
+   * detector watches this rather than the scan stats, which count attempts:
+   * a root is only quarantined when nothing completes, never merely because
+   * one slow call is outstanding.
+   */
+  private walkCompletions = 0;
   private readonly states = new Map<string, RootState>();
   private readonly fileStates = new Map<string, FileState>();
   private readonly activeScans = new Set<Promise<void>>();
@@ -474,8 +481,8 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   }
 
   /**
-   * Runs walkDirectory bounded by the walk timeout. Returns true when the walk
-   * completed. On timeout the root is quarantined and false is returned; the
+   * Runs walkDirectory under a stall watchdog. Returns true when the walk
+   * completed. On a stall the root is quarantined and false is returned; the
    * orphaned walk cannot be cancelled (the blocking syscall is uninterruptible)
    * but it checks the quarantine flag between steps, so it goes quiet instead
    * of continuing to enumerate — and, critically, instead of issuing further
@@ -494,7 +501,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     let timer: ReturnType<typeof setTimeout> | null = null;
     let resolveStalled: (v: "stalled") => void = () => {};
     const stalled = new Promise<"stalled">((resolve) => { resolveStalled = resolve; });
-    const progress = () => stats.directoriesScanned + stats.markdownFilesSeen;
+    const progress = () => this.walkCompletions;
     let lastProgress = progress();
     const arm = () => {
       timer = setTimeout(() => {
@@ -556,7 +563,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     let entries: FsDirentLike[];
     try {
       entries = await this.fsApi.readdir(dir);
+      this.walkCompletions += 1;
     } catch (error) {
+      this.walkCompletions += 1;
       const message = formatError(error);
       if (!message.includes("ENOENT")) {
         this.logger.warn?.(`[markdown-ingest] readdir failed for ${dir}: ${message}`);
@@ -583,6 +592,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       stats.filesIncluded++;
       const stat = await this.safeStatWithCtime(child);
+      this.walkCompletions += 1;
       if (stat === "missing") {
         // Genuinely gone between readdir and stat; leaving it out of
         // currentFiles lets pruneDeletedFiles retire its document.

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -161,7 +161,7 @@ interface FileCandidate {
 }
 
 type SyncMarkdownResult = "ingested" | "unchanged" | "deleted" | "skipped";
-type StreamReadResult = { text: string; fileHash: string } | "too_large" | "read_error" | null;
+type StreamReadResult = { text: string; fileHash: string } | "too_large" | { failed: string } | null;
 
 interface MarkdownSnapshotFile {
   version: number;
@@ -649,10 +649,12 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
         // currentFiles lets pruneDeletedFiles retire its document.
         continue;
       }
-      if (stat === "error") {
-        // Transient failure (EINTR, EPERM, EIO...): we know nothing about the
-        // file's fate, so protect its document from the prune pass and let a
-        // later scan retry it.
+      if ("failed" in stat) {
+        // Transient failure: we know nothing about the file's fate, so protect
+        // its document from the prune pass and let a later scan retry it. The
+        // original failure (EINTR, EPERM, EIO...) goes to the log — errno
+        // detail is how the incident behind this code was diagnosed.
+        this.logger.warn?.(`[markdown-ingest] stat failed for ${child}: ${stat.failed}; keeping existing document`);
         currentFiles.add(child);
         stats.syncErrors++;
         continue;
@@ -823,11 +825,12 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       await this.retireDocument(rootState, sourceDoc);
       return "deleted";
     }
-    if (stat === "error") {
+    if ("failed" in stat) {
       // Unknown state is not deletion evidence; keep the document. Thrown so
       // the caller's catch counts it as a sync error -- a persistent failure
-      // must show up in scan stats, not disappear into the skipped count.
-      throw new Error(`stat failed transiently for ${sourceDoc}; keeping existing document`);
+      // must show up in scan stats, not disappear into the skipped count --
+      // and the original failure text rides along for diagnostics.
+      throw new Error(`stat failed transiently for ${sourceDoc} (${stat.failed}); keeping existing document`);
     }
 
     const cached = this.fileStates.get(sourceDoc);
@@ -844,13 +847,13 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       }
       return "skipped";
     }
-    if (streamed === "read_error") {
+    if (streamed !== null && "failed" in streamed) {
       // The file exists (it just passed stat) but could not be read. That is a
       // transient condition, not deletion evidence; the old behavior here
       // deleted the document from the daemon on ANY read failure. Thrown so it
       // lands in the caller's sync-error accounting rather than vanishing into
-      // the skipped count.
-      throw new Error(`read failed transiently for ${sourceDoc}; keeping existing document`);
+      // the skipped count, with the original failure text for diagnostics.
+      throw new Error(`read failed transiently for ${sourceDoc} (${streamed.failed}); keeping existing document`);
     }
     if (!streamed) {
       await this.retireDocument(rootState, sourceDoc);
@@ -1044,13 +1047,15 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
 
   private async safeStatWithCtime(
     filePath: string,
-  ): Promise<{ size: number; mtimeMs: number; ctimeMs: number } | "missing" | "error"> {
+  ): Promise<{ size: number; mtimeMs: number; ctimeMs: number } | "missing" | { failed: string }> {
     try {
       return await this.fsApi.stat(filePath);
     } catch (error) {
       // Only a confirmed ENOENT means the file is gone. Any other failure is a
-      // transient condition that must never be treated as deletion evidence.
-      return isEnoent(error) ? "missing" : "error";
+      // transient condition that must never be treated as deletion evidence —
+      // and its detail (EINTR, EPERM, EIO...) is diagnostic gold, so it is
+      // carried along rather than collapsed into a bare sentinel.
+      return isEnoent(error) ? "missing" : { failed: formatError(error) };
     }
   }
 
@@ -1084,8 +1089,9 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       };
     } catch (error) {
       // null (-> delete) only for a confirmed ENOENT; anything else is
-      // transient and must not retire the document.
-      return isEnoent(error) ? null : "read_error";
+      // transient and must not retire the document. The detail rides along
+      // for diagnostics.
+      return isEnoent(error) ? null : { failed: formatError(error) };
     } finally {
       if (stream) {
         await stream.close().catch(() => {});

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -449,7 +449,15 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
           }
           await this.syncCandidates(rootState, candidates, stats);
           if (!this.stopping) {
-          if (!rootState.walkIncomplete) {
+          if (rootState.walkIncomplete) {
+            // Absence is not evidence here, so nothing is pruned. Presence
+            // still is: union what we did see into knownFiles, otherwise a
+            // file first discovered during a partial walk is never tracked
+            // and a later complete scan cannot prune it when it is deleted.
+            for (const file of currentFiles) {
+              rootState.knownFiles.add(file);
+            }
+          } else {
             await this.pruneDeletedFiles(rootState, currentFiles, stats);
             rootState.knownFiles = currentFiles;
           }

--- a/src/markdown-ingest.ts
+++ b/src/markdown-ingest.ts
@@ -115,8 +115,9 @@ interface RootState {
    * Drive paths when file-provider consent is missing: each open blocks ~20s
    * then fails EINTR, retried forever by libuv), and every blocked call
    * permanently occupies a libuv threadpool thread. A quarantined root is never
-   * scanned or watched again for the lifetime of this process; a restart
-   * retries it once.
+   * scanned again for the lifetime of this process, and no new watchers are
+   * created for it; watchers registered before the stall stay open until
+   * stop(), but they cannot schedule a scan. A restart retries the root once.
    */
   quarantined: boolean;
 }
@@ -717,9 +718,6 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
           mtimeMs: candidate.mtimeMs,
           ctimeMs: candidate.ctimeMs,
         });
-        if (result === "deleted") {
-          rootState.retiredThisScan.add(candidate.path);
-        }
         recordSyncResult(stats, result);
       } catch (error) {
         stats.syncErrors++;
@@ -818,13 +816,11 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     const sourceDoc = filePath;
     const relativePath = toPosixPath(path.relative(rootState.root, filePath));
 
-    // Re-check existence when initialStat is provided — the file may have been
-    // deleted between the scan pass and the sync pass.
+    // The walk's stat is reused when it supplied one; a file deleted between
+    // the walk and this point surfaces as an ENOENT from the read below.
     const stat = initialStat ?? (await this.safeStatWithCtime(filePath));
     if (stat === "missing") {
-      await this.deleteSourceDocument(sourceDoc);
-      this.fileStates.delete(sourceDoc);
-      this.snapshotDirty = true;
+      await this.retireDocument(rootState, sourceDoc);
       return "deleted";
     }
     if (stat === "error") {
@@ -843,6 +839,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     const streamed = await this.safeReadFileStreamed(filePath, maxBytes);
     if (streamed === "too_large") {
       if (cached && await this.deleteCachedSourceDocument(sourceDoc)) {
+        rootState.retiredThisScan.add(sourceDoc);
         return "deleted";
       }
       return "skipped";
@@ -856,9 +853,7 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
       throw new Error(`read failed transiently for ${sourceDoc}; keeping existing document`);
     }
     if (!streamed) {
-      await this.deleteSourceDocument(sourceDoc);
-      this.fileStates.delete(sourceDoc);
-      this.snapshotDirty = true;
+      await this.retireDocument(rootState, sourceDoc);
       return "deleted";
     }
 
@@ -876,9 +871,10 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
     }
 
     if (this.kind === "obsidian" && this.includePatterns.length === 0 && !looksLikeObsidianNote(filePath, text)) {
-      await this.deleteSourceDocument(sourceDoc);
-      this.fileStates.delete(sourceDoc);
-      this.snapshotDirty = true;
+      // Retires the document even though the result is "skipped" rather than
+      // "deleted", which is exactly why retirement is recorded here and not
+      // inferred from the return value at the call site.
+      await this.retireDocument(rootState, sourceDoc);
       return "skipped";
     }
     await this.ingestMarkdownDocument(sourceDoc, text, rootState.root, relativePath, fileHash, stat.size, stat.mtimeMs, stat.ctimeMs);
@@ -966,6 +962,19 @@ class DirectoryMarkdownSourceAdapter implements MarkdownSourceAdapter {
   private async deleteSourceDocument(sourceDoc: string): Promise<void> {
     const queue = await this.getIngestQueue();
     await queue.enqueueDelete(sourceDoc);
+  }
+
+  /**
+   * Deletes a document and records the retirement on the scan, so the
+   * partial-walk reconciliation knows this path no longer holds one. Every
+   * in-scan retirement goes through here or through
+   * deleteCachedSourceDocument, whose callers record it.
+   */
+  private async retireDocument(rootState: RootState, sourceDoc: string): Promise<void> {
+    await this.deleteSourceDocument(sourceDoc);
+    this.fileStates.delete(sourceDoc);
+    this.snapshotDirty = true;
+    rootState.retiredThisScan.add(sourceDoc);
   }
 
   private async deleteCachedSourceDocument(sourceDoc: string): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,13 @@ export interface PluginConfig {
   markdownIngestionDebounceMs?: number;
   markdownIngestionPriorityMode?: "mtime" | "ctime" | "size" | "fifo";
   markdownIngestionMaxTokensPerFile?: number;
+  /**
+   * Per-root stall timeout in milliseconds (default 60000). Measured as time
+   * since the last filesystem call returned, not as a budget for the whole
+   * walk: a large or slow root that keeps making progress is never
+   * interrupted. A root that goes this long with no completed filesystem call
+   * is treated as blocked and quarantined until the process restarts.
+   */
   markdownIngestionWalkTimeoutMs?: number;
   markdownIngestionSnapshotPath?: string;
   markdownIngestionObsidianSnapshotPath?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface PluginConfig {
   markdownIngestionDebounceMs?: number;
   markdownIngestionPriorityMode?: "mtime" | "ctime" | "size" | "fifo";
   markdownIngestionMaxTokensPerFile?: number;
+  markdownIngestionWalkTimeoutMs?: number;
   markdownIngestionSnapshotPath?: string;
   markdownIngestionObsidianSnapshotPath?: string;
   dreamPromotionEnabled?: boolean;

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1516,3 +1516,56 @@ test("a directory we cannot enumerate does not prune the documents hidden behind
 
   await handle.stop();
 });
+
+test("an obsidian note that stops qualifying is retired without being re-tracked", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-obsidian-retire-"));
+  const root = path.join(tempRoot, "vault");
+  const subDir = path.join(root, "sub");
+  const notePath = path.join(root, "note.md");
+  const rpc = new FakeRpcClient();
+  const fsApi = new FailingReaddirFsApi();
+  await fsApi.mkdir(root);
+  await fsApi.mkdir(subDir);
+  await fsApi.writeFile(path.join(subDir, "keep.md"), "#project keep\n", 1000);
+  await fsApi.writeFile(notePath, "#project a tagged note\n", 1000);
+
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionObsidianEnabled: true,
+      markdownIngestionObsidianRoots: [root],
+      markdownIngestionObsidianSnapshotPath: snapshotPath(tempRoot, "obsidian"),
+    },
+    async () => rpc as never,
+    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+  await handle.start();
+  assert.ok(rpc.documents.has(path.resolve(notePath)), "tagged note was not ingested");
+
+  const countDeletes = () => rpc.calls.filter(
+    (c) => c.method === "delete_authored_document"
+      && (c.params as { sourceDoc: string }).sourceDoc === path.resolve(notePath),
+  ).length;
+
+  // Partial walk: the note loses its tag, so it stops qualifying and its
+  // document is retired. This path returns "skipped", not "deleted" — the
+  // reason retirement is recorded at the deletion site rather than inferred
+  // from the result at the call site.
+  fsApi.failReaddirFor.add(path.resolve(subDir));
+  await fsApi.writeFile(notePath, "just prose now, no tag\n", 2000);
+  await handle.refresh();
+  assert.ok(!rpc.documents.has(path.resolve(notePath)), "untagged note was not retired");
+  assert.equal(countDeletes(), 1, "expected exactly one retire");
+
+  // The file then leaves and a complete walk runs: nothing more to delete.
+  await fsApi.rm(notePath);
+  fsApi.failReaddirFor.clear();
+  await handle.refresh();
+  assert.equal(
+    countDeletes(),
+    1,
+    "a document retired by obsidian filtering was deleted again by the prune pass",
+  );
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -85,6 +85,9 @@ class FakeFsApi {
   async rmdir(dir: string): Promise<void> {
     const abs = path.resolve(dir);
     this.dirs.delete(abs);
+    for (const d of [...this.dirs]) {
+      if (d.startsWith(abs + path.sep)) this.dirs.delete(d);
+    }
     for (const filePath of [...this.files.keys()]) {
       if (filePath.startsWith(abs + path.sep)) this.files.delete(filePath);
     }
@@ -1160,7 +1163,9 @@ class HangingReaddirFsApi extends FakeFsApi {
   readdirAttempts = 0;
   hangEnabled = true;
   override async readdir(dir: string): Promise<FsDirentLike[]> {
-    if (this.hangEnabled && path.resolve(dir).startsWith(path.resolve(this.hangPrefix))) {
+    const abs = path.resolve(dir);
+    const prefix = path.resolve(this.hangPrefix);
+    if (this.hangEnabled && (abs === prefix || abs.startsWith(prefix + path.sep))) {
       this.readdirAttempts += 1;
       return new Promise(() => {}); // blocks forever, like an uninterruptible open
     }
@@ -1374,8 +1379,10 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-slow-"));
   const root = path.join(tempRoot, "slow");
   const rpc = new FakeRpcClient();
-  // Each stat takes 60ms; the stall timeout is 100ms. No single call exceeds
-  // it, but the whole walk (6 files) takes ~360ms — over 3x the timeout.
+  // Each stat takes 60ms against a 400ms stall window, so no single step comes
+  // close to stalling even on a loaded runner, while the whole walk (6 files,
+  // ~360ms) still has to outlive a naive total-elapsed cap set at the same
+  // value. That is the distinction under test.
   const fsApi = new SlowButProgressingFsApi(60);
   await fsApi.mkdir(root);
   for (let i = 0; i < 6; i += 1) {
@@ -1388,7 +1395,7 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
       markdownIngestionEnabled: true,
       markdownIngestionRoots: [root],
       markdownIngestionSnapshotPath: snapshotPath(tempRoot),
-      markdownIngestionWalkTimeoutMs: 100,
+      markdownIngestionWalkTimeoutMs: 400,
     },
     async () => rpc as never,
     { error: (m: string) => errors.push(m), warn: () => {}, info: () => {} } as never,
@@ -1397,7 +1404,7 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
 
   await handle.start();
 
-  // The walk outlived the timeout many times over but never stalled, so the
+  // The walk outlived the timeout but never stalled, so the
   // root must be fully ingested and never quarantined. A total-elapsed cap
   // would have quarantined it here.
   assert.deepEqual(errors, [], `slow-but-healthy root was quarantined: ${errors.join(" | ")}`);

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1276,6 +1276,7 @@ test("a transient read failure keeps the document; only ENOENT deletes it", asyn
   await fsApi.mkdir(root);
   await fsApi.writeFile(notePath, "# v1\n", 1000);
 
+  const warns: string[] = [];
   const handle = createMarkdownIngestionHandle(
     {
       markdownIngestionEnabled: true,
@@ -1283,7 +1284,7 @@ test("a transient read failure keeps the document; only ENOENT deletes it", asyn
       markdownIngestionSnapshotPath: snapshotPath(tempRoot),
     },
     async () => rpc as never,
-    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    { error: () => {}, warn: (m: string) => warns.push(m), info: () => {} } as never,
     fsApi as never,
   );
   await handle.start();
@@ -1300,6 +1301,12 @@ test("a transient read failure keeps the document; only ENOENT deletes it", asyn
     "a transient read failure deleted the document",
   );
   assert.ok(rpc.documents.has(path.resolve(notePath)), "document lost after read failure");
+  // The original failure detail must survive to the log: errno text is how the
+  // production incident behind this change was diagnosed.
+  assert.ok(
+    warns.some((m) => m.includes("EPERM")),
+    `expected a warning carrying the EPERM detail, got: ${JSON.stringify(warns)}`,
+  );
 
   // Reading heals: the changed content is ingested on the next scan.
   fsApi.failReadsFor.clear();
@@ -1342,6 +1349,7 @@ test("a transient stat failure protects the file from the prune pass", async () 
   await fsApi.writeFile(aPath, "# a\n", 1000);
   await fsApi.writeFile(bPath, "# b\n", 1000);
 
+  const warns: string[] = [];
   const handle = createMarkdownIngestionHandle(
     {
       markdownIngestionEnabled: true,
@@ -1349,7 +1357,7 @@ test("a transient stat failure protects the file from the prune pass", async () 
       markdownIngestionSnapshotPath: snapshotPath(tempRoot),
     },
     async () => rpc as never,
-    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    { error: () => {}, warn: (m: string) => warns.push(m), info: () => {} } as never,
     fsApi as never,
   );
   await handle.start();
@@ -1362,6 +1370,10 @@ test("a transient stat failure protects the file from the prune pass", async () 
   assert.ok(
     rpc.documents.has(path.resolve(aPath)),
     "a transiently unstattable file was pruned from the daemon",
+  );
+  assert.ok(
+    warns.some((m) => m.includes("EINTR")),
+    `expected a warning carrying the EINTR detail, got: ${JSON.stringify(warns)}`,
   );
 
   await handle.stop();

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1133,3 +1133,181 @@ test("markdown ingestion default-excludes dependency and build directories", asy
 
   await handle.stop();
 });
+
+// ---------------------------------------------------------------------------
+// Hardening: a root whose directory enumeration never returns must not block
+// startup forever, and transient read/stat failures must never delete
+// documents from the daemon. Motivated by a production incident where iCloud
+// Drive enumeration blocked ~20s per call in an uninterruptible syscall
+// (missing file-provider consent), libuv retried on EINTR indefinitely,
+// gateway readiness never completed, and the cron scheduler was down for 48h.
+// ---------------------------------------------------------------------------
+
+class HangingReaddirFsApi extends FakeFsApi {
+  constructor(private readonly hangPrefix: string) { super(); }
+  readdirAttempts = 0;
+  override async readdir(dir: string): Promise<FsDirentLike[]> {
+    if (path.resolve(dir).startsWith(path.resolve(this.hangPrefix))) {
+      this.readdirAttempts += 1;
+      return new Promise(() => {}); // blocks forever, like an uninterruptible open
+    }
+    return super.readdir(dir);
+  }
+}
+
+test("a root whose walk never completes is quarantined instead of blocking start()", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-quarantine-"));
+  const hungRoot = path.join(tempRoot, "hung");
+  const goodRoot = path.join(tempRoot, "good");
+  const rpc = new FakeRpcClient();
+  const fsApi = new HangingReaddirFsApi(hungRoot);
+  await fsApi.mkdir(hungRoot);
+  await fsApi.mkdir(goodRoot);
+  await fsApi.writeFile(path.join(goodRoot, "note.md"), "# healthy root\n", 1000);
+
+  const errors: string[] = [];
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [hungRoot, goodRoot],
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+      markdownIngestionWalkTimeoutMs: 200,
+    },
+    async () => rpc as never,
+    { error: (m: string) => errors.push(m), warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+
+  const startedAt = Date.now();
+  await handle.start();
+  const elapsed = Date.now() - startedAt;
+
+  // start() returned despite the hung root, and well under the hang horizon.
+  assert.ok(elapsed < 5_000, `start() took ${elapsed}ms; the hung root blocked it`);
+  // The healthy root was still ingested.
+  assert.ok(
+    rpc.calls.some((c) => c.method === "ingest_markdown_document"),
+    "healthy root was not ingested",
+  );
+  // Nothing was deleted: a partial walk must never feed the prune pass.
+  assert.equal(
+    rpc.calls.filter((c) => c.method === "delete_authored_document").length,
+    0,
+    "quarantined scan deleted documents",
+  );
+  assert.ok(
+    errors.some((m) => m.includes("quarantined")),
+    "quarantine was not reported at error level",
+  );
+
+  // The quarantine holds: another refresh does not touch the hung root again.
+  const attemptsAfterStart = fsApi.readdirAttempts;
+  assert.equal(attemptsAfterStart, 1, "expected exactly one enumeration attempt on the hung root");
+  await handle.refresh();
+  assert.equal(fsApi.readdirAttempts, attemptsAfterStart, "quarantined root was re-enumerated");
+
+  await handle.stop();
+});
+
+class FailingReadFsApi extends FakeFsApi {
+  failReadsFor = new Set<string>();
+  failStatsFor = new Set<string>();
+  override async openReadStream(filePath: string) {
+    if (this.failReadsFor.has(path.resolve(filePath))) {
+      throw Object.assign(new Error(`EPERM: operation not permitted, open '${filePath}'`), { code: "EPERM" });
+    }
+    return super.openReadStream(filePath);
+  }
+  override async stat(filePath: string) {
+    if (this.failStatsFor.has(path.resolve(filePath))) {
+      throw Object.assign(new Error(`EINTR: interrupted system call, stat '${filePath}'`), { code: "EINTR" });
+    }
+    return super.stat(filePath);
+  }
+}
+
+test("a transient read failure keeps the document; only ENOENT deletes it", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-readerr-"));
+  const root = path.join(tempRoot, "docs");
+  const notePath = path.join(root, "note.md");
+  const rpc = new FakeRpcClient();
+  const fsApi = new FailingReadFsApi();
+  await fsApi.mkdir(root);
+  await fsApi.writeFile(notePath, "# v1\n", 1000);
+
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [root],
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+    },
+    async () => rpc as never,
+    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+  await handle.start();
+  assert.ok(rpc.documents.has(path.resolve(notePath)), "initial ingest failed");
+
+  // The file changes but reading it now fails with EPERM: the document must
+  // survive. The old behavior deleted it on any read failure.
+  await fsApi.writeFile(notePath, "# v2\n", 2000);
+  fsApi.failReadsFor.add(path.resolve(notePath));
+  await handle.refresh();
+  assert.equal(
+    rpc.calls.filter((c) => c.method === "delete_authored_document").length,
+    0,
+    "a transient read failure deleted the document",
+  );
+  assert.ok(rpc.documents.has(path.resolve(notePath)), "document lost after read failure");
+
+  // Reading heals: the changed content is ingested on the next scan.
+  fsApi.failReadsFor.clear();
+  await handle.refresh();
+  assert.ok(
+    rpc.documents.get(path.resolve(notePath))?.text.includes("v2"),
+    "healed file was not re-ingested",
+  );
+
+  // Control: genuine deletion (ENOENT) still retires the document.
+  await fsApi.rm(notePath);
+  await handle.refresh();
+  assert.ok(!rpc.documents.has(path.resolve(notePath)), "ENOENT no longer deletes");
+
+  await handle.stop();
+});
+
+test("a transient stat failure protects the file from the prune pass", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-staterr-"));
+  const root = path.join(tempRoot, "docs");
+  const aPath = path.join(root, "a.md");
+  const bPath = path.join(root, "b.md");
+  const rpc = new FakeRpcClient();
+  const fsApi = new FailingReadFsApi();
+  await fsApi.mkdir(root);
+  await fsApi.writeFile(aPath, "# a\n", 1000);
+  await fsApi.writeFile(bPath, "# b\n", 1000);
+
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [root],
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+    },
+    async () => rpc as never,
+    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+  await handle.start();
+  assert.ok(rpc.documents.has(path.resolve(aPath)) && rpc.documents.has(path.resolve(bPath)));
+
+  // a.md still exists but stat fails transiently (EINTR). The old walk left it
+  // out of the current-files set, so the prune pass deleted its document.
+  fsApi.failStatsFor.add(path.resolve(aPath));
+  await handle.refresh();
+  assert.ok(
+    rpc.documents.has(path.resolve(aPath)),
+    "a transiently unstattable file was pruned from the daemon",
+  );
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1146,8 +1146,9 @@ test("markdown ingestion default-excludes dependency and build directories", asy
 class HangingReaddirFsApi extends FakeFsApi {
   constructor(private readonly hangPrefix: string) { super(); }
   readdirAttempts = 0;
+  hangEnabled = true;
   override async readdir(dir: string): Promise<FsDirentLike[]> {
-    if (path.resolve(dir).startsWith(path.resolve(this.hangPrefix))) {
+    if (this.hangEnabled && path.resolve(dir).startsWith(path.resolve(this.hangPrefix))) {
       this.readdirAttempts += 1;
       return new Promise(() => {}); // blocks forever, like an uninterruptible open
     }
@@ -1165,8 +1166,11 @@ test("a root whose walk never completes is quarantined instead of blocking start
   await fsApi.mkdir(goodRoot);
   await fsApi.writeFile(path.join(goodRoot, "note.md"), "# healthy root\n", 1000);
 
+  const seededPath = path.join(hungRoot, "seeded.md");
+  await fsApi.writeFile(seededPath, "# seeded before the hang\n", 500);
+
   const errors: string[] = [];
-  const handle = createMarkdownIngestionHandle(
+  const makeHandle = () => createMarkdownIngestionHandle(
     {
       markdownIngestionEnabled: true,
       markdownIngestionRoots: [hungRoot, goodRoot],
@@ -1178,6 +1182,17 @@ test("a root whose walk never completes is quarantined instead of blocking start
     fsApi as never,
   );
 
+  // Phase 1: healthy. The soon-to-hang root ingests a document, so the
+  // no-deletion assertion below has something real to protect.
+  fsApi.hangEnabled = false;
+  const warmup = makeHandle();
+  await warmup.start();
+  assert.ok(rpc.documents.has(path.resolve(seededPath)), "seed ingest failed");
+  await warmup.stop();
+
+  // Phase 2: the same root now hangs, like a restart into broken consent.
+  fsApi.hangEnabled = true;
+  const handle = makeHandle();
   const startedAt = Date.now();
   await handle.start();
   const elapsed = Date.now() - startedAt;
@@ -1189,11 +1204,16 @@ test("a root whose walk never completes is quarantined instead of blocking start
     rpc.calls.some((c) => c.method === "ingest_markdown_document"),
     "healthy root was not ingested",
   );
-  // Nothing was deleted: a partial walk must never feed the prune pass.
+  // Nothing was deleted: a partial walk must never feed the prune pass. The
+  // seeded document under the hung root is the concrete thing at stake.
   assert.equal(
     rpc.calls.filter((c) => c.method === "delete_authored_document").length,
     0,
     "quarantined scan deleted documents",
+  );
+  assert.ok(
+    rpc.documents.has(path.resolve(seededPath)),
+    "the document seeded under the hung root was lost",
   );
   assert.ok(
     errors.some((m) => m.includes("quarantined")),
@@ -1211,10 +1231,14 @@ test("a root whose walk never completes is quarantined instead of blocking start
 
 class FailingReadFsApi extends FakeFsApi {
   failReadsFor = new Set<string>();
+  failReadsEnoentFor = new Set<string>();
   failStatsFor = new Set<string>();
   override async openReadStream(filePath: string) {
     if (this.failReadsFor.has(path.resolve(filePath))) {
       throw Object.assign(new Error(`EPERM: operation not permitted, open '${filePath}'`), { code: "EPERM" });
+    }
+    if (this.failReadsEnoentFor.has(path.resolve(filePath))) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), { code: "ENOENT" });
     }
     return super.openReadStream(filePath);
   }
@@ -1268,7 +1292,21 @@ test("a transient read failure keeps the document; only ENOENT deletes it", asyn
     "healed file was not re-ingested",
   );
 
-  // Control: genuine deletion (ENOENT) still retires the document.
+  // Control 1: ENOENT surfaced by the READ itself (file vanishes between stat
+  // and open) retires the document through safeReadFileStreamed's own branch.
+  await fsApi.writeFile(notePath, "# v3\n", 3000);
+  fsApi.failReadsEnoentFor.add(path.resolve(notePath));
+  await handle.refresh();
+  assert.ok(
+    !rpc.documents.has(path.resolve(notePath)),
+    "an ENOENT read no longer retires the document",
+  );
+  fsApi.failReadsEnoentFor.clear();
+
+  // Control 2: genuine deletion from disk still retires via the prune pass.
+  await fsApi.writeFile(notePath, "# v4\n", 4000);
+  await handle.refresh();
+  assert.ok(rpc.documents.has(path.resolve(notePath)), "re-ingest before prune control failed");
   await fsApi.rm(notePath);
   await handle.refresh();
   assert.ok(!rpc.documents.has(path.resolve(notePath)), "ENOENT no longer deletes");

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1399,12 +1399,12 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
   const root = path.join(tempRoot, "slow");
   const rpc = new FakeRpcClient();
   // Each stat takes 60ms against a 400ms stall window, so no single step comes
-  // close to stalling even on a loaded runner, while the whole walk (6 files,
+  // close to stalling even on a loaded runner, while the whole walk (10 files,
   // ~360ms) still has to outlive a naive total-elapsed cap set at the same
   // value. That is the distinction under test.
   const fsApi = new SlowButProgressingFsApi(60);
   await fsApi.mkdir(root);
-  for (let i = 0; i < 6; i += 1) {
+  for (let i = 0; i < 10; i += 1) {
     await fsApi.writeFile(path.join(root, `note-${i}.md`), `# note ${i}\n`, 1000 + i);
   }
 
@@ -1429,8 +1429,8 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
   assert.deepEqual(errors, [], `slow-but-healthy root was quarantined: ${errors.join(" | ")}`);
   assert.equal(
     rpc.documents.size,
-    6,
-    `expected all 6 files ingested, got ${rpc.documents.size}`,
+    10,
+    `expected all 10 files ingested, got ${rpc.documents.size}`,
   );
 
   await handle.stop();

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1397,3 +1397,61 @@ test("a root slower than the walk timeout is NOT quarantined while it keeps comp
 
   await handle.stop();
 });
+
+class FailingReaddirFsApi extends FakeFsApi {
+  failReaddirFor = new Set<string>();
+  override async readdir(dir: string): Promise<FsDirentLike[]> {
+    if (this.failReaddirFor.has(path.resolve(dir))) {
+      throw Object.assign(new Error(`EPERM: operation not permitted, scandir '${dir}'`), { code: "EPERM" });
+    }
+    return super.readdir(dir);
+  }
+}
+
+test("a directory we cannot enumerate does not prune the documents hidden behind it", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-readdirerr-"));
+  const root = path.join(tempRoot, "docs");
+  const subDir = path.join(root, "sub");
+  const topPath = path.join(root, "top.md");
+  const hiddenPath = path.join(subDir, "hidden.md");
+  const rpc = new FakeRpcClient();
+  const fsApi = new FailingReaddirFsApi();
+  await fsApi.mkdir(root);
+  await fsApi.mkdir(subDir);
+  await fsApi.writeFile(topPath, "# top\n", 1000);
+  await fsApi.writeFile(hiddenPath, "# hidden\n", 1000);
+
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [root],
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+    },
+    async () => rpc as never,
+    { error: () => {}, warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+  await handle.start();
+  assert.ok(rpc.documents.has(path.resolve(hiddenPath)), "initial ingest of nested file failed");
+
+  // The subdirectory becomes unreadable (EPERM). Its file is now invisible to
+  // the walk — but invisible is not deleted, so its document must survive.
+  fsApi.failReaddirFor.add(path.resolve(subDir));
+  await handle.refresh();
+  assert.ok(
+    rpc.documents.has(path.resolve(hiddenPath)),
+    "a document behind an unreadable directory was pruned",
+  );
+  assert.ok(rpc.documents.has(path.resolve(topPath)), "visible sibling was lost");
+
+  // Control: when the directory is genuinely removed, pruning proceeds.
+  fsApi.failReaddirFor.clear();
+  await fsApi.rm(hiddenPath);
+  await handle.refresh();
+  assert.ok(
+    !rpc.documents.has(path.resolve(hiddenPath)),
+    "a genuinely deleted file was not pruned",
+  );
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1349,3 +1349,51 @@ test("a transient stat failure protects the file from the prune pass", async () 
 
   await handle.stop();
 });
+
+class SlowButProgressingFsApi extends FakeFsApi {
+  constructor(private readonly delayMs: number) { super(); }
+  override async stat(filePath: string) {
+    await delay(this.delayMs);
+    return super.stat(filePath);
+  }
+}
+
+test("a root slower than the walk timeout is NOT quarantined while it keeps completing work", async () => {
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "libravdb-markdown-slow-"));
+  const root = path.join(tempRoot, "slow");
+  const rpc = new FakeRpcClient();
+  // Each stat takes 60ms; the stall timeout is 100ms. No single call exceeds
+  // it, but the whole walk (6 files) takes ~360ms — over 3x the timeout.
+  const fsApi = new SlowButProgressingFsApi(60);
+  await fsApi.mkdir(root);
+  for (let i = 0; i < 6; i += 1) {
+    await fsApi.writeFile(path.join(root, `note-${i}.md`), `# note ${i}\n`, 1000 + i);
+  }
+
+  const errors: string[] = [];
+  const handle = createMarkdownIngestionHandle(
+    {
+      markdownIngestionEnabled: true,
+      markdownIngestionRoots: [root],
+      markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+      markdownIngestionWalkTimeoutMs: 100,
+    },
+    async () => rpc as never,
+    { error: (m: string) => errors.push(m), warn: () => {}, info: () => {} } as never,
+    fsApi as never,
+  );
+
+  await handle.start();
+
+  // The walk outlived the timeout many times over but never stalled, so the
+  // root must be fully ingested and never quarantined. A total-elapsed cap
+  // would have quarantined it here.
+  assert.deepEqual(errors, [], `slow-but-healthy root was quarantined: ${errors.join(" | ")}`);
+  assert.equal(
+    rpc.documents.size,
+    6,
+    `expected all 6 files ingested, got ${rpc.documents.size}`,
+  );
+
+  await handle.stop();
+});

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -38,9 +38,9 @@ class FakeRpcClient {
 
 class FakeFsApi {
   // in-memory filesystem: absolute path → file entry
-  private files = new Map<string, { content: Buffer; mtimeMs: number; ctimeMs: number }>();
+  protected files = new Map<string, { content: Buffer; mtimeMs: number; ctimeMs: number }>();
   // directory set — tracked so readdir works without scanning files map
-  private dirs = new Set<string>();
+  protected dirs = new Set<string>();
 
   callbacks = new Map<string, Array<(event: string, filename: string | Buffer | null) => void>>();
 
@@ -81,10 +81,22 @@ class FakeFsApi {
     this.files.delete(path.resolve(filePath));
   }
 
+  /** Removes a directory and everything under it, so readdir on it throws ENOENT. */
+  async rmdir(dir: string): Promise<void> {
+    const abs = path.resolve(dir);
+    this.dirs.delete(abs);
+    for (const filePath of [...this.files.keys()]) {
+      if (filePath.startsWith(abs + path.sep)) this.files.delete(filePath);
+    }
+  }
+
   // ── FsApi interface ──────────────────────────────────────────────────
 
   async readdir(dir: string): Promise<FsDirentLike[]> {
     const abs = path.resolve(dir);
+    if (!this.dirs.has(abs)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, scandir '${dir}'`), { code: "ENOENT" });
+    }
     const results: FsDirentLike[] = [];
     const prefix = abs.endsWith(path.sep) ? abs : abs + path.sep;
 
@@ -1444,13 +1456,28 @@ test("a directory we cannot enumerate does not prune the documents hidden behind
   );
   assert.ok(rpc.documents.has(path.resolve(topPath)), "visible sibling was lost");
 
-  // Control: when the directory is genuinely removed, pruning proceeds.
+  // A file discovered only during a partial walk must still be tracked, or a
+  // later complete scan cannot prune it when it is deleted.
+  const lateFile = path.join(root, "late.md");
+  await fsApi.writeFile(lateFile, "# late\n", 2000);
+  await handle.refresh(); // still partial: subDir remains unreadable
+  assert.ok(rpc.documents.has(path.resolve(lateFile)), "late file was not ingested");
   fsApi.failReaddirFor.clear();
-  await fsApi.rm(hiddenPath);
+  await fsApi.rm(lateFile);
+  await handle.refresh(); // complete walk now
+  assert.ok(
+    !rpc.documents.has(path.resolve(lateFile)),
+    "a file first seen during a partial walk was never tracked, so its deletion was missed",
+  );
+
+  // Control: an ENOENT from readdir itself (the directory is gone, not
+  // unreadable) is real absence, so its files are pruned normally.
+  fsApi.failReaddirFor.clear();
+  await fsApi.rmdir(subDir);
   await handle.refresh();
   assert.ok(
     !rpc.documents.has(path.resolve(hiddenPath)),
-    "a genuinely deleted file was not pruned",
+    "files under a genuinely removed directory were not pruned",
   );
 
   await handle.stop();

--- a/test/integration/markdown-ingest.test.ts
+++ b/test/integration/markdown-ingest.test.ts
@@ -1438,6 +1438,7 @@ test("a directory we cannot enumerate does not prune the documents hidden behind
       markdownIngestionEnabled: true,
       markdownIngestionRoots: [root],
       markdownIngestionSnapshotPath: snapshotPath(tempRoot),
+      markdownIngestionMaxTokensPerFile: 100,
     },
     async () => rpc as never,
     { error: () => {}, warn: () => {}, info: () => {} } as never,
@@ -1468,6 +1469,39 @@ test("a directory we cannot enumerate does not prune the documents hidden behind
   assert.ok(
     !rpc.documents.has(path.resolve(lateFile)),
     "a file first seen during a partial walk was never tracked, so its deletion was missed",
+  );
+
+  // A file whose document is retired DURING a partial walk, while the file
+  // itself stays present, must not be re-tracked: the next complete scan would
+  // then delete an already-deleted document. The oversize path is the clean
+  // way to retire a document without the file leaving the walk.
+  const grower = path.join(root, "grower.md");
+  const countDeletes = () => rpc.calls.filter(
+    (c) => c.method === "delete_authored_document"
+      && (c.params as { sourceDoc: string }).sourceDoc === path.resolve(grower),
+  ).length;
+  await fsApi.writeFile(grower, "# small\n", 3000);
+  fsApi.failReaddirFor.add(path.resolve(subDir));
+  await handle.refresh();
+  assert.ok(rpc.documents.has(path.resolve(grower)), "grower was not ingested while small");
+
+  // Still a partial walk. The file is present in the walk but now exceeds the
+  // per-file cap, so its document is retired.
+  await fsApi.writeFile(grower, `# big\n${"x".repeat(4000)}\n`, 4000);
+  await handle.refresh();
+  assert.ok(!rpc.documents.has(path.resolve(grower)), "oversized document was not retired");
+  const deletesAfterRetire = countDeletes();
+  assert.equal(deletesAfterRetire, 1, "expected exactly one retire for the oversized file");
+
+  // Now the file leaves for real and a COMPLETE walk runs. Its document is
+  // already gone, so nothing further should be deleted for it.
+  await fsApi.rm(grower);
+  fsApi.failReaddirFor.clear();
+  await handle.refresh();
+  assert.equal(
+    countDeletes(),
+    deletesAfterRetire,
+    "an already-retired document was deleted a second time by the prune pass",
   );
 
   // Control: an ENOENT from readdir itself (the directory is gone, not


### PR DESCRIPTION
## Summary

This replacement PR ports the effective changes from #376 onto the released
`v1.10.22` baseline and includes one additional retirement-tracking fix found
during current-main validation.

- Add a per-root filesystem stall watchdog with process-lifetime quarantine.
- Prevent partial walks and transient filesystem failures from pruning valid
  authored documents.
- Treat only confirmed `ENOENT` failures as deletion evidence.
- Expose and document `markdownIngestionWalkTimeoutMs`.
- Remove retired paths from complete-scan tracking so read-time ENOENT,
  oversized-file, and filtered-note retirement cannot trigger duplicate deletes
  on a later scan.

Original PR: #376

## Validation

- `pnpm check` — 272 unit tests and 55 integration tests passed
- `plugin-inspector ci` — PASS, 0 breakages
- `pnpm run build` — passed
- `pnpm pack` — passed
- Fresh OpenClaw 2026.8.2 profile — plugin loaded and `plugins doctor` passed

## Merge notes

This branch is based on current `main` at `v1.10.22`. It should supersede
#376; the original PR should not be merged independently because this branch
contains the additional retirement-tracking correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add per-root Markdown walk stall watchdog with process-lifetime quarantine.
- Prevent blocked roots from delaying readiness or affecting other roots.
- Treat only confirmed `ENOENT` errors as document deletion.
- Preserve documents during partial walks and transient filesystem failures.
- Track retired paths to prevent duplicate deletions.
- Preserve errno details in sync-error diagnostics.
- Expose and document `markdownIngestionWalkTimeoutMs` with a 60-second default.
- Add integration coverage for hangs, slow progress, transient failures, partial walks, and filtered notes.

## Complexity and review impact

- Directory walking remains **O(F)** time for `F` discovered filesystem entries.
- Retirement tracking uses **O(R)** additional space for `R` paths retired during a scan.
- Per-root watchdog state uses **O(1)** additional space per root.
- No asymptotic time regression is expected.
- Cyclomatic complexity increases in the ingestion path because it now handles timeout, partial-walk, `ENOENT`, transient-error, and retirement branches.
- The added integration tests cover the new control-flow branches.

## Validation

- 272 unit tests passed.
- 55 integration tests passed.
- `plugin-inspector ci`, build, package creation, and fresh OpenClaw 2026.8.2 profile checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->