### PR TITLE
fix: reconcile empty dream promotion sources

### DIFF
--- a/src/dream-promotion.ts
+++ b/src/dream-promotion.ts
@@ -212,14 +212,6 @@ export function createDreamPromotionHandle(
 
     const text = textDecoder.decode(bytes);
     const candidates = parseDreamPromotionCandidates(text);
-    if (candidates.length === 0) {
-      lastFileState = {
-        size: stat.size,
-        mtimeMs: stat.mtimeMs,
-        fileHash,
-      };
-      return;
-    }
 
     const client = await getClient();
     await client.promoteDreamEntries({

--- a/test/integration/dream-promotion.test.ts
+++ b/test/integration/dream-promotion.test.ts
@@ -125,6 +125,22 @@ test("dream promotion handle reads diary bullets and forwards them to the sideca
     await delay(25);
 
     assert.equal(client.calls.filter((call) => call.method === "promoteDreamEntries").length, 1);
+
+    await fsp.writeFile(
+      diaryPath,
+      [
+        "# DREAMS",
+        "",
+        "## Deep Sleep",
+        "- No longer a candidate",
+      ].join("\n"),
+    );
+    fsApi.callbacks.get(path.dirname(diaryPath))?.[0]?.("change", path.basename(diaryPath));
+    await delay(25);
+
+    const promoteCalls = client.calls.filter((call) => call.method === "promoteDreamEntries");
+    assert.equal(promoteCalls.length, 2);
+    assert.deepEqual((promoteCalls[1]?.params as { entries: unknown[] }).entries, []);
   } finally {
     await handle?.stop();
     if (previousStateDir === undefined) {


### PR DESCRIPTION
## Summary\n\nWhen a previously promoted diary entry stops matching the dream-promotion rules, the watcher now sends an explicit promoteDreamEntries RPC with entries: [] so stale daemon-side promotion state can be reconciled. Unchanged-file hash suppression and retry-after-RPC-failure behavior remain intact.\n\n## Verification\n\n- pnpm check — PASS (276 unit tests, 55 integration tests)\n- pnpm run build — PASS\n- pnpm pack — PASS (v1.10.24 package)\n- plugin-inspector — 0 breakages\n\nBased on current main/v1.10.24. The existing local CHANGELOG.md edit was intentionally not included.