### PR TITLE
fix: merge dream and normal memory search

### DIFF
--- a/src/dream-routing.ts
+++ b/src/dream-routing.ts
@@ -23,11 +23,11 @@ const DREAM_PATTERN_RULES: Array<{ label: string; patterns: RegExp[] }> = [
 
 /** Phrases that contain "dream" but are idiomatic (not memory-recall intent). */
 const DREAM_FALSE_POSITIVE_PATTERNS: RegExp[] = [
-  /\bpipe\s+dreams?\b/i,
-  /\bdream\s+team\b/i,
-  /\bamerican\s+dream\b/i,
-  /\bdream\s+(?:house|home|car|wedding|vacation|job|school)\b/i,
-  /\bin\s+(?:my|our|your)\s+dreams\b/i,
+  /\bpipe\s+dreams?\b/gi,
+  /\bdream\s+team\b/gi,
+  /\bamerican\s+dream\b/gi,
+  /\bdream\s+(?:house|home|car|wedding|vacation|job|school)\b/gi,
+  /\bin\s+(?:my|our|your)\s+dreams\b/gi,
 ];
 
 const DREAM_MATCHED_PATTERNS = ["dream"] as const;
@@ -38,15 +38,13 @@ export interface DreamQuerySignal {
 }
 
 export function detectDreamQuerySignal(queryText: string): DreamQuerySignal {
+  const candidateText = DREAM_FALSE_POSITIVE_PATTERNS.reduce(
+    (text, pattern) => text.replace(pattern, " "),
+    queryText,
+  );
+
   for (const rule of DREAM_PATTERN_RULES) {
-    if (rule.patterns.some((pattern) => pattern.test(queryText))) {
-      // Reject known idiomatic false positives that slip through.
-      if (DREAM_FALSE_POSITIVE_PATTERNS.some((p) => p.test(queryText))) {
-        return {
-          active: false,
-          matchedPatterns: [],
-        };
-      }
+    if (rule.patterns.some((pattern) => pattern.test(candidateText))) {
       return {
         active: true,
         matchedPatterns: [...DREAM_MATCHED_PATTERNS],

--- a/src/memory-runtime.ts
+++ b/src/memory-runtime.ts
@@ -116,13 +116,35 @@ function createMemorySearchManager(
       const minScore = normalizeNumber(params.minScore);
       const client = await getClient();
 
-      const result = dreamQuery.active && cfg.crossSessionRecall !== false && searchCorpus !== "sessions"
-        ? await client.searchText({
-            collection: resolveDreamCollection(userId),
-            text: queryText,
+      const dreamCollection = dreamQuery.active && cfg.crossSessionRecall !== false && searchCorpus !== "sessions"
+        ? resolveDreamCollection(userId)
+        : undefined;
+      const normalSearch = searchResolvedCollections(
+        client,
+        cfg,
+        userId,
+        sessionId,
+        queryText,
+        k,
+        searchCorpus,
+        params.kind,
+        params.signals,
+      );
+      const result = dreamCollection
+        ? mergeSearchResults(
+            await Promise.all([
+              normalSearch,
+              client.searchText({
+                collection: dreamCollection,
+                text: queryText,
+                k,
+                kind: params.kind || undefined,
+                signals: params.signals && params.signals.length > 0 ? params.signals : undefined,
+              }),
+            ]),
             k,
-          })
-        : await searchResolvedCollections(client, cfg, userId, sessionId, queryText, k, searchCorpus, params.kind, params.signals);
+          )
+        : await normalSearch;
       const filteredResults =
         minScore === undefined
           ? result.results
@@ -224,6 +246,23 @@ async function searchResolvedCollections(
         kind: kindFilter,
         signals: signalFilter,
       });
+}
+
+function mergeSearchResults(
+  responses: Array<{ results: ProtoSearchResult[] }>,
+  limit: number,
+): { results: ProtoSearchResult[] } {
+  const seenIds = new Set<string>();
+  const results = responses
+    .flatMap((response) => response.results)
+    .sort((left, right) => right.score - left.score)
+    .filter((item) => {
+      if (seenIds.has(item.id)) return false;
+      seenIds.add(item.id);
+      return true;
+    })
+    .slice(0, limit);
+  return { results };
 }
 
 function resolveSearchCollections(

--- a/test/unit/dream-routing.test.ts
+++ b/test/unit/dream-routing.test.ts
@@ -23,6 +23,12 @@ test("dream routing detects explicit dream phrasing", () => {
   assert.equal(detectDreamQuerySignal("dream recall practice").active, true);
 });
 
+test("dream routing preserves explicit dream phrasing alongside idioms", () => {
+  assert.equal(detectDreamQuerySignal("I had a dream about my dream house").active, true);
+  assert.equal(detectDreamQuerySignal("I had a dream about the American dream").active, true);
+  assert.equal(detectDreamQuerySignal("I had a dream last night about my dream job").active, true);
+});
+
 test("dream routing rejects idiomatic false positives", () => {
   assert.equal(detectDreamQuerySignal("pipe dream architecture").active, false);
   assert.equal(detectDreamQuerySignal("pipe dreams everywhere").active, false);
@@ -37,6 +43,12 @@ test("dream routing rejects idiomatic false positives", () => {
   assert.equal(detectDreamQuerySignal("dream home interior design").active, false);
   assert.equal(detectDreamQuerySignal("in my dreams").active, false);
   assert.equal(detectDreamQuerySignal("in your dreams").active, false);
+});
+
+test("dream routing rejects idioms that overlap dream recall patterns", () => {
+  assert.equal(detectDreamQuerySignal("tell me about the American dream").active, false);
+  assert.equal(detectDreamQuerySignal("pipe dreams about instant success").active, false);
+  assert.equal(detectDreamQuerySignal("tell me about your dream job").active, false);
 });
 
 test("dream routing ignores ordinary memory queries", () => {

--- a/test/unit/memory-runtime.test.ts
+++ b/test/unit/memory-runtime.test.ts
@@ -74,7 +74,7 @@ test("memory runtime bridge searches the resolved durable namespace under the la
   assert.equal(result[0]?.source, "memory");
 });
 
-test("memory runtime bridge routes dream queries to the dream collection when cross-session recall is enabled", async () => {
+test("memory runtime bridge adds dream results to normal memory when cross-session recall is enabled", async () => {
   for (const cfg of [{}, { crossSessionRecall: true }] satisfies PluginConfig[]) {
     const rpc = new FakeRpc();
     const runtime = buildMemoryRuntimeBridge(async () => rpc as never, cfg);
@@ -83,12 +83,74 @@ test("memory runtime bridge routes dream queries to the dream collection when cr
     const result = await manager.search({ query: "tell me about your dreams from last week", userId: "u1" });
 
     assert.ok(Array.isArray(result));
-    assert.equal(rpc.calls[1]?.method, "searchText");
-    assert.deepEqual(rpc.calls[1]?.params.collection, "dream:u1");
-    assert.equal(rpc.calls.some((call) => call.method === "searchTextCollections"), false);
-    assert.equal(result.length, 1);
+    assert.equal(rpc.calls[1]?.method, "searchTextCollections");
+    assert.equal(rpc.calls[2]?.method, "searchText");
+    assert.deepEqual(rpc.calls[2]?.params.collection, "dream:u1");
+    assert.equal(result.length, 2);
     assert.equal(result[0]?.snippet, "dream recall item");
+    assert.equal(result[1]?.snippet, "remembered item");
   }
+});
+
+test("memory runtime bridge keeps normal results when the dream collection is empty", async () => {
+  const rpc = new FakeRpc();
+  rpc.searchText = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchText", params });
+    return { results: [] };
+  };
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({ query: "tell me about your dreams", userId: "u1" });
+
+  assert.ok(Array.isArray(result));
+  assert.deepEqual(result.map((item) => item.snippet), ["remembered item"]);
+  assert.equal(rpc.calls[1]?.method, "searchTextCollections");
+  assert.equal(rpc.calls[2]?.method, "searchText");
+});
+
+test("memory runtime bridge merges, deduplicates, and caps dream and normal results", async () => {
+  const rpc = new FakeRpc();
+  rpc.searchTextCollections = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchTextCollections", params });
+    return {
+      results: [
+        { id: "normal", score: 0.95, text: "normal memory", metadata: { collection: "user:u1" } },
+        { id: "shared", score: 0.7, text: "lower-ranked duplicate", metadata: { collection: "user:u1" } },
+      ],
+    };
+  };
+  rpc.searchText = async (params: Record<string, unknown>) => {
+    rpc.calls.push({ method: "searchText", params });
+    return {
+      results: [
+        { id: "dream", score: 0.9, text: "dream memory", metadata: { collection: "dream:u1" } },
+        { id: "shared", score: 0.8, text: "higher-ranked duplicate", metadata: { collection: "dream:u1" } },
+        { id: "overflow", score: 0.6, text: "outside result limit", metadata: { collection: "dream:u1" } },
+      ],
+    };
+  };
+  const runtime = buildMemoryRuntimeBridge(async () => rpc as never, {});
+  const { manager } = await runtime.getMemorySearchManager();
+
+  const result = await manager.search({
+    query: "tell me about your dreams",
+    userId: "u1",
+    limit: 3,
+    kind: "episodic",
+    signals: ["visual"],
+  });
+
+  assert.ok(Array.isArray(result));
+  assert.deepEqual(result.map((item) => item.snippet), [
+    "normal memory",
+    "dream memory",
+    "higher-ranked duplicate",
+  ]);
+  assert.deepEqual(rpc.calls[1]?.params.kind, "episodic");
+  assert.deepEqual(rpc.calls[1]?.params.signals, ["visual"]);
+  assert.deepEqual(rpc.calls[2]?.params.kind, "episodic");
+  assert.deepEqual(rpc.calls[2]?.params.signals, ["visual"]);
 });
 
 test("memory runtime bridge rejects invalid dream collections before daemon search", async () => {


### PR DESCRIPTION
## Summary

Combines the intent-routing fix from #367 with the additive dream/normal search fix from #366.

- Preserve genuine dream recall in compound queries containing idiomatic phrases.
- Search normal session/user/global collections alongside the dedicated dream collection.
- Merge, score-sort, deduplicate, and cap the combined results.
- Preserve kind and signal filters on both search paths.
- Keep normal memory results when the dream collection is empty.

## Validation

- OpenClaw 2026.8.2 compatibility baseline
- 
> @xdarkicex/openclaw-memory-libravdb@1.10.23 check /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> tsc --noEmit && pnpm run test:ts && pnpm run test:integration


> @xdarkicex/openclaw-memory-libravdb@1.10.23 test:ts /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> pnpm run test:inspect && pnpm run clean:test && tsc -p tsconfig.tests.json && node --test .ts-build/test/unit/*.test.js


> @xdarkicex/openclaw-memory-libravdb@1.10.23 test:inspect /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> pnpm run plugin:ci


> @xdarkicex/openclaw-memory-libravdb@1.10.23 plugin:ci /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute

Status: PASS
Breakages: 0
Issues: 1
Artifacts: 1

> @xdarkicex/openclaw-memory-libravdb@1.10.23 clean:test /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> node scripts/clean-test-build.mjs

✔ assemble timeout rejects when promise hangs (52.211125ms)
✔ assemble timeout returns result when promise resolves before timeout (0.734ms)
✔ assemble timeout uses configured value (0.087542ms)
✔ extractQueryHint returns last user message text (1.199458ms)
✔ extractQueryHint skips non-user messages (1.332875ms)
✔ extractQueryHint handles content array (0.346583ms)
✔ extractQueryHint truncates to 200 chars (0.187875ms)
✔ isNewUserTurn detects new user turn (0.430042ms)
✔ isNewUserTurn returns false for tool-result only after assistant (0.066667ms)
✔ isNewUserTurn returns true for empty context (0.055041ms)
✔ TurnMemoryCache caches and retrieves (0.355125ms)
✔ TurnMemoryCache normalizes query keys (0.340458ms)
✔ TurnMemoryCache evicts LRU (0.129ms)
✔ TurnMemoryCache invalidates session (0.089ms)
✔ CLI metadata registers the memory descriptor only when LibraVDB owns the memory slot (0.906209ms)
✔ full CLI registration exposes standard memory commands and LibraVDB operator commands (0.372125ms)
✔ flush command sends explicit user ids through the userId RPC field (0.271583ms)
✔ export command keeps user ids separate from derived namespaces (0.260959ms)
✔ status command shuts the plugin runtime down after printing status (0.238125ms)
✔ status --index requires --force before rebuilding (0.177958ms)
✔ status --index --force rebuilds before printing status (0.249708ms)
✔ search command applies the status gate threshold by default (1.1885ms)
✔ search command honors an explicit min-score below the default threshold (0.881875ms)
✔ status --deep probes authored collection search health (0.442125ms)
✔ status --deep reports invalid user collection without probing it (0.331041ms)
✔ status --deep includes authored probe rows in table output (0.308834ms)
✔ index command uses an extended timeout for rebuild_index (0.1545ms)
✔ non-full CLI registration exposes command structure without action handlers (0.083291ms)
✔ discovery registration exposes runtime-backed memory commands for lazy CLI loading (0.494167ms)
LibraVDB bootstrap sessionId=s1 userId=fixed-user sessionKey=sk1
✔ context engine bootstraps session via client (2.139291ms)
✔ context engine returns compact failure instead of throwing when client is unavailable (1.795667ms)
✔ context engine direct compact declines below threshold without acquiring client (0.135959ms)
✔ context engine direct compact honors forced compaction below threshold (0.132916ms)
✔ context engine direct compact via runtimeContext short-circuits below threshold without acquiring client (0.111208ms)
✔ context engine direct compact via runtimeContext.manualCompaction honors forced compaction below threshold (0.171ms)
✔ context engine direct compact falls back to runtimeContext on sentinel top-level values (0.433667ms)
✔ context engine clears BeforeTurnKernel timeout after successful retrieval (4.733833ms)
BeforeTurnKernel failed for session s1-before-turn-aborts-timeout: BeforeTurnKernel timed out after 1ms
LibraVDB bootstrap sessionId=s1 userId=fixed-user sessionKey=sk1
LibraVDB ingest sessionId=s1 userId=fixed-user role=user heartbeat=false contentLen=13
LibraVDB afterTurn sessionId=s1-after-turn-config userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-after-turn-config
LibraVDB afterTurn sessionId=s1-nonblock userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-nonblock
LibraVDB afterTurn sessionId=s1-after-turn-idempotent-29009 userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-after-turn-idempotent-29009
LibraVDB afterTurn sessionId=s1-after-turn-idempotent-29009 userId=fixed-user messageCount=2 newMessages=0 overlapIndex=2 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn sessionId=s1-after-turn-cursor-gap-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-after-turn-cursor-gap-29009
LibraVDB afterTurn prePromptMessageCount consumed all messages; forwarding latest message for compatibility prePromptMessageCount=2 start=2 totalMessages=2
LibraVDB afterTurn sessionId=s1-after-turn-cursor-gap-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=2 heartbeat=false
[LibraVDB] Daemon reported cursor gap for session s1-after-turn-cursor-gap-29009. Resetting manifest for full re-sync next turn.
[LibraVDB] Re-seeded daemon session s1-after-turn-cursor-gap-29009 with 2 source messages after cursor gap.
LibraVDB predictive graph returned no predictions sessionId=s1-after-turn-cursor-gap-29009
BeforeTurnKernel failed for session s1-before-turn-attempt-guard: simulated beforeTurn failure
LibraVDB afterTurn sessionId=s1-env-strip userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-env-strip
LibraVDB afterTurn sessionId=s1-imessage userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-imessage
✔ context engine aborts BeforeTurnKernel transport on local timeout (8.571542ms)
✔ context engine bootstrap resolves config userId and passes it to daemon (0.367875ms)
✔ context engine ingest resolves config userId and passes it to daemon (0.664667ms)
✔ context engine afterTurn resolves config userId and passes messages to daemon (3.804875ms)
✔ context engine afterTurn does not block on daemon ingestion (1.321375ms)
✔ context engine afterTurn is idempotent when manifest has already ACKed every forwarded message (1.406083ms)
✔ context engine afterTurn repairs a daemon cursor gap in the same task (1.92225ms)
✔ context engine beforeTurn attempts only once for the same session turn after failure (1.00675ms)
✔ context engine beforeTurn attempt guard is scoped per session (0.607625ms)
✔ context engine afterTurn strips OpenClaw untrusted metadata envelope before ingest (1.584458ms)
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
✔ context engine afterTurn strips iMessage envelope retaining routing context (51.656125ms)
✔ context engine assemble strips OpenClaw untrusted metadata envelope from prompt (52.898791ms)
BeforeTurnKernel failed for session circuit-class-change: deadline exceeded
BeforeTurnKernel failed for session circuit-class-change: deadline exceeded
BeforeTurnKernel circuit open class=timeout sessionId=circuit-class-change consecutive=3 cooldownMs=15000 
BeforeTurnKernel failed for session circuit-class-change: deadline exceeded
BeforeTurnKernel failed for session circuit-class-change: unavailable
BeforeTurnKernel failed for session s1-selected-context: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-daemon-invented-tool: client.beforeTurnKernel is not a function
LibraVDB activated daemon-owned compacted projection sessionId=s1-owned-compaction source=compact
LibraVDB activated daemon-owned compacted projection sessionId=s1-owned-compaction-budget source=compact
LibraVDB discarded incomplete compacted projection sessionId=s1-owned-compaction-budget
LibraVDB activated daemon-owned compacted projection sessionId=s1-restored-owned-compaction source=assemble
LibraVDB activated daemon-owned compacted projection sessionId=s1-replaced-engine source=compact
LibraVDB predictive compaction trigger phase=assemble sessionId=s1-replaced-engine currentTokenCount=50000 threshold=16000 targetSize=15999 tokenBudget=100000
LibraVDB predictive compaction did not compact phase=assemble sessionId=s1-replaced-engine currentTokenCount=50000 threshold=16000 targetSize=15999 tokenBudget=100000 reason=overbudget_not_compacted
LibraVDB predictive compaction made no additional progress at 50000 tokens; continuing with the existing daemon-owned compacted projection.
LibraVDB tokenBudgetMax trim sessionId=s1-replaced-engine injectionBefore=330 injectionAfter=100 cap=100
LibraVDB skipping assemble context search for post-tool continuation sessionId=s1-replaced-engine
LibraVDB tokenBudgetMax trim sessionId=s1-replaced-engine injectionBefore=330 injectionAfter=5 cap=5
LibraVDB activated daemon-owned compacted projection sessionId=s1-dispose-other-engine-assembly source=assemble
LibraVDB discarded incomplete compacted projection sessionId=s1-replaced-engine
LibraVDB activated daemon-owned compacted projection sessionId=s1-reset-active-engine source=compact
LibraVDB activated daemon-owned compacted projection sessionId=s1-boundary-divergence-race source=assemble
LibraVDB activated daemon-owned compacted projection sessionId=s1-boundary-divergence-race source=assemble
LibraVDB activated daemon-owned compacted projection sessionId=s1-projection-race source=compact
LibraVDB predictive compaction trigger phase=assemble sessionId=s1-compaction-reset-race currentTokenCount=50000 threshold=16000 targetSize=15999 tokenBudget=100000
LibraVDB afterTurn sessionId=s1-after-turn-reset-race-29009-1788478780194 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn sessionId=s1-after-turn-reset-race-29009-1788478780194 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB activated daemon-owned compacted projection sessionId=s1-compaction-without-marker source=assemble
[compact:trace] daemon state lastCompactedTurn=37 tokenAccumulatorAfter=unknown totalTurns=unknown skippedNoNewTurns=true
LibraVDB predictive compaction trigger phase=assemble sessionId=s1-compaction-without-marker currentTokenCount=50000 threshold=16000 targetSize=15999 tokenBudget=100000
LibraVDB predictive compaction completed phase=assemble sessionId=s1-compaction-without-marker currentTokenCount=50000 threshold=16000 targetSize=15999 tokenBudget=100000
LibraVDB predictive compaction trigger phase=assemble sessionId=s1-empty-success-recall currentTokenCount=50000 threshold=1 targetSize=1 tokenBudget=100000
LibraVDB activated daemon-owned compacted projection sessionId=s1-empty-success-recall source=compact
LibraVDB predictive compaction completed phase=assemble sessionId=s1-empty-success-recall currentTokenCount=50000 threshold=1 targetSize=1 tokenBudget=100000
LibraVDB exact recall injected sessionId=s1-empty-success-recall facts=1/1
LibraVDB activated daemon-owned compacted projection sessionId=s1-overlapping-compaction source=assemble
LibraVDB discarded stale compacted projection sessionId=s1-boundary-divergence-race
LibraVDB discarded incomplete compacted projection sessionId=s1-projection-race
LibraVDB discarded stale compacted projection sessionId=s1-projection-race
LibraVDB discarded stale compaction result after session state change sessionId=s1-compaction-reset-race
LibraVDB afterTurn failed sessionId=s1-after-turn-reset-race-29009-1788478780194: session lifecycle changed
LibraVDB afterTurn failed sessionId=s1-after-turn-reset-race-29009-1788478780194: session lifecycle changed
LibraVDB discarded incomplete compacted projection sessionId=s1-compaction-without-marker
LibraVDB discarded incomplete compacted projection sessionId=s1-empty-success-recall
LibraVDB discarded stale compacted projection sessionId=s1-overlapping-compaction
BeforeTurnKernel failed for session s1-legitimate-consecutive-identical: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-legitimate-consecutive-identical-no-id: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-system-addition-tools: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-authored-context: client.beforeTurnKernel is not a function
LibraVDB activated daemon-owned compacted projection sessionId=s1-compact-prose source=assemble
BeforeTurnKernel failed for session s1-system-addition-name-json: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-system-addition-multiline-tool-json: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-preserve-planning-language: client.beforeTurnKernel is not a function
LibraVDB afterTurn sessionId=s1-preamble userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-preamble
LibraVDB afterTurn sessionId=s1-no-fence userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-no-fence
LibraVDB afterTurn sessionId=s1-unclosed-fence userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-unclosed-fence
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
LibraVDB afterTurn sessionId=s1-predictive-escape-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned predictions sessionId=s1-predictive-escape-29009 count=1
BeforeTurnKernel failed for session s1-predictive-escape-29009: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB bootstrap sessionId=session-a userId=fixed-user sessionKey=key-a
LibraVDB ingest sessionId=session-a userId=fixed-user role=user heartbeat=false contentLen=2
LibraVDB afterTurn sessionId=session-a userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB bootstrap sessionId=session-b userId=fixed-user sessionKey=key-b
LibraVDB predictive graph returned no predictions sessionId=session-a
LibraVDB ingest sessionId=session-b userId=fixed-user role=user heartbeat=false contentLen=2
LibraVDB afterTurn sessionId=session-b userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=session-b
LibraVDB bootstrap sessionId=s1 userId=framework-user sessionKey=sk1
✔ context engine clears a stale circuit cooldown when the failure class changes (4.716375ms)
✔ context engine assemble uses latest selected-context user utterance as retrieval query (1.068666ms)
✔ context engine assemble keeps live current-turn tool protocol visible (0.353375ms)
✔ context engine assemble restores live tool protocol flattened by daemon (0.185541ms)
✔ context engine assemble does not restore daemon-invented flattened tool syntax (0.480875ms)
✔ context engine assemble keeps duplicate live tool protocol visible without ids (0.203333ms)
✔ context engine assemble maps repeated no-id live tool protocol in source order (0.174542ms)
✔ context engine assemble does not duplicate consumed live tool protocol (0.166167ms)
✔ successful daemon compaction makes an exact turn-aligned source suffix authoritative (0.705625ms)
✔ incomplete compacted marker falls back while preserving the complete live tool bundle (0.723ms)
✔ daemon compacted context marker restores assembled authority after plugin restart (0.915375ms)
✔ daemon compacted projection survives engine replacement until session state is cleared (1.763542ms)
✔ disposing one engine does not invalidate another engine's in-flight assembly (0.525333ms)
✔ session cleanup deactivates an existing engine and clears its post-tool projection (2.148917ms)
✔ boundary divergence fences an older overlapping assembly from restoring stale projection (0.481125ms)
✔ engine replacement does not persist ambiguous compaction or cross a lifecycle race (0.388167ms)
✔ reset during predictive compaction cannot activate stale projection state (0.1915ms)
✔ direct compact reports failure when reset wins the lifecycle race (0.118583ms)
✔ queued afterTurn work cannot repopulate session state after reset (0.335875ms)
✔ successful predictive compaction does not restore an older cached marker (0.380167ms)
✔ empty successful compaction keeps the uncompacted source and recall injection (0.648792ms)
✔ successful compaction fences an overlapping assembly holding an older marker (0.362916ms)
✔ context engine assemble drops consecutive duplicate provider replay messages (0.153875ms)
✔ context engine assemble preserves legitimate consecutive identical messages from different source indices (1.037375ms)
✔ context engine assemble preserves legitimate consecutive identical no-id messages from different source indices (0.457833ms)
✔ context engine assemble strips historical tool syntax from memory system additions (0.492042ms)
✔ context engine assemble demotes daemon authored context to inert memory data (0.860625ms)
✔ context engine preserves compacted session context prose without render ledger headings (0.37975ms)
✔ context engine assemble preserves ordinary JSON with name fields in memory additions (0.498375ms)
✔ context engine assemble strips multiline tool-call JSON without consuming nearby ordinary JSON (0.518417ms)
✔ context engine assemble preserves ordinary assistant planning language (0.718584ms)
✔ context engine afterTurn strips envelope with leading media preamble (0.869042ms)
✔ context engine afterTurn preserves content when envelope header has no fence or blank line (0.512834ms)
✔ context engine afterTurn preserves content when envelope fence is unclosed (0.466083ms)
✔ context engine assemble resolves config userId and passes it to daemon (0.447459ms)
✔ context engine assemble injects exact factual recall for marker tokens (0.948ms)
✔ context engine exact recall checks existing facts per block (0.854333ms)
✔ context engine preserves system prompt additions intact when they exceed the token budget (0.923042ms)
✔ context engine assemble trims messages against remaining budget after system prompt additions (1.121792ms)
✔ context engine assemble drops messages when system prompt leaves no wrapper budget (0.895ms)
✔ context engine skips predictive context when it cannot fit within the token budget (2.665166ms)
✔ context engine exact recall skips additions that would exceed the token budget (0.654417ms)
✔ context engine assemble preserves useful context for small token budgets (0.868625ms)
✔ context engine assemble keeps daemon result when exact recall RPC acquisition fails (0.857834ms)
✔ context engine exact recall rejects invalid user collections before probing (0.501083ms)
✔ context engine assemble uses source messages directly as transcript (0.724083ms)
✔ context engine assemble preserves reinjected user turn during budget clamp (0.448125ms)
✔ context engine assemble budgets system prompt when preserving reinjected user turn (0.415042ms)
✔ context engine exact recall skips empty-text search results (0.458ms)
✔ context engine exact recall ignores malformed non-string search result text (3.0465ms)
✔ exact recall extracts quoted phrases from user queries (1.114625ms)
✔ exact recall extracts mixed-case identifiers with separators (1.360167ms)
✔ exact recall skips common query words even when in quoted phrases (1.124458ms)
✔ identity is stable across multiple sessions with the same config userId (3.863667ms)
LibraVDB: auto-derived identity "z3robit@Mac.attlocal.net#2e347370" written to /var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-unit-state-718zTD/libravdb-identity.json
LibraVDB bootstrap sessionId=s1 userId=z3robit@Mac.attlocal.net#2e347370 sessionKey=provided-key
BeforeTurnKernel failed for session conformance-session-1: client.beforeTurnKernel is not a function
LibraVDB bootstrap sessionId=conformance-session-1 userId=u1 sessionKey=sk
LibraVDB ingest sessionId=conformance-session-1 userId=u1 role=user heartbeat=false contentLen=2
LibraVDB afterTurn sessionId=conformance-session-1 userId=u1 messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=conformance-session-1
LibraVDB ingest sessionId=s1 userId=u1 role=user heartbeat=true contentLen=15
✔ framework-provided userId override takes priority over config userId (52.195416ms)
✔ identity is resolved and sessionKey forwarded when no config userId is set (5.182833ms)
✔ sessionId is normalized in every context engine lifecycle hook (1.161083ms)
✔ context engine rejects blank sessionId before lifecycle RPCs (0.389875ms)
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
LibraVDB afterTurn sessionId=s1-predictive-budget-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned predictions sessionId=s1-predictive-budget-29009 count=1
BeforeTurnKernel failed for session s1-predictive-budget-29009: client.beforeTurnKernel is not a function
LibraVDB predictive context injected sessionId=s1-predictive-budget-29009 items=1/1 tokens=84
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=3/3
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB exact recall injected sessionId=s1 facts=1/1
LibraVDB afterTurn sessionId=s1-predictive-truncate-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned predictions sessionId=s1-predictive-truncate-29009 count=3
BeforeTurnKernel failed for session s1-predictive-truncate-29009: client.beforeTurnKernel is not a function
LibraVDB predictive context injected sessionId=s1-predictive-truncate-29009 items=3/3 tokens=113
LibraVDB afterTurn sessionId=s1-predictive-oversized-29009 userId=fixed-user messageCount=1 newMessages=1 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned predictions sessionId=s1-predictive-oversized-29009 count=1
BeforeTurnKernel failed for session s1-predictive-oversized-29009: client.beforeTurnKernel is not a function
LibraVDB predictive context injected sessionId=s1-predictive-oversized-29009 items=1/1 tokens=104
BeforeTurnKernel failed for session s1: client.beforeTurnKernel is not a function
LibraVDB assemble produced no replay-safe user turn; reinjecting the latest user message for provider compatibility.
LibraVDB afterTurn sessionId=s1-assemble-drain-29009 userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-assemble-drain-29009
BeforeTurnKernel failed for session s1-assemble-drain-29009: client.beforeTurnKernel is not a function
BeforeTurnKernel failed for session s1-assemble-drain-empty-29009: client.beforeTurnKernel is not a function
LibraVDB tokenBudgetMax trim sessionId=s-cap injectionBefore=9000 injectionAfter=1000 cap=1000
LibraVDB bootstrap sessionId=s2 userId=fixed-user sessionKey=agent:main:session:s2
LibraVDB subagent memory disabled (excludeSubagents) sessionKey=agent:main:subagent:child1
LibraVDB subagent spawned sessionKey=agent:main:subagent:child2 tokenBudget=8000 ttl=120s
LibraVDB bootstrap sessionId=c2 userId=fixed-user sessionKey=agent:main:subagent:child2
LibraVDB afterTurn sessionId=s1-commit-unbound userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-commit-unbound
LibraVDB afterTurn sessionId=s1-commit-concurrent userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-commit-concurrent
LibraVDB afterTurn sessionId=s1-commit-retry userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn sessionId=s1-commit-retry userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-commit-retry
LibraVDB afterTurn failed sessionId=s1-commit-retry: daemon unavailable
LibraVDB afterTurn sessionId=s1-commit-shared-failure userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn sessionId=s1-commit-shared-failure userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn failed sessionId=s1-commit-shared-failure: daemon unavailable
LibraVDB predictive graph returned no predictions sessionId=s1-commit-shared-failure
LibraVDB afterTurn sessionId=s1-commit-reset-retry userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn failed sessionId=s1-commit-reset-retry: session lifecycle changed
LibraVDB afterTurn sessionId=s1-commit-reset-retry userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-commit-reset-retry
LibraVDB afterTurn sessionId=s1-commit-distinct userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-commit-distinct
LibraVDB afterTurn sessionId=s1-commit-distinct userId=fixed-user messageCount=2 newMessages=0 overlapIndex=2 prePromptMessageCount=unknown heartbeat=false
LibraVDB afterTurn sessionId=s1-bootstrap-orphan userId=fixed-user messageCount=2 newMessages=2 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
✔ ingest forwards isHeartbeat flag to the daemon (50.978166ms)
✔ resolveIdentity returns config userId with source=config (0.301958ms)
✔ resolveIdentity returns config userId with whitespace trimming (0.072542ms)
✔ resolveIdentity auto-derives when only sessionKey is provided (0.151833ms)
✔ resolveIdentity returns 'default' when no inputs are provided (0.066541ms)
✔ resolveIdentity with noAutoPersist skips writing identity file (0.889292ms)
✔ resolveIdentity creates identity file with owner-only permissions (1.472333ms)
✔ context engine exact recall escapes control characters inside injected memory facts (1.694666ms)
✔ context engine escapes predictive context text before injecting it into the system prompt (1.621334ms)
✔ exact recall injects facts item-by-item, dropping tail items when budget is exhausted (0.619917ms)
✔ exact recall inner-truncates a single oversized fact with [truncated] marker (0.502667ms)
✔ predictive context injects items item-by-item, dropping tail items when budget is exhausted (1.227375ms)
✔ predictive context inner-truncates an oversized prediction with [truncated] marker (0.939042ms)
✔ system prompt addition yields to user turn reinjection under tight budget (0.444542ms)
✔ context engine assemble drains pending async ingestion before daemon RPC (1.29775ms)
✔ context engine assemble drain handles empty queue gracefully (1.176167ms)
✔ tokenBudgetMax caps the daemon budget and truncates the injected system prompt (0.628333ms)
✔ tokenBudgetMax unset: daemon budget passes through uncapped (0.206833ms)
✔ excludeAgents: excluded agent skips all kernel work without touching the daemon (0.229125ms)
✔ excludeAgents: a direct compact() carrying sessionKey stays inert after the side table overflows (3.103792ms)
✔ excludeAgents: an active excluded session stays inert for a sessionKey-less compact via the refreshed side table (2.658125ms)
✔ excludeAgents: a non-excluded agent still reaches the daemon (0.732667ms)
✔ excludeSubagents: a spawned subagent skips all kernel work (1.157ms)
✔ excludeSubagents off by default: a subagent is granted a normal expansion budget (0.25175ms)
✔ commitTurn works when the host holds it as a bare, unbound function (1.438708ms)
✔ commitTurn serializes concurrent calls with the same advancementKey (4.807875ms)
✔ commitTurn does not record the key when ingestion fails, and a retry succeeds (2.84625ms)
✔ commitTurn concurrent callers all see the failure when the shared ingest fails (6.306667ms)
✔ commitTurn leaves the advancement key retryable when the session resets during ingestion (3.368875ms)
✔ commitTurn never reports duplicate for an excluded session (0.598958ms)
✔ commitTurn never reports duplicate when concurrent excluded calls share a key (0.183666ms)
✔ commitTurn reports duplicate only for a replayed key, never for repeated content (1.275875ms)
✔ afterTurn fails loudly when the daemon confirms none of the batch (0.801291ms)
LibraVDB bootstrap sessionId=s1-bootstrap-orphan userId=fixed-user sessionKey=sk-bootstrap-orphan
LibraVDB afterTurn sessionId=s1-bootstrap-orphan userId=fixed-user messageCount=4 newMessages=4 overlapIndex=0 prePromptMessageCount=unknown heartbeat=false
LibraVDB predictive graph returned no predictions sessionId=s1-bootstrap-orphan
LibraVDB predictive graph returned no predictions sessionId=s1-bootstrap-orphan
✔ bootstrap does not orphan an ingestion that is still in flight (5.462292ms)
✔ daemon packaging scripts keep runtime and model asset layout in sync (1.445167ms)
✔ dream promotion parser only accepts explicit deep-sleep candidate bullets (2.468333ms)
✔ dream promotion parser accepts explicit promotion candidate headings (1.060958ms)
✔ dream promotion parser rejects substring-only section matches (0.261333ms)
✔ dream promotion parser rejects partially parsed numeric metadata (0.255042ms)
✔ disabled dream promotion does not validate unused diary paths (0.53625ms)
✔ enabled dream promotion validates configured diary paths (0.727417ms)
✔ dream promotion rejects traversal and paths outside allowed roots (0.404042ms)
✔ dream promotion accepts explicit diary files under an allowed root (0.73075ms)
✔ normalizeDiaryPath expands ~ to home directory (0.116667ms)
✔ normalizeDiaryPath expands ~subpath correctly (0.642792ms)
✔ normalizeDiaryPath rejects .. traversal (0.100208ms)
✔ normalizeDiaryPath rejects paths outside allowed roots (0.079333ms)
✔ dream routing detects explicit dream phrasing (2.4665ms)
✔ dream routing preserves explicit dream phrasing alongside idioms (0.2395ms)
✔ dream routing rejects idiomatic false positives (1.25875ms)
✔ dream routing rejects idioms that overlap dream recall patterns (0.2025ms)
✔ dream routing ignores ordinary memory queries (0.268166ms)
✔ dream routing resolves the dedicated dream collection name (0.429959ms)
✔ stops scanning when daemon returns acceptMore: false (14.193542ms)
✔ continues scanning when daemon returns no feedback (16.059667ms)
✔ formatError returns trimmed Error message for non-blank messages (0.686416ms)
✔ formatError falls back to String() for blank Error messages (0.088333ms)
✔ formatError falls back to String() for non-Error values (0.072542ms)
✔ chunked ingest replaces first chunk then appends remaining chunks (1.155875ms)
✔ chunked ingest does not extend chunks past the configured budget at newline boundaries (0.273125ms)
✔ ok=false ingest responses retry the same chunk before advancing (2.648708ms)
✔ ok=false ingest responses fail instead of being treated as accepted (2.484834ms)
✔ async queue-time nodesAccepted=0 / nodesRejected=0 is success, not a rejection (0.406833ms)
✔ a real rejection (nodesRejected>0) with a lower burst limit shrinks and retries the same offset (0.878375ms)
✔ resolveClientEndpoint returns explicit endpoint unchanged (0.543375ms)
✔ resolveClientEndpoint returns env var when endpoint is undefined or auto (0.080708ms)
✔ resolveClientEndpoint returns a unix socket path by default on darwin (0.119792ms)
✔ loadSecretFromEnv trims direct secrets (0.08025ms)
✔ loadSecretFromEnv treats whitespace direct secrets as unset and falls back to secret file (0.878292ms)
✔ loadSecretFromEnv ignores whitespace direct secrets without file fallback (0.090042ms)
✔ isLegacyJsonRpcHealthResponse recognizes legacy health responses (0.08425ms)
✔ detectLegacyJsonRpcDaemon probes legacy JSON-RPC unix health (8.331125ms)
✔ close prevents RPC methods (0.923792ms)
✔ bootstrapHandshake wraps transport errors (3.140125ms)
✔ bootstrapHandshake reports legacy JSON-RPC daemon compatibility (6.99925ms)
✔ nonce sent in request, rotated from response header (0.421375ms)
✔ nonce cleared when transport throws (0.121875ms)
✔ auth mutex releases when an in-flight rpc is aborted (0.508958ms)
✔ auth skipped for Health (0.089ms)
✔ nonce read from trailer fallback (0.073834ms)
✔ recovery serializes inside mutex — single bootstrap (0.117166ms)
✔ no auth headers without secret (0.053ms)
✔ loadSecretFromEnv returns undefined when no env vars are set (0.030958ms)
✔ loadSecretFromEnv returns secret from LIBRAVDB_AUTH_SECRET (0.035791ms)
✔ loadSecretFromEnv warns and returns undefined for unreadable file (0.152416ms)
✔ cross-tenant search keeps same record ids from different tenants (0.782125ms)
✔ before_reset hook forwards advisory reset context to the runtime (1.035666ms)
✔ session_end hook forwards advisory end metadata to the runtime (0.230334ms)
✔ manifest store does not create its directory until save (5.815166ms)
✔ manifest store keeps lossy-sanitizer session ids in distinct files (1.979833ms)
✔ manifest store rejects a file whose embedded session id does not match (2.024041ms)
✔ manifest overlap requires ordered tail-prefix match (0.406417ms)
✔ manifest overlap tolerates rotated ids for ordered multi-message matches (0.31275ms)
✔ manifest overlap distinguishes single repeated content by message id (0.244583ms)
✔ markdown hash sentinel is stable and changes with content (1.843416ms)
✔ markdown hash sentinel uses the wasm backend when available (0.087834ms)
✔ matchesGlob: single-segment wildcard matches files in same directory (2.497416ms)
✔ matchesGlob: **/ matches across path segments (0.365833ms)
✔ matchesGlob: **/*.md matches deeply nested markdown files (0.246708ms)
✔ matchesGlob: ? matches a single non-slash character (0.2185ms)
✔ matchesGlob: character classes match single characters (0.66925ms)
✔ matchesGlob: negated character classes with ! (0.20475ms)
✔ matchesGlob: brace expansion matches alternatives (0.698667ms)
✔ matchesGlob: literal characters and dots match exactly (0.382ms)
✔ matchesGlob: combined patterns work together (0.389333ms)
✔ memory prompt section returns string array with static header when no messages (0.77425ms)
✔ memory prompt section stays synchronous and does not perform rpc lookups (0.161125ms)
✔ memory prompt section guides memory tool use when libravdb_memory_search is available (0.125209ms)
✔ memory prompt section works with citationsMode (0.274459ms)
✔ causal traversal guidance includes the available causal follow-up tools (0.48525ms)
✔ memory_describe defaults to the active session id (2.114375ms)
✔ memory_grep defaults to the active session id (0.400416ms)
✔ memory_expand defaults to the active session id (0.327875ms)
✔ memory_expand explicit session id takes precedence over active session id (0.285959ms)
✔ memory_expand graph mode preserves typed causal and hop edges (0.65925ms)
✔ memory_expand uses remaining subagent budget instead of dropping the first oversized request (3.310792ms)
✔ subagent spawn sanitizes invalid numeric expansion budgets (3.739833ms)
✔ memory runtime bridge searches the resolved durable namespace under the latest host contract (9.674875ms)
✔ memory runtime bridge adds dream results to normal memory when cross-session recall is enabled (1.3455ms)
✔ memory runtime bridge keeps normal results when the dream collection is empty (0.906458ms)
✔ memory runtime bridge merges, deduplicates, and caps dream and normal results (0.47025ms)
✔ memory runtime bridge rejects invalid dream collections before daemon search (0.613416ms)
✔ memory runtime bridge treats dream queries as session-scoped searches when cross-session recall is disabled (0.334167ms)
✔ memory runtime bridge returns no results for dream queries without a session when cross-session recall is disabled (0.27875ms)
✔ memory runtime bridge falls back to session-scoped namespace when no other identity is present (1.103208ms)
✔ memory runtime bridge keeps the legacy string search shape (1.56425ms)
✔ memory runtime bridge falls back to metadata text when search result text is blank (0.668208ms)
✔ memory runtime bridge treats non-object metadata JSON as missing (0.263625ms)
✔ memory runtime bridge does not authorize hidden paths from legacy search results (0.161208ms)
✔ memory runtime bridge respects disabled cross-session recall (0.131667ms)
✔ memory runtime bridge treats whitespace-only structured queries as missing (0.080458ms)
✔ memory runtime bridge trims query and scope strings before searching (0.089667ms)
✔ memory runtime bridge returns no results without a session when cross-session recall is disabled (0.08625ms)
✔ memory runtime bridge ignores whitespace-only session ids when cross-session recall is disabled (0.075166ms)
✔ memory runtime bridge round-trips encoded collection names in result paths (0.074084ms)
✔ memory runtime bridge rejects readFile paths not returned by search (0.484ms)
✔ memory runtime bridge exposes cached status and keeps legacy helpers delegated (0.352292ms)
✔ resolveDurableNamespace trims inputs and prefers sessionKey over agentId (0.558542ms)
✔ resolveDurableNamespace trims fallback values and rejects blank fallback strings (0.079708ms)
✔ validateNamespace rejects invalid collection names (0.255834ms)
✔ resolveUserCollection validates the full prefixed collection name (1.103834ms)
✔ resolveDurableNamespace rejects userId starting with reserved prefix (0.236375ms)
✔ resolveDurableNamespace rejects invalid namespace characters (0.167708ms)
✔ resolveDurableNamespace accepts valid userId without reserved prefix (0.286917ms)
✔ LibraVDB memory tools expose libravdb_memory_search and libravdb_memory_get through the runtime bridge (3.093709ms)
✔ LibraVDB libravdb_memory_search supports sessions corpus filtering without memory-core (0.630625ms)
✔ LibraVDB libravdb_memory_search constrains sessions corpus before top-k ranking (0.216667ms)
✔ LibraVDB libravdb_memory_search constrains memory corpus before top-k ranking (0.19525ms)
✔ LibraVDB libravdb_memory_search duplicate guard expires instead of blocking the whole session (0.3295ms)
✔ LibraVDB libravdb_memory_get reports unknown paths as disabled instead of reading arbitrary files (0.4125ms)
✔ enrichStartupError adds provisioning guidance for daemon startup failures (0.515833ms)
✔ enrichStartupError leaves unrelated errors alone (0.132041ms)
✔ resolveStartupHealthTimeoutMs uses the normal RPC timeout when it is higher (0.064666ms)
✔ validateEmbeddingConfig rejects onnx-local without explicit daemon asset paths (0.19575ms)
✔ validateEmbeddingConfig rejects missing local onnx-local model assets (0.616125ms)
✔ validateEmbeddingConfig skips filesystem checks for remote daemon endpoints (0.099959ms)
✔ validateEmbeddingConfig accepts complete local onnx-local asset paths (0.894ms)
✔ detectDaemonReleaseTarget matches the spec platform table (1.830542ms)
✔ buildDaemonReleaseAssetURL uses tagged release assets (0.207292ms)
✔ slot check — ours: register succeeds (1.8095ms)
✔ slot check — other plugin: register throws (0.252875ms)
✔ slot check — unset: register succeeds with warning (0.162958ms)
✔ slot check — 'none': register succeeds (0.0785ms)
✔ registrationMode gate — 'full' allows registration (0.121875ms)
✔ registrationMode gate — 'cli-metadata' returns early without throwing (0.071375ms)
✔ registrationMode gate — 'setup-only' returns early without throwing (0.062958ms)
✔ combined — cli-metadata with conflicting slot: mode gate blocks before slot check (0.081208ms)
✔ runtime lifecycle cleanup preserves context-engine runtime on disable (0.098042ms)
✔ runtime lifecycle cleanup preserves runtime on per-session delete (0.308292ms)
ℹ tests 276
ℹ suites 0
ℹ pass 276
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 30418.997958

> @xdarkicex/openclaw-memory-libravdb@1.10.23 test:integration /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> pnpm run test:inspect && pnpm run clean:test && tsc -p tsconfig.tests.json && node --test .ts-build/test/integration/checklist-validation.test.js .ts-build/test/integration/dream-promotion.test.js .ts-build/test/integration/host-flow.test.js .ts-build/test/integration/markdown-ingest.test.js


> @xdarkicex/openclaw-memory-libravdb@1.10.23 test:inspect /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> pnpm run plugin:ci


> @xdarkicex/openclaw-memory-libravdb@1.10.23 plugin:ci /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute

Status: PASS
Breakages: 0
Issues: 1
Artifacts: 1

> @xdarkicex/openclaw-memory-libravdb@1.10.23 clean:test /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> node scripts/clean-test-build.mjs

✔ manifest and package metadata satisfy checklist structure (4.929209ms)
✔ manifest schema includes runtime-consumed context tuning keys (0.762584ms)
✔ manifest schema requires explicit assets for onnx-local embedding setup (1.025417ms)
✔ manifest schema requires a remote endpoint for remote embedding setup (0.808458ms)
✔ source checklist invariants are present in host code (0.961458ms)
✔ dream promotion handle reads diary bullets and forwards them to the sidecar (55.762125ms)
✔ bootstrap correctly forwards session arguments to the RPC layer (2.252375ms)
✔ ingest correctly forwards message payload to the RPC layer (2.661125ms)
✔ assemble passes correct configuration mapping and returns expected payload (3.976042ms)
✔ assemble clamps oversized daemon context to token budget (1.127333ms)
✔ assemble fail-closed on sidecar errors with budget-clamped fallback (0.717875ms)
✔ assemble triggers force compaction at dynamic 80% threshold before daemon assembly (1.638625ms)
✔ assemble prefers authoritative currentTokenCount for predictive compaction (0.6915ms)
✔ assemble keeps compactThreshold explicit override when compactSessionTokenBudget is zero (0.633041ms)
✔ assemble blocks assembly when server declines over-budget compaction (0.642833ms)
✔ assemble blocks daemon assembly when predictive compaction fails (1.241459ms)
✔ compact maps host budget requests onto legacy sidecar fields (0.53775ms)
✔ compact normalizes daemon compact response into SDK CompactResult (0.443209ms)
✔ compact treats an already-compacted daemon session as a successful handoff (0.402166ms)
✔ compact rejects empty sessionId to prevent accidental session rollover (0.536416ms)
✔ compact omits invalid currentTokenCount values from the wire request (0.399542ms)
✔ afterTurn forwards only post-prompt messages and strips prePromptMessageCount (2.09225ms)
✔ afterTurn forwards latest message when prePromptMessageCount consumes all messages (1.313375ms)
✔ afterTurn forwards all messages when prePromptMessageCount is absent (1.227333ms)
✔ afterTurn triggers predictive compaction from runtimeContext currentTokenCount (1.455667ms)
✔ afterTurn does not trigger predictive compaction without authoritative currentTokenCount (1.7145ms)
✔ afterTurn triggers predictive compaction from oversized forwarded messages (1.319292ms)
✔ markdown ingestion roots stay inert unless explicitly enabled (28.181417ms)
✔ obsidian roots stay inert unless explicitly enabled (26.629667ms)
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-markdown-sKzrQM dirs=3 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=3
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-markdown-sKzrQM dirs=3 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=1 ingested=0 deleted=0 deferred=0 errors=0 durationMs=1
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-markdown-sKzrQM dirs=3 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=0
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-markdown-sKzrQM dirs=3 prunedDirs=0 markdown=0 included=0 skipped=0 unchanged=0 ingested=0 deleted=1 deferred=0 errors=0 durationMs=1
✔ markdown ingestion forwards raw markdown to the go sidecar and stays hash-stable (82.910417ms)
[markdown-ingest] obsidian scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-obsidian-BNw9ZX dirs=1 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=1
✔ obsidian markdown ingestion flips source kind while reusing the same rpc path (1.495834ms)
[markdown-ingest] obsidian scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-obsidian-skip-IblBMS dirs=1 prunedDirs=0 markdown=1 included=1 skipped=1 unchanged=0 ingested=0 deleted=0 deferred=0 errors=0 durationMs=1
✔ obsidian markdown ingestion skips untaged notes by default (1.480958ms)
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-memory-file-odYeGy dirs=1 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=0
✔ markdown ingestion always includes MEMORY.md by filename even under narrow include globs (1.220458ms)
[markdown-ingest] obsidian scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-obsidian-inline-12BuJl dirs=1 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=1
✔ obsidian markdown ingestion accepts inline tags like #project (1.169208ms)
[markdown-ingest] obsidian scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-obsidian-crlf-bQItH3 dirs=1 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=1
✔ obsidian markdown ingestion accepts CRLF frontmatter tags (1.08525ms)
[markdown-ingest] obsidian scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-obsidian-heading-tag-vQoubb dirs=1 prunedDirs=0 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=1
✔ obsidian markdown ingestion accepts tags in headings (1.254958ms)
✔ markdown ingestion stop waits for an in-flight startup scan (2.599625ms)
✔ markdown ingestion prunes excluded directories before recursion (1.185958ms)
✔ markdown ingestion persists snapshots across adapter restarts (2.3345ms)
✔ markdown ingestion startup processes newest files first in mtime mode (11.095875ms)
✔ markdown ingestion startup defers files exceeding per-file max token cap (1.56675ms)
✔ markdown ingestion retracts a cached document when it becomes oversized (27.396875ms)
✔ markdown ingestion startup streams reads without fsApi.readFile dependency (1.429375ms)
✔ backpressure resume cursor skips already-processed files on retry scan (204.433833ms)
✔ resume cursor invalidates when target file is deleted during pause (7.863792ms)
✔ watcher-triggered scan resets resume cursor for full re-scan (55.984208ms)
✔ ingest feedback interface stores all 8 daemon fields without dropping any (7.4835ms)
✔ REPLACE and APPEND ingest modes are unaffected by feedback interface changes (20.432958ms)
[markdown-ingest] loaded 0 generic file snapshots from /Users/z3robit/.openclaw/libravdb-markdown-ingest-generic.json
[markdown-ingest] generic scan complete root=/var/folders/rf/blv0zst12q3drgg8typ6bg6w0000gn/T/libravdb-md-default-exclude-tp30Ys dirs=4 prunedDirs=5 markdown=1 included=1 skipped=0 unchanged=0 ingested=1 deleted=0 deferred=0 errors=0 durationMs=1
✔ markdown ingestion default-excludes dependency and build directories (4.245584ms)
✔ a root whose walk never completes is quarantined instead of blocking start() (204.268375ms)
✔ a transient read failure keeps the document; only ENOENT deletes it (6.013ms)
✔ a transient stat failure protects the file from the prune pass (1.252792ms)
✔ a root slower than the walk timeout is NOT quarantined while it keeps completing work (619.060333ms)
✔ a directory we cannot enumerate does not prune the documents hidden behind it (10.40175ms)
✔ an obsidian note that stops qualifying is retired without being re-tracked (4.349667ms)
ℹ tests 55
ℹ suites 0
ℹ pass 55
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 30087.360375: 276/276 unit tests and 55/55 integration tests passed
- : PASS, 0 breakages
- 
> @xdarkicex/openclaw-memory-libravdb@1.10.23 build /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> tsc -p tsconfig.build.json && node scripts/bundle-entrypoint.mjs && mkdir -p dist/proto && cp -rf api/proto/. dist/proto/: PASS
- 
> @xdarkicex/openclaw-memory-libravdb@1.10.23 prepack /Users/z3robit/Development/golang/src/github.com/xDarkicex/openclaw-memory-libravdb
> npm run build


> @xdarkicex/openclaw-memory-libravdb@1.10.23 build
> tsc -p tsconfig.build.json && node scripts/bundle-entrypoint.mjs && mkdir -p dist/proto && cp -rf api/proto/. dist/proto/

📦  @xdarkicex/openclaw-memory-libravdb@1.10.23
Tarball Contents
dist/cli-descriptors.d.ts
dist/cli-descriptors.js
dist/cli-metadata.d.ts
dist/cli-metadata.js
dist/cli.d.ts
dist/cli.js
dist/context-engine.d.ts
dist/context-engine.js
dist/dream-promotion.d.ts
dist/dream-promotion.js
dist/dream-routing.d.ts
dist/dream-routing.js
dist/format-error.d.ts
dist/format-error.js
dist/grpc-client.d.ts
dist/grpc-client.js
dist/identity.d.ts
dist/identity.js
dist/index.d.ts
dist/index.js
dist/ingest-queue.d.ts
dist/ingest-queue.js
dist/libravdb-client.d.ts
dist/libravdb-client.js
dist/lifecycle-hooks.d.ts
dist/lifecycle-hooks.js
dist/manifest.d.ts
dist/manifest.js
dist/markdown-hash.d.ts
dist/markdown-hash.js
dist/markdown-ingest.d.ts
dist/markdown-ingest.js
dist/memory-provider.d.ts
dist/memory-provider.js
dist/memory-runtime.d.ts
dist/memory-runtime.js
dist/memory-scopes.d.ts
dist/memory-scopes.js
dist/memory-tools.d.ts
dist/memory-tools.js
dist/plugin-runtime.d.ts
dist/plugin-runtime.js
dist/proto/intelligence_kernel/v1/kernel.proto
dist/recall-cache.d.ts
dist/recall-cache.js
dist/rpc-protobuf-codecs.d.ts
dist/rpc-protobuf-codecs.js
dist/rpc.d.ts
dist/rpc.js
dist/rules.d.ts
dist/rules.js
dist/sidecar.d.ts
dist/sidecar.js
dist/tools/memory-recall.d.ts
dist/tools/memory-recall.js
dist/turn-cache.d.ts
dist/turn-cache.js
dist/types.d.ts
dist/types.js
docs/architecture-decisions/adr-001-onnx-over-ollama.md
docs/architecture-decisions/adr-002-libravdb-over-lancedb.md
docs/architecture-decisions/adr-003-convex-gating-over-threshold.md
docs/architecture-decisions/adr-004-sidecar-over-native-ts.md
docs/architecture-decisions/README.md
docs/architecture.md
docs/assets/libravdb-logo.svg
docs/configuration.md
docs/contributing.md
docs/debugging-tool-loop-regression.md
docs/dependencies.md
docs/development.md
docs/embedding-profiles.md
docs/features.md
docs/install.md
docs/installation.md
docs/models.md
docs/mTLS_configuration.md
docs/performance-and-tuning.md
docs/problem.md
docs/README.md
docs/security.md
docs/subagent-finds.md
docs/TLS_configuration.md
docs/uninstall.md
docs/yaml/default-gguf.yaml
docs/yaml/default-onnx.yaml
HOOK.md
index.js
openclaw.plugin.json
package.json
README.md
Tarball Details
xdarkicex-openclaw-memory-libravdb-1.10.23.tgz: PASS

This branch is based on current  at v1.10.23. The existing local  edit is intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserves dream recall for compound queries that contain idiomatic phrases.
- Searches normal session, user, and global collections in parallel with the dream collection.
- Merges results by ID, keeps the highest score, sorts by descending score, and limits output to `k`.
- Applies `kind` and `signals` filters to dream searches.
- Retains normal results when the dream collection is empty.
- Adds unit coverage for routing, merging, deduplication, ranking, limits, fallback behavior, and filter propagation.
- No exported or public API declarations changed.
- The merge adds linear processing, `O(n)` time and space, for the combined result set after both searches. Parallel search does not change the aggregate work.
- Cyclomatic complexity increases in the search path because it now handles parallel searches, result merging, filtering, deduplication, and fallback behavior. The increase is localized to the search implementation and its helper.
- Validation passed with 276 unit tests, 55 integration tests, TypeScript checks, plugin inspection, build, and package preparation. Plugin inspection reported zero breakages and one issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->