### PR TITLE
fix: account for provider replay pressure and preserve live tool exchanges

### DIFF
--- a/docs/provider-replay-accounting.md
+++ b/docs/provider-replay-accounting.md
@@ -13,6 +13,10 @@ projection contains tool protocol, budget enforcement uses the existing
 turn-aligned enforcer. It keeps the current user/call/result bundle together,
 even if that bundle alone exceeds budget, and reports that pressure to the host
 instead of dropping one side of the exchange.
+An oversized projection with no user boundary is dropped as a whole; its system
+addition is bounded separately. Under-budget tool-only inputs are unchanged.
+Tool argument estimation uses the existing guarded block serializer; cyclic or
+BigInt arguments do not throw from accounting or rewrite the source objects.
 
 This change does not introduce an excerpt allowance, delete reasoning, classify
 completed tasks, change daemon ingestion, or implement tool-result rehydration.
@@ -22,7 +26,7 @@ that all prompt-cache misses or slow greetings are fixed.
 
 ## Validation
 
-`pnpm check` passed: plugin inspector PASS, 279 unit tests and 55 integration
+`pnpm check` passed: plugin inspector PASS, 281 unit tests and 55 integration
 tests, zero failures or skips. `pnpm build` passed. The three new regressions
 fail on unpatched upstream and pass on the fix. In a synthetic zero-estimate
 control, a 90,000-character result remains 90,000 characters and the same source
@@ -43,17 +47,26 @@ The new tests in `test/unit/context-engine.test.ts` cover:
    With reported usage zero, predictive compaction must still see the pressure.
 3. An active tool exchange that exceeds budget by itself. It must not lose its
    result while retaining its call, or report that the exchange fits.
+4. Cyclic and BigInt tool arguments: finite estimates and unchanged source data.
+5. Oversized no-user tool-call, tool-result, and paired projections are bounded,
+   while under-budget versions are preserved.
 
-All three fail against upstream `c3570e1` (v1.10.25). The baseline run uses the
+The first three fail against upstream `c3570e1` (v1.10.25). The baseline run uses the
 new tests with only `src/context-engine.ts` replaced in the generated test build
 by a transpilation of that commit's source. A fresh TypeScript build restores
 the patched implementation before running the full tests.
+
+Review regressions were tested against PR head `7db783f` before fixing it:
+cyclic arguments threw `TypeError: Converting circular structure to JSON`, and
+an oversized tool-result-only projection was returned intact. Both fail-before
+tests pass after the review corrections. These are local adapter tests, not a
+new live Gateway or model performance experiment.
 
 ## Anonymized incident evidence
 
 A short greeting in an existing research session resulted in 101,450 processed
 prompt tokens: 52,345 ms prompt evaluation versus 946 ms generation (71 tokens).
-OpenClaw's prompt-submitted to model-completed interval was 57,301 ms, with no
+OpenClaw's interval from prompt submission to model completion was 57,301 ms, with no
 new tool calls. Its usage fields were zero. This is evidence of replay pressure,
 not proof that this patch reduces production latency to a particular target.
 

--- a/docs/provider-replay-accounting.md
+++ b/docs/provider-replay-accounting.md
@@ -1,0 +1,64 @@
+# Provider replay accounting
+
+Compaction pressure must describe the source projection returned to the host,
+not the smaller normalized representation sent to daemon ingestion. Historical
+tool results are deliberately excluded from ingestion, but may still be replayed.
+Text, reasoning and tool-call arguments now contribute to the message estimate.
+Cached compacted context contributes to predictive pressure; returned system
+additions contribute to assembly estimates. A low or non-finite daemon estimate
+cannot suppress the local estimate.
+
+More accurate accounting can expose previously hidden overflow. When a
+projection contains tool protocol, budget enforcement uses the existing
+turn-aligned enforcer. It keeps the current user/call/result bundle together,
+even if that bundle alone exceeds budget, and reports that pressure to the host
+instead of dropping one side of the exchange.
+
+This change does not introduce an excerpt allowance, delete reasoning, classify
+completed tasks, change daemon ingestion, or implement tool-result rehydration.
+It is still a character-based estimate, not an exact model tokenizer. Image
+tokens and host-added tool schemas are not newly modeled here. It does not claim
+that all prompt-cache misses or slow greetings are fixed.
+
+## Validation
+
+`pnpm check` passed: plugin inspector PASS, 279 unit tests and 55 integration
+tests, zero failures or skips. `pnpm build` passed. The three new regressions
+fail on unpatched upstream and pass on the fix. In a synthetic zero-estimate
+control, a 90,000-character result remains 90,000 characters and the same source
+array is returned, while its transcript estimate is now 22,551 tokens rather
+than zero. There is no evidence-excerpting policy in this patch.
+
+Production has not been deployed with this branch. No after-fix production
+latency reduction, automatic retrieval of old results, or Discord delivery
+success is claimed by these test results.
+
+## Reproduction and controls
+
+The new tests in `test/unit/context-engine.test.ts` cover:
+
+1. Reasoning, large tool arguments and results plus a system addition, with a
+   zero/non-finite daemon estimate. The source array remains unchanged.
+2. A completed research exchange with a large result, followed by a greeting.
+   With reported usage zero, predictive compaction must still see the pressure.
+3. An active tool exchange that exceeds budget by itself. It must not lose its
+   result while retaining its call, or report that the exchange fits.
+
+All three fail against upstream `c3570e1` (v1.10.25). The baseline run uses the
+new tests with only `src/context-engine.ts` replaced in the generated test build
+by a transpilation of that commit's source. A fresh TypeScript build restores
+the patched implementation before running the full tests.
+
+## Anonymized incident evidence
+
+A short greeting in an existing research session resulted in 101,450 processed
+prompt tokens: 52,345 ms prompt evaluation versus 946 ms generation (71 tokens).
+OpenClaw's prompt-submitted to model-completed interval was 57,301 ms, with no
+new tool calls. Its usage fields were zero. This is evidence of replay pressure,
+not proof that this patch reduces production latency to a particular target.
+
+Stored history included 182,366 characters of prior tool results and 82,983
+characters of reasoning. The system-prompt trace reported 64,669 characters.
+The trajectory payload was truncated, so these are not an exact decomposition
+of the backend token count. No raw conversations, identities, endpoints,
+credentials, hostnames or absolute installation paths are included here.

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -733,7 +733,7 @@ function approximateMessageTokens(message: OpenClawCompatibleMessage): number {
         if (!block || typeof block !== "object") return "";
         const value = block as Record<string, unknown>;
         if (value.type === "toolCall") {
-          return JSON.stringify(value.arguments ?? {}) + String(value.name ?? "");
+          return stringifyKernelBlock(value);
         }
         return typeof value.text === "string" ? value.text
           : typeof value.thinking === "string" ? value.thinking : "";
@@ -1138,9 +1138,20 @@ function enforceCompactedProjectionBudgetInvariant(
   }
 
   const lastUserIndex = findLastUserMessageIndex(result.messages);
-  const mandatoryMessages = lastUserIndex >= 0
-    ? result.messages.slice(lastUserIndex)
-    : result.messages;
+  // Without a user boundary, no live turn can be protected. Drop the entire
+  // oversized projection rather than orphaning calls/results by suffix trimming.
+  if (lastUserIndex < 0) {
+    const systemPromptAddition = truncateSystemPromptAdditionToTokenBudget(
+      result.systemPromptAddition, effectiveBudget,
+    );
+    return {
+      ...result,
+      messages: [],
+      systemPromptAddition,
+      estimatedTokens: approximateTokenCount(systemPromptAddition),
+    };
+  }
+  const mandatoryMessages = result.messages.slice(lastUserIndex);
   const mandatoryTokens = approximateMessagesTokens(mandatoryMessages);
   const systemPromptBudget = Math.max(0, effectiveBudget - mandatoryTokens);
   const systemPromptAddition = truncateSystemPromptAdditionToTokenBudget(

--- a/src/context-engine.ts
+++ b/src/context-engine.ts
@@ -727,8 +727,19 @@ function approximateTokenCount(text: unknown): number {
  * Approximates tokens for a single message including wrapper overhead.
  */
 function approximateMessageTokens(message: OpenClawCompatibleMessage): number {
-  // Approximate per-message wrapper overhead so trimming is conservative.
-  return approximateTokenCount(message.content) + 8;
+  // Measure replay content, not the ingestion normalizer's filtered view.
+  const content = Array.isArray(message.content)
+    ? message.content.map((block) => {
+        if (!block || typeof block !== "object") return "";
+        const value = block as Record<string, unknown>;
+        if (value.type === "toolCall") {
+          return JSON.stringify(value.arguments ?? {}) + String(value.name ?? "");
+        }
+        return typeof value.text === "string" ? value.text
+          : typeof value.thinking === "string" ? value.thinking : "";
+      }).join("\n")
+    : message.content;
+  return approximateTokenCount(content) + 8;
 }
 
 /**
@@ -1971,10 +1982,14 @@ export function normalizeAssembleResult(
   const systemPromptAddition = typeof result.systemPromptAddition === "string"
     ? sanitizeDaemonSystemPromptAddition(result.systemPromptAddition)
     : "";
+  const messages = sourceMessages ?? [];
+  const reportedTokens = typeof result.estimatedTokens === "number" && Number.isFinite(result.estimatedTokens)
+    ? result.estimatedTokens : 0;
 
   return {
-    messages: sourceMessages ?? [],
-    estimatedTokens: typeof result.estimatedTokens === "number" ? result.estimatedTokens : 0,
+    messages,
+    estimatedTokens: Math.max(reportedTokens,
+      approximateMessagesTokens(messages) + approximateTokenCount(systemPromptAddition)),
     systemPromptAddition,
     promptAuthority,
     ...(result.debug != null ? { debug: result.debug } : {}),
@@ -2238,7 +2253,9 @@ export function buildContextEngineFactory(
     tokenBudget: number | undefined,
     compactionProjectionActive: boolean,
   ): OpenClawCompatibleAssembleResult {
-    return compactionProjectionActive
+    // Newly visible pressure must not orphan a live tool call or result.
+    return compactionProjectionActive || result.messages.some((message) =>
+      isToolResultRole(message.role) || hasKernelToolCallBlock(message.content))
       ? enforceCompactedProjectionBudgetInvariant(result, tokenBudget)
       : enforceTokenBudgetInvariant(result, tokenBudget);
 
@@ -3088,8 +3105,8 @@ export function buildContextEngineFactory(
         : RESERVED_CURRENT_TURN_TOKENS;
       const currentContextTokens = resolvePredictiveCompactionTokenCount({
         currentTokenCount: args.currentTokenCount,
-        messages,
-        prompt: strippedPrompt,
+        messages: projectedSourceMessages(),
+        prompt: strippedPrompt + (cachedCompactedProjection?.context ?? ""),
       });
       const dynamicCompactThreshold = getDynamicCompactThreshold(args.tokenBudget);
       const predictiveTargetSize = resolvePredictiveCompactionTarget({

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 
-import { buildContextEngineFactory, clearCompactedProjectionState, createCompactedProjectionState, FLUSH_ASYNC_INGESTION } from "../../src/context-engine.js";
+import { buildContextEngineFactory, clearCompactedProjectionState, createCompactedProjectionState, FLUSH_ASYNC_INGESTION, normalizeAssembleResult } from "../../src/context-engine.js";
 import fs from "node:fs";
 import { execSync } from "node:child_process";
 import { resolveIdentity } from "../../src/identity.js";
@@ -118,6 +118,49 @@ function fakeRuntime(client: FakeClient): PluginRuntime {
     shutdown: async () => {},
   };
 }
+
+test("replay accounting includes reasoning and arguments without rewriting history", () => {
+  const messages = [
+    { role: "assistant", content: [
+      { type: "thinking", thinking: "reason ".repeat(1000) },
+      { type: "toolCall", id: "call-1", name: "write", arguments: { text: "x".repeat(40000) } },
+    ] },
+    { role: "toolResult", toolCallId: "call-1", content: [{ type: "text", text: "evidence ".repeat(1000) }] },
+  ];
+  for (const reported of [0, NaN, Infinity]) {
+    const result = normalizeAssembleResult({ estimatedTokens: reported, systemPromptAddition: "context ".repeat(1000) }, messages);
+    assert.equal(result.messages, messages);
+    assert.ok(Number.isFinite(result.estimatedTokens) && result.estimatedTokens >= 16000);
+  }
+  assert.equal(normalizeAssembleResult({ estimatedTokens: 100000 }, messages).estimatedTokens, 100000);
+});
+
+test("predictive pressure includes old tool evidence omitted from daemon ingestion", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user", compactThreshold: 1000 });
+  const messages = [
+    { role: "user", content: "Research" },
+    { role: "assistant", content: [{ type: "toolCall", id: "c", name: "lookup", arguments: {} }] },
+    { role: "toolResult", toolCallId: "c", content: [{ type: "text", text: "evidence ".repeat(2000) }] },
+    { role: "assistant", stopReason: "stop", content: "The research is complete." },
+    { role: "user", content: "hello" },
+  ];
+  await engine.assemble({ sessionId: "pressure-raw", messages, tokenBudget: 100000, currentTokenCount: 0 });
+  assert.ok(client.calls.some((call) => call.method === "compactSession"));
+});
+
+test("pressure enforcement keeps an oversized live tool exchange intact", async () => {
+  const client = new FakeClient();
+  const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user", compactThreshold: 100000 });
+  const messages = [
+    { role: "user", content: "Continue the lookup" },
+    { role: "assistant", content: [{ type: "toolCall", id: "live", name: "lookup", arguments: {} }] },
+    { role: "toolResult", toolCallId: "live", content: "evidence ".repeat(2000) },
+  ];
+  const result = await engine.assemble({ sessionId: "live-pressure", messages, tokenBudget: 1000 });
+  assert.deepEqual(result.messages, messages);
+  assert.ok(result.estimatedTokens > 1000, "report overflow rather than silently dropping the result");
+});
 
 function installBeforeTurnKernel(
   client: FakeClient,

--- a/test/unit/context-engine.test.ts
+++ b/test/unit/context-engine.test.ts
@@ -135,6 +135,32 @@ test("replay accounting includes reasoning and arguments without rewriting histo
   assert.equal(normalizeAssembleResult({ estimatedTokens: 100000 }, messages).estimatedTokens, 100000);
 });
 
+test("replay accounting tolerates non-JSON tool arguments without changing them", () => {
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  for (const args of [cyclic, { count: 1n }]) {
+    const messages = [{ role: "assistant", content: [{ type: "toolCall", id: "c", name: "lookup", arguments: args }] }];
+    const result = normalizeAssembleResult({ estimatedTokens: 0 }, messages);
+    assert.equal(result.messages, messages);
+    assert.ok(Number.isFinite(result.estimatedTokens) && result.estimatedTokens > 0);
+  }
+});
+
+test("pressure enforcement bounds tool-only projections without splitting protocol", async () => {
+  for (const shape of ["result", "call", "pair"]) {
+    const engine = buildContextEngineFactory(fakeRuntime(new FakeClient()), { userId: "fixed-user", compactThreshold: 100000 });
+    const messages = [
+      ...(shape !== "result" ? [{ role: "assistant", content: [{ type: "toolCall", id: "c", name: "lookup", arguments: { text: "x".repeat(18000) } }] }] : []),
+      ...(shape !== "call" ? [{ role: "toolResult", toolCallId: "c", content: "evidence ".repeat(2000) }] : []),
+    ];
+    const control = await engine.assemble({ sessionId: `no-user-control-${shape}`, messages, tokenBudget: 100000 });
+    assert.deepEqual(control.messages, messages, "no-user input is not unconditionally dropped");
+    const result = await engine.assemble({ sessionId: `no-user-${shape}`, messages, tokenBudget: 1000 });
+    assert.deepEqual(result.messages, []);
+    assert.ok(result.estimatedTokens <= 1000);
+  }
+});
+
 test("predictive pressure includes old tool evidence omitted from daemon ingestion", async () => {
   const client = new FakeClient();
   const engine = buildContextEngineFactory(fakeRuntime(client), { userId: "fixed-user", compactThreshold: 1000 });


### PR DESCRIPTION
## Summary

- Predictive compaction now measures the selected provider-replay projection instead of the filtered daemon-ingestion view. Historical tool evidence is no longer invisible merely because ingestion intentionally excludes it.
- Replay estimates count text, reasoning and tool-call arguments. Cached compacted context and returned system additions are accounted for; zero/non-finite daemon estimates cannot suppress the local estimate, while larger valid estimates are retained.
- Newly detected pressure uses the existing turn-aligned enforcer for tool-bearing projections, preserving the live user/call/result bundle and honestly reporting overflow rather than orphaning a result.

Closes #386. Related: #378 / merged #379 (already in the v1.10.25 baseline).

**Intentionally excluded:** no excerpt cap, reasoning deletion, completed-task classifier, tool-result rehydration, config migration, daemon protocol change, or OpenClaw core patch. The experimental retention-policy work is not in this branch.

## Invariant and code changes

All implementation changes are localized to `src/context-engine.ts`:

1. `approximateMessageTokens`: estimate replay blocks directly, including reasoning and serialized tool arguments, instead of passing them through ingestion normalization.
2. `normalizeAssembleResult`: keep the source message array unchanged and floor the reported estimate at the source-plus-system-addition estimate.
3. `assemble`: base predictive pressure on `projectedSourceMessages()` and cached compacted context, not `normalizeKernelMessages(recentMessages)`.
4. `enforceAssembleBudget`: use turn-aligned enforcement when source messages contain tool protocol, not only after daemon compaction has activated.

This remains a character estimator. It does not add exact tokenizer/image accounting or visibility into host-added schemas. A live exchange that alone exceeds budget remains oversized and is reported as such; it is not silently made to fit by corrupting protocol.

## Anonymized behavior evidence

Incident environment: OpenClaw 2026.9.2, plugin v1.10.25, OpenAI-compatible Qwen/llama.cpp backend, plugin owning context compaction. A short greeting followed prior research, with no new tool calls:

| Counter | Observed |
|---|---:|
| Backend processed prompt tokens | 101,450 |
| Prompt evaluation | 52,345 ms |
| Generation | 946 ms / 71 tokens |
| Host prompt-submitted to model-completed | 57,301 ms |
| Host recorded token usage | 0 |

Stored history included 182,366 characters of old tool results and 82,983 characters of reasoning. The system-prompt trace reported 64,669 characters. The trajectory payload was truncated: this is **not** an exact component breakdown of the wire prompt, nor proof of a single cause for every latency/cache issue. Backend-to-host correlation used ordering and timing.

No raw prompts, identities, tenant/session IDs, network addresses, hostnames, credentials or local installation paths are published.

## Falsification and after-fix proof

The three new tests were run against an unmodified transpilation of upstream `c3570e1`'s `context-engine.ts`, keeping the new fixtures unchanged:

```text
Baseline: 3 tests, 0 pass, 3 fail
- replay estimate too low for reasoning / arguments / result / system addition
- compactSession not called for historical tool evidence followed by greeting
- oversized live result removed while its call remains
```

Then the patched TypeScript was rebuilt and the full repository checks rerun:

```text
pnpm check
  plugin inspector: PASS
  unit:        279 tests, 279 pass, 0 fail, 0 skip
  integration:  55 tests,  55 pass, 0 fail, 0 skip
pnpm build
  exit 0
npm run test:integration
  55 tests, 55 pass, 0 fail, 0 skip
```

Additional synthetic built-module control:

```json
{"resultChars":90000,"estimatedTokens":22551,"sameSourceArray":true}
```

The baseline returns that full result with estimate zero when the daemon reports zero. The fix preserves the evidence and corrects accounting; no token reduction from the separate excerpting experiment is attributed to this PR.

The focused tests additionally assert larger valid daemon estimates are preserved, non-finite estimates are handled, and the live protocol/source array is not rewritten.

**Proof limitations:** this branch has not been deployed to production. The after-fix evidence is synthetic/module and repository integration testing, not a live Gateway/Discord latency or delivery result. No claim is made that this alone achieves sub-five-second greetings. See `docs/provider-replay-accounting.md` for the scoped behavior and evidence record.

## Risk and review focus

Correct accounting may trigger compaction sooner than before. Please review that pressure follows the selected source projection, not normalized ingestion; that cached context is included; and that overflow preserves the newest tool exchange. No new RPC type or extra summarizer is introduced. Work remains linear in the traversed text/history, though more actual replay bytes are now measured.

## Review state

Ready for maintainer review and CI. No review comments exist on this new PR yet. AI-assisted implementation and audit; baseline falsification and the documented commands were actually run. Production deployment and live latency confirmation remain unperformed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Measures predictive compaction from the source projection returned for provider replay.
- Counts text, reasoning, tool-call arguments, cached compacted context, and system additions.
- Preserves larger valid daemon estimates.
- Ignores zero or non-finite daemon estimates when a local estimate is available.
- Preserves live user/tool-call/result bundles during budget enforcement.
- Reports unavoidable overflow instead of removing only the result.
- Adds regression tests and provider replay accounting documentation.

## Complexity

- The new estimation logic remains linear, **O(n)** in the number of replay messages and content blocks.
- Budget enforcement remains linear for the processed projection, **O(n)**.
- No new nested iteration introduces a higher asymptotic bound.
- Cyclomatic complexity increases locally through additional projection and tool-protocol branches.
- The increase is limited to the accounting and budget-enforcement paths.
- No public API or daemon protocol changes are included.

## Validation

- `pnpm check` passes.
- `pnpm build` passes.
- The three regression tests fail against the unmodified implementation and pass with this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->